### PR TITLE
Fix spurious "Unparseable block headers" warnings (#10)

### DIFF
--- a/runtime/src/agents/result-parser.ts
+++ b/runtime/src/agents/result-parser.ts
@@ -112,7 +112,7 @@ export class ResultParser {
 
     // Split on task headers like "## Task: task-001 - Module Name"
     // or "### task-001: Module Name"
-    const taskBlocks = content.split(/^#{2,3}\s+(?:Task:\s*)?/m).filter(Boolean);
+    const taskBlocks = content.split(/^#{2,3}\s+(?:Task:\s*)?(?=task-\d+)/mi).filter(Boolean);
 
     for (const block of taskBlocks) {
       const task = ResultParser.parseTaskBlock(block);
@@ -151,8 +151,8 @@ export class ResultParser {
         // Block didn't match task header pattern — not necessarily an error
         // (could be a preamble or non-task heading)
         const headerLine = block.split('\n')[0]?.trim() ?? '(unknown)';
-        // Only count as failed if it looks like it was *trying* to be a task
-        if (/task/i.test(headerLine)) {
+        // Only count as failed if it looks like it was *trying* to be a canonical task
+        if (/task-\d+/i.test(headerLine)) {
           failedBlockHeaders.push(headerLine);
         }
       }

--- a/runtime/tests/result-parser.test.ts
+++ b/runtime/tests/result-parser.test.ts
@@ -159,6 +159,41 @@ Just notes.
       expect(log.info).toHaveBeenCalledWith(expect.stringContaining('1 tasks OK'));
     });
 
+    it('should not treat structural headings as task blocks', () => {
+      const content = `## Task Summary
+
+This section summarizes all tasks.
+
+## Tasks
+
+Here are the tasks:
+
+## Task: task-001 - Module A
+
+**Description:** First task
+**Complexity:** simple
+
+**Source Files:**
+- src/a.py
+
+## Task: task-002 - Module B
+
+**Description:** Second task
+**Complexity:** simple
+
+**Source Files:**
+- src/b.py
+`;
+      const log = silentLogger();
+      const tasks = ResultParser.parseMigrationPlanContent(content, log);
+      expect(tasks).toHaveLength(2);
+      expect(log.warn).not.toHaveBeenCalledWith(expect.stringContaining('Unparseable block headers'));
+      expect(log.error).not.toHaveBeenCalledWith(expect.stringContaining('Task Summary'));
+      expect(log.error).not.toHaveBeenCalledWith(expect.stringContaining('Tasks'));
+      expect(tasks[0]?.id).toBe('task-001');
+      expect(tasks[1]?.id).toBe('task-002');
+    });
+
     it('should reject non-canonical "Task N:" headers', () => {
       const content = `## Task 1: Migrate Constants Module
 


### PR DESCRIPTION
## Summary

Fixes false `"Unparseable block headers"` warnings emitted on every migration run by tightening the split regex in `parseMigrationPlanContent` so structural headings like `## Task Summary` and `## Tasks` are no longer misidentified as task blocks.

Closes #10

## Changes

- **`runtime/src/agents/result-parser.ts`**
  - Updated `parseMigrationPlanContent` split regex from `/^#{2,3}\s+(?:Task:\s*)?/m` to `/^#{2,3}\s+(?:Task:\s*)?(?=task-\d+)/mi`, using a lookahead so only headings containing a canonical task ID (e.g. `task-001`) are used as split points.
  - Tightened the failed-block heuristic from `/task/i` to `/task-\d+/i` to prevent structural headings that contain the word "task" (e.g. `Task Summary`) from triggering spurious `failedBlockHeaders` entries.
- **`runtime/tests/result-parser.test.ts`**
  - Added a regression test that provides a migration plan containing structural headings (`## Task Summary`, `## Tasks`) alongside valid task blocks, and asserts no `warn` or `error` logger calls are made for unparseable headers.

## Testing

All 45 existing `result-parser` tests continue to pass. The new regression test verifies that structural headings no longer produce `"Unparseable block headers"` warnings and that only valid `task-\d+` blocks are returned in the parsed result. Full build and test suite passed with exit code 0.

Closes #10