### PR TITLE
Make Phase 4 token projection configurable (#8)

### DIFF
--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -55,6 +55,11 @@ export const MigrationConfigSchema = z.object({
      * Default: 3.
      */
     maxInfraRetries: z.number().int().min(0).max(10).default(3),
+    /**
+     * Estimated average number of tokens consumed per migration task.
+     * Used for Phase 4 cost projection. Default: 5000.
+     */
+    avgTokensPerTask: z.number().int().min(1).default(5000),
   }).default({}),
   copilot: z.object({
     cliCommand: z.string().default('copilot'),

--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -474,8 +474,8 @@ export class MigrationOrchestrator {
 
     // 1c. Cost projection
     const taskCount = tasks.length;
-    const avgTokensPerTask = 5000;
-    const estimatedTotalTokens = taskCount * avgTokensPerTask * 3; // migrator + parity + test-writer
+    const agentMultiplier = this.config.target.testCommand ? 3 : 2; // migrator + parity (+ test-writer if testCommand set)
+    const estimatedTotalTokens = taskCount * this.config.options.avgTokensPerTask * agentMultiplier;
     const model = this.config.copilot.model ?? 'claude-sonnet-4';
     const estimator = new CostEstimator(this.config.copilot.costOverrides);
     const projected = estimator.estimateFromTotal(model, estimatedTotalTokens);

--- a/runtime/tests/config-schema.test.ts
+++ b/runtime/tests/config-schema.test.ts
@@ -22,6 +22,7 @@ describe('MigrationConfigSchema', () => {
     expect(result.options.continueOnBlocked).toBe(true);
     expect(result.options.maxBlockedTasks).toBe(0);
     expect(result.options.maxInfraRetries).toBe(3);
+    expect(result.options.avgTokensPerTask).toBe(5000);
     expect(result.copilot.cliCommand).toBe('copilot');
     expect(result.copilot.timeout).toBe(300000);
   });
@@ -189,6 +190,19 @@ describe('MigrationConfigSchema', () => {
     it('should leave phaseTimeouts undefined when omitted', () => {
       const result = MigrationConfigSchema.parse(validConfig);
       expect(result.copilot.phaseTimeouts).toBeUndefined();
+    });
+
+    it('should default avgTokensPerTask to 5000 when omitted', () => {
+      const result = MigrationConfigSchema.parse(validConfig);
+      expect(result.options.avgTokensPerTask).toBe(5000);
+    });
+
+    it('should accept a custom avgTokensPerTask value', () => {
+      const result = MigrationConfigSchema.parse({
+        ...validConfig,
+        options: { avgTokensPerTask: 8000 },
+      });
+      expect(result.options.avgTokensPerTask).toBe(8000);
     });
   });
 });

--- a/runtime/tests/helpers/mocks.ts
+++ b/runtime/tests/helpers/mocks.ts
@@ -97,6 +97,7 @@ export function createMockConfig(overrides?: Partial<MigrationConfig>): Migratio
       continueOnBlocked: true,
       maxBlockedTasks: 0,
       maxInfraRetries: 3,
+      avgTokensPerTask: 5000,
     },
     copilot: {
       cliCommand: 'copilot',

--- a/runtime/tests/orchestrator.test.ts
+++ b/runtime/tests/orchestrator.test.ts
@@ -253,6 +253,7 @@ describe('MigrationOrchestrator', () => {
           continueOnBlocked: true,
           maxBlockedTasks: 0,
           maxInfraRetries: 3,
+          avgTokensPerTask: 5000,
         },
       });
 
@@ -327,6 +328,7 @@ describe('MigrationOrchestrator', () => {
           continueOnBlocked: true,
           maxBlockedTasks: 0,
           maxInfraRetries: 3,
+          avgTokensPerTask: 5000,
         },
       });
 
@@ -363,6 +365,7 @@ describe('MigrationOrchestrator', () => {
           continueOnBlocked: true,
           maxBlockedTasks: 0,
           maxInfraRetries: 3,
+          avgTokensPerTask: 5000,
         },
       });
 
@@ -563,6 +566,7 @@ describe('MigrationOrchestrator', () => {
           continueOnBlocked: true,
           maxBlockedTasks: 0,
           maxInfraRetries: 3,
+          avgTokensPerTask: 5000,
         },
       });
 
@@ -642,6 +646,7 @@ describe('MigrationOrchestrator', () => {
           continueOnBlocked: true,
           maxBlockedTasks: 0,
           maxInfraRetries: 3,
+          avgTokensPerTask: 5000,
         },
       });
 
@@ -699,6 +704,7 @@ describe('MigrationOrchestrator', () => {
             continueOnBlocked: true,
             maxBlockedTasks: 0,
             maxInfraRetries: 3,
+            avgTokensPerTask: 5000,
           },
         },
       );
@@ -841,6 +847,7 @@ describe('MigrationOrchestrator', () => {
             continueOnBlocked: true,
             maxBlockedTasks: 0,
             maxInfraRetries: 3,
+            avgTokensPerTask: 5000,
           },
         },
       );
@@ -897,6 +904,96 @@ describe('MigrationOrchestrator', () => {
 
       // Task should be blocked because major issues remain after max retries
       expect(result.blockedTasks).toContain('task-001');
+    });
+
+    it('should use avgTokensPerTask from config for Phase 4 cost projection', async () => {
+      const launcherFn = createMockLauncher();
+      const logger = createSilentLogger(tempDir);
+      const infoSpy = vi.spyOn(logger, 'info');
+
+      const config = createMockConfig({
+        options: {
+          maxParallelAgents: 3,
+          maxRetriesPerTask: 3,
+          largeFileThreshold: 500,
+          maxLinesPerTask: 500,
+          dryRun: false,
+          resume: false,
+          invocationDelayMs: 0,
+          buildConcurrency: 1,
+          continueOnBlocked: true,
+          maxBlockedTasks: 0,
+          maxInfraRetries: 3,
+          avgTokensPerTask: 8000,
+        },
+      });
+
+      const progressDir = join(tempDir, '.aamf', 'migration', config.projectName);
+      await ensureDir(progressDir);
+
+      const checkpoint = new CheckpointManager(progressDir, logger);
+      await checkpoint.load(config.projectName);
+      const progressFile = join(progressDir, 'progress.md');
+      const progress = new ProgressWriter(progressFile);
+      await progress.initialize(config);
+
+      const mockLauncher = new MockAgentLauncher(launcherFn);
+      const orchestrator = new MigrationOrchestrator(config, checkpoint, mockLauncher as any, progress, logger, tempDir);
+
+      await writeMigrationPlan(progressDir);
+      await orchestrator.run();
+
+      // 2 tasks * 8000 avgTokensPerTask * 2 (no testCommand) = 32,000
+      const projectionLog = infoSpy.mock.calls.find((call) => call[0]?.includes('estimated'));
+      expect(projectionLog).toBeDefined();
+      expect(projectionLog![0]).toContain('32,000');
+    });
+
+    it('should use multiplier of 2 without testCommand and 3 with testCommand', async () => {
+      const launcherFn = createMockLauncher();
+
+      // Without testCommand: multiplier = 2
+      {
+        const logger = createSilentLogger(tempDir);
+        const infoSpy = vi.spyOn(logger, 'info');
+        const config = createMockConfig({ options: { maxParallelAgents: 3, maxRetriesPerTask: 3, largeFileThreshold: 500, maxLinesPerTask: 500, dryRun: false, resume: false, invocationDelayMs: 0, buildConcurrency: 1, continueOnBlocked: true, maxBlockedTasks: 0, maxInfraRetries: 3, avgTokensPerTask: 1000 } });
+        const progressDir2 = join(tempDir, 'sub1', '.aamf', 'migration', config.projectName);
+        await ensureDir(progressDir2);
+        const checkpoint = new CheckpointManager(progressDir2, logger);
+        await checkpoint.load(config.projectName);
+        const progress = new ProgressWriter(join(progressDir2, 'progress.md'));
+        await progress.initialize(config);
+        const mockLauncher = new MockAgentLauncher(launcherFn);
+        const orchestrator = new MigrationOrchestrator(config, checkpoint, mockLauncher as any, progress, logger, join(tempDir, 'sub1'));
+        await writeMigrationPlan(progressDir2);
+        await orchestrator.run();
+        // 2 tasks * 1000 * 2 = 4,000
+        const log = infoSpy.mock.calls.find((c) => c[0]?.includes('estimated'));
+        expect(log![0]).toContain('4,000');
+      }
+
+      // With testCommand: multiplier = 3
+      {
+        const logger = createSilentLogger(tempDir);
+        const infoSpy = vi.spyOn(logger, 'info');
+        const config = createMockConfig({
+          target: { language: 'typescript', outputPath: '/tmp/target', testCommand: 'npm test' },
+          options: { maxParallelAgents: 3, maxRetriesPerTask: 3, largeFileThreshold: 500, maxLinesPerTask: 500, dryRun: false, resume: false, invocationDelayMs: 0, buildConcurrency: 1, continueOnBlocked: true, maxBlockedTasks: 0, maxInfraRetries: 3, avgTokensPerTask: 1000 },
+        });
+        const progressDir3 = join(tempDir, 'sub2', '.aamf', 'migration', config.projectName);
+        await ensureDir(progressDir3);
+        const checkpoint = new CheckpointManager(progressDir3, logger);
+        await checkpoint.load(config.projectName);
+        const progress = new ProgressWriter(join(progressDir3, 'progress.md'));
+        await progress.initialize(config);
+        const mockLauncher = new MockAgentLauncher(launcherFn);
+        const orchestrator = new MigrationOrchestrator(config, checkpoint, mockLauncher as any, progress, logger, join(tempDir, 'sub2'));
+        await writeMigrationPlan(progressDir3);
+        await orchestrator.run();
+        // 2 tasks * 1000 * 3 = 6,000
+        const log = infoSpy.mock.calls.find((c) => c[0]?.includes('estimated'));
+        expect(log![0]).toContain('6,000');
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Replaces the hardcoded `5000` tokens-per-task constant and fixed `3` agent multiplier in the Phase 4 cost projection with a configurable value and a dynamically derived multiplier. Closes #8

## Changes

- **`runtime/src/config/schema.ts`** — Added optional `avgTokensPerTask` field (default: `5000`) to the `options` schema object.
- **`runtime/src/core/orchestrator.ts`** — Phase 4 cost projection now reads `this.config.options.avgTokensPerTask` instead of the hardcoded `5000`, and uses a dynamic agent multiplier: `3` when `target.testCommand` is configured, `2` otherwise.
- **`runtime/tests/config-schema.test.ts`** — Added tests verifying `avgTokensPerTask` defaults to `5000` when omitted and accepts custom values.
- **`runtime/tests/orchestrator.test.ts`** — Added tests verifying the projected token count reflects the configured `avgTokensPerTask` value and that the multiplier is `2` without `testCommand` and `3` with it.
- **`runtime/tests/helpers/mocks.ts`** — Updated mock config to include the new `avgTokensPerTask` field.

## Testing

All existing tests continue to pass (`vitest run`: 73 tests, 0 failures). New tests cover the schema default, custom value acceptance, and both branches of the dynamic multiplier logic.

Closes #8