### PR TITLE
fix: Phase 0 KB indexing with embeddings support

### DIFF
--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -79,6 +79,23 @@ export const MigrationConfigSchema = z.object({
      */
     kbIndex: z.object({
       enabled: z.boolean().default(false),
+      /** Embedding configuration for semantic search in the KB. */
+      embeddings: z.object({
+        /** Enable vector embeddings during indexing (requires Python + sentence-transformers). */
+        enabled: z.boolean().default(false),
+        /**
+         * Full HuggingFace model name compatible with sentence-transformers.
+         * The embedding dimensionality is auto-detected from the model at startup.
+         * Examples:
+         *   'Qwen/Qwen3-Embedding-0.6B'  (~1.5 GB)
+         *   'Qwen/Qwen3-Embedding-4B'
+         *   'BAAI/bge-small-en-v1.5'
+         *   'sentence-transformers/all-MiniLM-L6-v2'
+         */
+        model: z.string().default('Qwen/Qwen3-Embedding-0.6B'),
+        /** Path to the Python binary with sentence-transformers installed. */
+        pythonBin: z.string().default('python3'),
+      }).optional(),
     }).optional(),
   }).default({}),
   copilot: z.object({

--- a/runtime/src/core/agent-launcher.ts
+++ b/runtime/src/core/agent-launcher.ts
@@ -245,8 +245,14 @@ export class CopilotRunner implements AgentRunner {
     }
 
     // Inject MCP config for KB server access
+    // Copilot CLI uses --additional-mcp-config with { mcpServers: { name: { url } } } format
     if (invocation.mcpConfig) {
-      args.push('--mcp-config', JSON.stringify(invocation.mcpConfig));
+      const mcpServersDef = {
+        mcpServers: {
+          'aamf-kb': { url: invocation.mcpConfig.url, type: 'http' },
+        },
+      };
+      args.push('--additional-mcp-config', JSON.stringify(mcpServersDef));
     }
 
     const env: NodeJS.ProcessEnv = {
@@ -400,8 +406,14 @@ export class ClaudeCodeRunner implements AgentRunner {
     }
 
     // Inject MCP config for KB server access
+    // Claude Code uses --mcp-config with a JSON string containing the server definition
     if (invocation.mcpConfig) {
-      args.push('--mcp-config', JSON.stringify(invocation.mcpConfig));
+      const mcpServersDef = {
+        mcpServers: {
+          'aamf-kb': { url: invocation.mcpConfig.url, type: 'http' },
+        },
+      };
+      args.push('--mcp-config', JSON.stringify(mcpServersDef));
     }
 
     const env: NodeJS.ProcessEnv = {

--- a/runtime/src/core/checkpoint.ts
+++ b/runtime/src/core/checkpoint.ts
@@ -82,7 +82,7 @@ export class CheckpointManager {
     this.state = {
       projectName,
       version: CHECKPOINT_VERSION,
-      currentPhase: 1,
+      currentPhase: 0,
       currentTask: null,
       completedPhases: [],
       completedTasks: [],

--- a/runtime/src/core/kb-server-process.ts
+++ b/runtime/src/core/kb-server-process.ts
@@ -67,9 +67,13 @@ export class KbServerProcess {
     // Spin up a live embedder if the KB was indexed with one.
     const modelName = getKbMeta(this.db, 'embedding_model');
     if (modelName) {
-      const dimsStr = getKbMeta(this.db, 'embedding_dims');
-      const dims = dimsStr ? parseInt(dimsStr, 10) : 1024;
-      this.embedder = new SentenceTransformersProvider(modelName, dims);
+      this.embedder = new SentenceTransformersProvider(modelName);
+      try {
+        await this.embedder.init();
+      } catch {
+        // Model not available at serve time — fall back to structural search only.
+        this.embedder = null;
+      }
     }
 
     const mcpServer = createKbMcpServer(this.db, this.dbPath, this.embedder ?? undefined);

--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -1,4 +1,4 @@
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import pLimit from 'p-limit';
 import { PHASES, PhaseDefinition } from './phase-registry.js';
 import { CheckpointManager } from './checkpoint.js';
@@ -24,6 +24,8 @@ import { Logger } from '../logging/logger.js';
 import { fileExists, countFileLines, atomicWrite } from '../util/fs.js';
 import { spawnWithTimeout } from '../util/process.js';
 import { IndexBuilder } from '../indexer/index.js';
+import { SentenceTransformersProvider, type EmbeddingProvider } from '../indexer/embedder.js';
+import { ensurePythonDeps } from '../indexer/ensure-python-deps.js';
 import { KbServerProcess } from './kb-server-process.js';
 
 // ─── Infrastructure Error Detection ──────────────────────────────────────────
@@ -104,9 +106,12 @@ export class MigrationOrchestrator {
   private readonly contextBuilder: ContextBuilder;
   private readonly tokenTracker: TokenTracker;
   private readonly progressDir: string;
+  private readonly projectRoot: string;
   private readonly singlePhase?: number;
   private readonly kbDbPath: string;
   private kbServer?: KbServerProcess;
+  /** Live embedding provider created during Phase 0 and disposed on shutdown. */
+  private embedder?: EmbeddingProvider;
   /** Stores the migration-planner AgentResult from Phase 3 for Phase 4 to consume. */
   private phase3PlanResult?: AgentResult;
   /**
@@ -127,6 +132,7 @@ export class MigrationOrchestrator {
     projectRoot: string,
     singlePhase?: number,
   ) {
+    this.projectRoot = projectRoot;
     this.progressDir = join(projectRoot, '.aamf', 'migration', config.projectName);
     this.contextBuilder = new ContextBuilder(config, this.progressDir);
     this.tokenTracker = new TokenTracker();
@@ -155,11 +161,11 @@ export class MigrationOrchestrator {
     let aborted = false;
 
     // Determine which phases to execute
-    const phasesToRun = this.singlePhase
+    const phasesToRun = this.singlePhase != null
       ? PHASES.filter(p => p.id === this.singlePhase)
       : PHASES;
 
-    if (this.singlePhase) {
+    if (this.singlePhase != null) {
       this.logger.info(`Running single phase: ${this.singlePhase}`);
     }
 
@@ -186,8 +192,9 @@ export class MigrationOrchestrator {
           continue;
         }
 
-        // Skip already-completed phases on resume
-        if (phase.id < resumePoint.phase) {
+        // Skip already-completed phases on resume (but not when explicitly
+        // requesting a single phase via --phase).
+        if (this.singlePhase == null && phase.id < resumePoint.phase) {
           phaseResults.push({
             phase: phase.id,
             name: phase.name,
@@ -282,8 +289,12 @@ export class MigrationOrchestrator {
         this.progress.setTokenUsage(this.tokenTracker.getTotal());
       }
     } finally {
-      // Always stop the KB server, whether migration succeeded, failed, or was aborted
+      // Always stop the KB server and dispose the embedder, whether migration succeeded, failed, or was aborted
       await this.stopKbServer();
+      if (this.embedder) {
+        try { await this.embedder.dispose(); } catch { /* ignore */ }
+        this.embedder = undefined;
+      }
     }
 
     const totalDuration = Date.now() - startTime;
@@ -351,8 +362,40 @@ export class MigrationOrchestrator {
    * source directory. Wraps the build in retry logic and a timeout.
    */
   async executePhase0(start: number = Date.now()): Promise<PhaseResult> {
-    this.logger.info(`Building KB index at ${this.kbDbPath}`);
-    const builder = new IndexBuilder(this.kbDbPath, { rootDir: this.config.source.path });
+    const sourceRoot = resolve(this.projectRoot, this.config.source.path);
+    this.logger.info(`Building KB index at ${this.kbDbPath} (source: ${sourceRoot})`);
+
+    // Optionally set up the embedding provider for semantic search.
+    const embCfg = this.config.options.kbIndex?.embeddings;
+    if (embCfg?.enabled) {
+      const pythonBin = embCfg.pythonBin ?? 'python3';
+      const model = embCfg.model ?? 'Qwen/Qwen3-Embedding-0.6B';
+      this.logger.info(`Embeddings enabled — ensuring Python deps (python: ${pythonBin}, model: ${model})`);
+      try {
+        await ensurePythonDeps(pythonBin);
+      } catch (err) {
+        this.logger.warn(
+          `Failed to install Python embedding deps — embeddings will be skipped: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+      this.embedder = new SentenceTransformersProvider(model, pythonBin);
+      try {
+        await this.embedder.init();
+        this.logger.info(`Embedding model loaded — dims: ${this.embedder.dims}`);
+      } catch (err) {
+        this.logger.warn(
+          `Failed to initialise embedding model — embeddings will be skipped: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        try { await this.embedder.dispose(); } catch { /* ignore */ }
+        this.embedder = undefined;
+      }
+    }
+
+    const builder = new IndexBuilder(this.kbDbPath, { rootDir: sourceRoot }, this.embedder);
 
     const maxAttempts = this.config.options.maxRetriesPerTask;
     const timeout =
@@ -1421,9 +1464,23 @@ export class MigrationOrchestrator {
     const phaseTimeouts = this.config.copilot.phaseTimeouts;
     const timeout = phaseTimeouts?.[phase] ?? this.config.copilot.timeout;
 
-    // Agents that benefit from KB access when the KB server is running
+    // Agents that benefit from KB access when the KB server is running.
+    // Essentially every agent that analyses or transforms source code.
     const KB_AWARE_AGENTS: AgentName[] = [
-      'impact-assessor', 'knowledge-builder', 'migration-planner', 'code-migrator',
+      'impact-assessor',
+      'knowledge-builder',
+      'large-file-analyzer',
+      'migration-planner',
+      'adjudicator',
+      'code-migrator',
+      'parity-verifier',
+      'test-writer',
+      'failure-recovery',
+      'final-parity-checker',
+      'e2e-test-crafter',
+      'documentation-writer',
+      'idiomatic-reviewer',
+      'idiomatic-refactorer',
     ];
     const mcpConfig = (KB_AWARE_AGENTS.includes(agent) && this.kbServer)
       ? this.kbServer.mcpConfig

--- a/runtime/src/indexer/db.ts
+++ b/runtime/src/indexer/db.ts
@@ -8,6 +8,9 @@
  */
 
 import Database from 'better-sqlite3';
+import { createRequire } from 'node:module';
+
+const esmRequire = createRequire(import.meta.url);
 
 // Re-export the Database type so callers don't need to import better-sqlite3.
 export type { Database };
@@ -149,8 +152,8 @@ export function getKbMeta(db: Database.Database, key: string): string | undefine
  */
 export function createVec0Tables(db: Database.Database, dims: number): void {
   // Load the sqlite-vec native extension.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const sqliteVec = require('sqlite-vec') as { load(db: Database.Database): void };
+  // Use createRequire for ESM compatibility (native addons cannot be loaded via import()).
+  const sqliteVec = esmRequire('sqlite-vec') as { load(db: Database.Database): void };
   sqliteVec.load(db);
 
   db.exec(`

--- a/runtime/src/indexer/embedder.ts
+++ b/runtime/src/indexer/embedder.ts
@@ -5,6 +5,9 @@
  * embeddings from text. The primary implementation (`SentenceTransformersProvider`)
  * delegates to a Python subprocess that runs a sentence-transformers model,
  * communicating over stdin/stdout using newline-delimited JSON (NDJSON).
+ *
+ * The model's embedding dimensionality is auto-detected at startup — the
+ * Python script writes a `{"dims": N}` line before entering the request loop.
  */
 
 import { spawn, type ChildProcess } from 'node:child_process';
@@ -17,8 +20,16 @@ export interface EmbeddingProvider {
   embed(texts: string[]): Promise<number[][]>;
   /** Human-readable model identifier. */
   readonly modelName: string;
-  /** Dimensionality of the returned vectors. */
+  /**
+   * Dimensionality of the returned vectors.
+   * Only valid after `init()` resolves (throws before that).
+   */
   readonly dims: number;
+  /**
+   * Spawn the Python subprocess, load the model, and detect dim size.
+   * Must be called (and awaited) before the first `embed()` call.
+   */
+  init(): Promise<void>;
   /** Release the underlying process / resources. */
   dispose(): Promise<void>;
 }
@@ -26,15 +37,20 @@ export interface EmbeddingProvider {
 // ─── Python bootstrap script ──────────────────────────────────────────────────
 
 /**
- * Inline Python script: reads NDJSON lines from stdin, each with a `texts`
- * array, and writes back NDJSON lines with an `embeddings` array.
+ * Inline Python script that:
+ *   1. Loads the model.
+ *   2. Prints `{"dims": <N>}` on the first stdout line.
+ *   3. Enters an NDJSON request loop (stdin → stdout).
  *
- * Model name is received as the first CLI argument (sys.argv[1]).
+ * Model name is received as sys.argv[1].
  */
 const BOOTSTRAP_SCRIPT = `
 import sys, json
 from sentence_transformers import SentenceTransformer
 model = SentenceTransformer(sys.argv[1], trust_remote_code=True)
+dims = model.get_sentence_embedding_dimension()
+sys.stdout.write(json.dumps({"dims": dims}) + "\\n")
+sys.stdout.flush()
 for line in sys.stdin:
     line = line.strip()
     if not line:
@@ -56,27 +72,75 @@ interface PendingRequest {
  * Communicates with a Python subprocess via stdin/stdout NDJSON to produce
  * embeddings using a sentence-transformers compatible model.
  *
- * The subprocess is spawned lazily on the first call to `embed()` and kept
- * alive for the lifetime of the provider for efficiency.
+ * Call `init()` first to spawn the process and detect the model's embedding
+ * dimensionality.  The subprocess is kept alive for the lifetime of the
+ * provider for efficiency.
  */
 export class SentenceTransformersProvider implements EmbeddingProvider {
   readonly modelName: string;
-  readonly dims: number;
+  private _dims: number | null = null;
 
   private proc: ChildProcess | null = null;
   private rl: readline.Interface | null = null;
   private readonly pendingRequests: PendingRequest[] = [];
   private readonly pythonBin: string;
+  /** Whether the first stdout line (dims handshake) has been consumed. */
+  private initialized = false;
 
-  constructor(modelName: string, dims: number, pythonBin = 'python3') {
+  constructor(modelName: string, pythonBin = 'python3') {
     this.modelName = modelName;
-    this.dims = dims;
     this.pythonBin = pythonBin;
+  }
+
+  /** Embedding dimensionality — available only after `init()`. */
+  get dims(): number {
+    if (this._dims === null) {
+      throw new Error('EmbeddingProvider not initialised — call init() first');
+    }
+    return this._dims;
+  }
+
+  /**
+   * Spawn the Python subprocess, load the model, and read the `{"dims": N}`
+   * handshake line.  This may take a while on first run (model download).
+   */
+  async init(): Promise<void> {
+    if (this.initialized) return;
+    this.spawnProcess();
+
+    // The very first line from the subprocess is the dims handshake.
+    return new Promise<void>((resolve, reject) => {
+      const onLine = (line: string) => {
+        try {
+          const msg = JSON.parse(line) as { dims?: number };
+          if (typeof msg.dims === 'number') {
+            this._dims = msg.dims;
+            this.initialized = true;
+            resolve();
+          } else {
+            reject(new Error(`Unexpected handshake from embedding subprocess: ${line}`));
+          }
+        } catch (err) {
+          reject(new Error(`Failed to parse embedding handshake: ${line}`));
+        }
+      };
+      // Read exactly one line for the handshake, then re-wire for embed requests.
+      this.rl!.once('line', onLine);
+
+      // If the process dies before the handshake, reject.
+      this.proc!.once('exit', (code) => {
+        if (!this.initialized) {
+          reject(new Error(`Embedding subprocess exited with code ${code} before handshake`));
+        }
+      });
+    });
   }
 
   async embed(texts: string[]): Promise<number[][]> {
     if (texts.length === 0) return [];
-    this.ensureProcess();
+    if (!this.initialized) {
+      throw new Error('EmbeddingProvider not initialised — call init() first');
+    }
     return new Promise<number[][]>((resolve, reject) => {
       this.pendingRequests.push({ resolve, reject });
       this.proc!.stdin!.write(JSON.stringify({ texts }) + '\n');
@@ -97,17 +161,19 @@ export class SentenceTransformersProvider implements EmbeddingProvider {
   }
 
   /** Spawn the Python subprocess and wire up the readline interface. */
-  private ensureProcess(): void {
+  private spawnProcess(): void {
     if (this.proc) return;
 
-    // Pass the script via -c and the model name as the first positional argument.
     this.proc = spawn(this.pythonBin, ['-c', BOOTSTRAP_SCRIPT, this.modelName], {
       stdio: ['pipe', 'pipe', 'inherit'],
     });
 
     this.rl = readline.createInterface({ input: this.proc.stdout! });
 
+    // After init(), all subsequent lines are embed responses.
     this.rl.on('line', (line) => {
+      // Skip lines until init handshake is done (handled by init's once listener).
+      if (!this.initialized) return;
       const pending = this.pendingRequests.shift();
       if (!pending) return;
       try {
@@ -138,13 +204,6 @@ export class SentenceTransformersProvider implements EmbeddingProvider {
 
 // ─── Qwen3 factory ────────────────────────────────────────────────────────────
 
-/** Known embedding dimensions for each supported Qwen3-Embedding model size. */
-const QWEN3_DIMS: Record<'0.6B' | '4B' | '8B', number> = {
-  '0.6B': 1024,
-  '4B':   2560,
-  '8B':   4096,
-};
-
 /**
  * Creates a `SentenceTransformersProvider` pre-configured for the specified
  * Qwen3-Embedding model size.
@@ -157,5 +216,5 @@ export function Qwen3EmbeddingProvider(
   pythonBin = 'python3',
 ): SentenceTransformersProvider {
   const modelName = `Qwen/Qwen3-Embedding-${size}`;
-  return new SentenceTransformersProvider(modelName, QWEN3_DIMS[size], pythonBin);
+  return new SentenceTransformersProvider(modelName, pythonBin);
 }

--- a/runtime/src/indexer/ensure-python-deps.ts
+++ b/runtime/src/indexer/ensure-python-deps.ts
@@ -1,0 +1,58 @@
+/**
+ * @module indexer/ensure-python-deps
+ *
+ * Validates that the Python environment has the packages required for
+ * embedding generation (`sentence-transformers`, `torch`).  If missing,
+ * attempts an automatic `pip install` before the first embedding run.
+ *
+ * This is only used when `kbIndex.embeddings.enabled` is `true` in the
+ * migration config.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/** Python packages required by the sentence-transformers embedding provider. */
+const REQUIRED_PACKAGES = ['sentence_transformers', 'torch'];
+
+/**
+ * Checks whether each of `REQUIRED_PACKAGES` is importable by the given Python
+ * binary.  For any missing package, runs `pip install sentence-transformers`
+ * (which pulls in `torch` as a transitive dependency).
+ *
+ * Throws if the Python binary is not found or if `pip install` fails.
+ *
+ * @param pythonBin  Path to the Python 3 interpreter (default: `'python3'`).
+ * @param timeout    Maximum milliseconds to wait for the install (default: 5 min).
+ */
+export async function ensurePythonDeps(
+  pythonBin = 'python3',
+  timeout = 5 * 60_000,
+): Promise<void> {
+  // Probe which packages are already available.
+  const missing: string[] = [];
+  for (const pkg of REQUIRED_PACKAGES) {
+    try {
+      await execFileAsync(pythonBin, ['-c', `import ${pkg}`], { timeout: 10_000 });
+    } catch {
+      missing.push(pkg);
+    }
+  }
+
+  if (missing.length === 0) return;
+
+  // `sentence-transformers` transitively installs torch, so a single pip
+  // install call is sufficient.
+  await execFileAsync(
+    pythonBin,
+    ['-m', 'pip', 'install', '--quiet', 'sentence-transformers'],
+    { timeout },
+  );
+
+  // Verify the install succeeded.
+  for (const pkg of REQUIRED_PACKAGES) {
+    await execFileAsync(pythonBin, ['-c', `import ${pkg}`], { timeout: 10_000 });
+  }
+}

--- a/runtime/src/indexer/parser.ts
+++ b/runtime/src/indexer/parser.ts
@@ -7,6 +7,9 @@
  */
 
 import Parser from 'tree-sitter';
+import { createRequire } from 'node:module';
+
+const esmRequire = createRequire(import.meta.url);
 
 // ─── Grammar package map ──────────────────────────────────────────────────────
 
@@ -71,8 +74,9 @@ export class ParserPool {
     }
 
     try {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      let grammar = require(pkg);
+      // Native addons must be loaded via require(), not import().
+      // Use createRequire to ensure it works in both CJS and ESM contexts.
+      let grammar = esmRequire(pkg);
 
       // Some packages (e.g. tree-sitter-typescript) export sub-grammars.
       if (language === 'typescript' && grammar.typescript) {

--- a/runtime/src/kb-server/server.ts
+++ b/runtime/src/kb-server/server.ts
@@ -146,13 +146,19 @@ export function createKbMcpServer(
  * `SentenceTransformersProvider` instance for it.  Returns `undefined` when no
  * embedding model is recorded in the database.
  */
-function buildEmbedder(db: Database.Database): EmbeddingProvider | undefined {
+async function buildEmbedder(db: Database.Database): Promise<EmbeddingProvider | undefined> {
   const modelName = getKbMeta(db, 'embedding_model');
   if (!modelName) return undefined;
 
-  const dimsStr = getKbMeta(db, 'embedding_dims');
-  const dims = dimsStr ? parseInt(dimsStr, 10) : 1024;
-  return new SentenceTransformersProvider(modelName, dims);
+  const provider = new SentenceTransformersProvider(modelName);
+  try {
+    await provider.init();
+    return provider;
+  } catch {
+    // Model not available — fall back to structural search only.
+    try { await provider.dispose(); } catch { /* ignore */ }
+    return undefined;
+  }
 }
 
 // ─── CLI argument parsing ─────────────────────────────────────────────────────
@@ -173,7 +179,7 @@ async function main(): Promise<void> {
   const { dbPath } = parseArgs();
 
   const db = openReadOnly(dbPath);
-  const embedder = buildEmbedder(db);
+  const embedder = await buildEmbedder(db);
 
   const server = createKbMcpServer(db, dbPath, embedder);
 

--- a/runtime/tests/agent-launcher.test.ts
+++ b/runtime/tests/agent-launcher.test.ts
@@ -564,7 +564,7 @@ describe('AgentLauncher', () => {
   });
 
   describe('mcpConfig injection', () => {
-    it('should pass --mcp-config flag when mcpConfig is provided', async () => {
+    it('should pass --additional-mcp-config flag when mcpConfig is provided', async () => {
       const script = await createScript('echo-mcp-args.sh', 'echo "ARGS:$@"\nexit 0');
       const launcher = makeLauncher(script);
       const { contextFile, progressDir } = await prepareInvocation('mcp-config-001');
@@ -590,11 +590,12 @@ describe('AgentLauncher', () => {
       expect(agentLog).toBeDefined();
 
       const logContent = await readFile(join(logDir, agentLog!), 'utf-8');
-      expect(logContent).toContain('--mcp-config');
+      expect(logContent).toContain('--additional-mcp-config');
+      expect(logContent).toContain('aamf-kb');
       expect(logContent).toContain('localhost:4321');
     });
 
-    it('should not include --mcp-config flag when mcpConfig is absent', async () => {
+    it('should not include --additional-mcp-config flag when mcpConfig is absent', async () => {
       const script = await createScript('echo-no-mcp.sh', 'echo "ARGS:$@"\nexit 0');
       const launcher = makeLauncher(script);
       const { contextFile, progressDir } = await prepareInvocation('no-mcp-001');
@@ -615,7 +616,7 @@ describe('AgentLauncher', () => {
       expect(agentLog).toBeDefined();
 
       const logContent = await readFile(join(logDir, agentLog!), 'utf-8');
-      expect(logContent).not.toContain('--mcp-config');
+      expect(logContent).not.toContain('--additional-mcp-config');
     });
   });
 });

--- a/runtime/tests/checkpoint.test.ts
+++ b/runtime/tests/checkpoint.test.ts
@@ -24,7 +24,7 @@ describe('CheckpointManager', () => {
   it('should create initial state on first load', async () => {
     const state = await manager.load('test-project');
     expect(state.projectName).toBe('test-project');
-    expect(state.currentPhase).toBe(1);
+    expect(state.currentPhase).toBe(0);
     expect(state.completedPhases).toEqual([]);
     expect(state.completedTasks).toEqual([]);
     expect(state.version).toBe(1);

--- a/runtime/tests/config-schema.test.ts
+++ b/runtime/tests/config-schema.test.ts
@@ -344,6 +344,50 @@ describe('MigrationConfigSchema', () => {
         });
         expect(result.options.kbIndex?.enabled).toBe(false);
       });
+
+      it('should leave embeddings undefined when omitted from kbIndex', () => {
+        const result = MigrationConfigSchema.parse({
+          ...validConfig,
+          options: { kbIndex: { enabled: true } },
+        });
+        expect(result.options.kbIndex?.embeddings).toBeUndefined();
+      });
+
+      it('should default embeddings.enabled to false when embeddings is {}', () => {
+        const result = MigrationConfigSchema.parse({
+          ...validConfig,
+          options: { kbIndex: { enabled: true, embeddings: {} } },
+        });
+        expect(result.options.kbIndex?.embeddings?.enabled).toBe(false);
+      });
+
+      it('should accept embeddings with all fields', () => {
+        const result = MigrationConfigSchema.parse({
+          ...validConfig,
+          options: {
+            kbIndex: {
+              enabled: true,
+              embeddings: { enabled: true, model: 'BAAI/bge-small-en-v1.5', pythonBin: '/usr/bin/python3.11' },
+            },
+          },
+        });
+        const emb = result.options.kbIndex?.embeddings;
+        expect(emb?.enabled).toBe(true);
+        expect(emb?.model).toBe('BAAI/bge-small-en-v1.5');
+        expect(emb?.pythonBin).toBe('/usr/bin/python3.11');
+      });
+
+      it('should default model to Qwen3-Embedding-0.6B and pythonBin to python3', () => {
+        const result = MigrationConfigSchema.parse({
+          ...validConfig,
+          options: {
+            kbIndex: { enabled: true, embeddings: { enabled: true } },
+          },
+        });
+        const emb = result.options.kbIndex?.embeddings;
+        expect(emb?.model).toBe('Qwen/Qwen3-Embedding-0.6B');
+        expect(emb?.pythonBin).toBe('python3');
+      });
     });
   });
 });

--- a/runtime/tests/embedder.test.ts
+++ b/runtime/tests/embedder.test.ts
@@ -14,29 +14,31 @@ const ENABLED = process.env.AAMF_EMBEDDER === '1';
 // ─── Gated: constructor / property tests (requires AAMF_EMBEDDER=1) ───────────
 
 describe.skipIf(!ENABLED)('SentenceTransformersProvider (no subprocess)', () => {
-  it('should expose modelName and dims from constructor', () => {
-    const p = new SentenceTransformersProvider('my/model', 768);
+  it('should expose modelName from constructor', () => {
+    const p = new SentenceTransformersProvider('my/model');
     expect(p.modelName).toBe('my/model');
-    expect(p.dims).toBe(768);
+  });
+
+  it('dims should throw before init() is called', () => {
+    const p = new SentenceTransformersProvider('my/model');
+    expect(() => p.dims).toThrow('call init() first');
   });
 
   it('dispose() should resolve immediately when no subprocess was started', async () => {
-    const p = new SentenceTransformersProvider('my/model', 768);
+    const p = new SentenceTransformersProvider('my/model');
     await expect(p.dispose()).resolves.toBeUndefined();
   });
 });
 
 describe.skipIf(!ENABLED)('Qwen3EmbeddingProvider factory', () => {
-  it('should set correct modelName and dims for 4B', () => {
+  it('should set correct modelName for 4B', () => {
     const p = Qwen3EmbeddingProvider('4B');
     expect(p.modelName).toBe('Qwen/Qwen3-Embedding-4B');
-    expect(p.dims).toBe(2560);
   });
 
-  it('should set correct modelName and dims for 8B', () => {
+  it('should set correct modelName for 8B', () => {
     const p = Qwen3EmbeddingProvider('8B');
     expect(p.modelName).toBe('Qwen/Qwen3-Embedding-8B');
-    expect(p.dims).toBe(4096);
   });
 });
 
@@ -51,6 +53,7 @@ describe.skipIf(!ENABLED)('Qwen3EmbeddingProvider', () => {
 
   it('returns float arrays of the expected dimension (0.6B)', async () => {
     provider = Qwen3EmbeddingProvider('0.6B');
+    await provider.init();
     const result = await provider.embed(['hello world']);
 
     expect(result).toHaveLength(1);
@@ -60,6 +63,7 @@ describe.skipIf(!ENABLED)('Qwen3EmbeddingProvider', () => {
 
   it('batches multiple texts into a single round-trip', async () => {
     provider = Qwen3EmbeddingProvider('0.6B');
+    await provider.init();
     const texts = ['foo bar', 'baz qux', 'hello world'];
     const result = await provider.embed(texts);
 
@@ -78,6 +82,5 @@ describe.skipIf(!ENABLED)('Qwen3EmbeddingProvider', () => {
   it('modelName is set correctly', () => {
     provider = Qwen3EmbeddingProvider('0.6B');
     expect(provider.modelName).toBe('Qwen/Qwen3-Embedding-0.6B');
-    expect(provider.dims).toBe(1024);
   });
 });

--- a/runtime/tests/ensure-python-deps.test.ts
+++ b/runtime/tests/ensure-python-deps.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { execFile } from 'node:child_process';
+
+// We test the module by mocking child_process.execFile.
+
+describe('ensurePythonDeps', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should do nothing when all packages are already importable', async () => {
+    // Mock execFile to always succeed (packages present)
+    vi.mock('node:child_process', async (importOriginal) => {
+      const original = await importOriginal<typeof import('node:child_process')>();
+      return {
+        ...original,
+        execFile: vi.fn((_cmd: string, _args: string[], _opts: unknown, cb?: Function) => {
+          if (cb) cb(null, '', '');
+          return {} as any;
+        }),
+      };
+    });
+
+    // Re-import to pick up mock
+    const { ensurePythonDeps } = await import('../src/indexer/ensure-python-deps.js');
+    await expect(ensurePythonDeps('python3')).resolves.toBeUndefined();
+  });
+});

--- a/runtime/tests/fixtures/jq-c-project/migration.config.json
+++ b/runtime/tests/fixtures/jq-c-project/migration.config.json
@@ -21,7 +21,13 @@
     "maxLinesPerTask": 500,
     "tokenBudget": 500000,
     "dryRun": false,
-    "resume": false
+    "resume": false,
+    "kbIndex": {
+      "enabled": true,
+      "embeddings": {
+        "enabled": true
+      }
+    }
   },
   "copilot": {
     "cliCommand": "copilot",

--- a/runtime/tests/fixtures/lz4-c-project/migration.config.json
+++ b/runtime/tests/fixtures/lz4-c-project/migration.config.json
@@ -53,7 +53,13 @@
     "maxLinesPerTask": 500,
     "tokenBudget": 1000000,
     "dryRun": false,
-    "resume": true
+    "resume": true,
+    "kbIndex": {
+      "enabled": true,
+      "embeddings": {
+        "enabled": true
+      }
+    }
   },
   "copilot": {
     "cliCommand": "copilot",

--- a/runtime/tests/fixtures/protobuf-upb-project/migration.config.json
+++ b/runtime/tests/fixtures/protobuf-upb-project/migration.config.json
@@ -34,7 +34,13 @@
     "maxLinesPerTask": 500,
     "tokenBudget": 3000000,
     "dryRun": false,
-    "resume": true
+    "resume": true,
+    "kbIndex": {
+      "enabled": true,
+      "embeddings": {
+        "enabled": true
+      }
+    }
   },
   "copilot": {
     "cliCommand": "copilot",

--- a/runtime/tests/fixtures/sqlite-c-project/migration.config.json
+++ b/runtime/tests/fixtures/sqlite-c-project/migration.config.json
@@ -21,7 +21,13 @@
     "maxLinesPerTask": 500,
     "tokenBudget": 500000,
     "dryRun": false,
-    "resume": false
+    "resume": false,
+    "kbIndex": {
+      "enabled": true,
+      "embeddings": {
+        "enabled": true
+      }
+    }
   },
   "copilot": {
     "cliCommand": "copilot",

--- a/runtime/tests/fixtures/tiny-python-project/migration.config.json
+++ b/runtime/tests/fixtures/tiny-python-project/migration.config.json
@@ -19,7 +19,13 @@
     "maxLinesPerTask": 500,
     "tokenBudget": 100000,
     "dryRun": false,
-    "resume": false
+    "resume": false,
+    "kbIndex": {
+      "enabled": true,
+      "embeddings": {
+        "enabled": true
+      }
+    }
   },
   "copilot": {
     "cliCommand": "copilot",

--- a/runtime/tests/fixtures/zstd-c-project/migration.config.json
+++ b/runtime/tests/fixtures/zstd-c-project/migration.config.json
@@ -32,7 +32,13 @@
     "maxLinesPerTask": 500,
     "tokenBudget": 2000000,
     "dryRun": false,
-    "resume": true
+    "resume": true,
+    "kbIndex": {
+      "enabled": true,
+      "embeddings": {
+        "enabled": true
+      }
+    }
   },
   "copilot": {
     "cliCommand": "copilot",

--- a/runtime/tests/orchestrator.test.ts
+++ b/runtime/tests/orchestrator.test.ts
@@ -303,6 +303,107 @@ describe('MigrationOrchestrator', () => {
         buildSpy.mockRestore();
       }
     });
+
+    it('executePhase0 should pass embedder to IndexBuilder when embeddings.enabled is true', async () => {
+      const { IndexBuilder } = await import('../src/indexer/index.js');
+      const buildSpy = vi.spyOn(IndexBuilder.prototype, 'build').mockResolvedValue(undefined);
+
+      // Mock ensurePythonDeps to avoid actually running pip
+      const depsMod = await import('../src/indexer/ensure-python-deps.js');
+      const depsSpy = vi.spyOn(depsMod, 'ensurePythonDeps').mockResolvedValue(undefined);
+
+      // Mock embedder init() to avoid spawning a real Python process
+      const { SentenceTransformersProvider } = await import('../src/indexer/embedder.js');
+      const initSpy = vi.spyOn(SentenceTransformersProvider.prototype, 'init').mockResolvedValue(undefined);
+      const disposeSpy = vi.spyOn(SentenceTransformersProvider.prototype, 'dispose').mockResolvedValue(undefined);
+
+      try {
+        const launcherFn = createMockLauncher();
+        const { orchestrator } = await setupOrchestrator(tempDir, launcherFn, {
+          options: {
+            maxParallelAgents: 3,
+            maxRetriesPerTask: 1,
+            largeFileThreshold: 500,
+            maxLinesPerTask: 500,
+            dryRun: false,
+            resume: false,
+            invocationDelayMs: 0,
+            buildConcurrency: 1,
+            continueOnBlocked: true,
+            maxBlockedTasks: 0,
+            maxInfraRetries: 3,
+            avgTokensPerTask: 5000,
+            contextWindowStrategy: 'per-invocation',
+            kbIndex: {
+              enabled: true,
+              embeddings: { enabled: true, model: 'Qwen/Qwen3-Embedding-0.6B', pythonBin: 'python3' },
+            },
+          },
+        });
+
+        const result = await orchestrator.executePhase0(Date.now());
+
+        expect(result.phase).toBe(0);
+        expect(depsSpy).toHaveBeenCalledWith('python3');
+        expect(initSpy).toHaveBeenCalled();
+      } finally {
+        buildSpy.mockRestore();
+        depsSpy.mockRestore();
+        initSpy.mockRestore();
+        disposeSpy.mockRestore();
+      }
+    });
+
+    it('executePhase0 should skip embeddings gracefully when ensurePythonDeps fails', async () => {
+      const { IndexBuilder } = await import('../src/indexer/index.js');
+      const buildSpy = vi.spyOn(IndexBuilder.prototype, 'build').mockResolvedValue(undefined);
+
+      const depsMod = await import('../src/indexer/ensure-python-deps.js');
+      const depsSpy = vi.spyOn(depsMod, 'ensurePythonDeps').mockRejectedValue(
+        new Error('python3 not found'),
+      );
+
+      // Mock init to simulate failure (Python not available)
+      const { SentenceTransformersProvider } = await import('../src/indexer/embedder.js');
+      const initSpy = vi.spyOn(SentenceTransformersProvider.prototype, 'init').mockRejectedValue(
+        new Error('Embedding subprocess exited with code 1 before handshake'),
+      );
+      const disposeSpy = vi.spyOn(SentenceTransformersProvider.prototype, 'dispose').mockResolvedValue(undefined);
+
+      try {
+        const launcherFn = createMockLauncher();
+        const { orchestrator } = await setupOrchestrator(tempDir, launcherFn, {
+          options: {
+            maxParallelAgents: 3,
+            maxRetriesPerTask: 1,
+            largeFileThreshold: 500,
+            maxLinesPerTask: 500,
+            dryRun: false,
+            resume: false,
+            invocationDelayMs: 0,
+            buildConcurrency: 1,
+            continueOnBlocked: true,
+            maxBlockedTasks: 0,
+            maxInfraRetries: 3,
+            avgTokensPerTask: 5000,
+            contextWindowStrategy: 'per-invocation',
+            kbIndex: {
+              enabled: true,
+              embeddings: { enabled: true },
+            },
+          },
+        });
+
+        // Should still succeed — embeddings are best-effort
+        const result = await orchestrator.executePhase0(Date.now());
+        expect(result.phase).toBe(0);
+      } finally {
+        buildSpy.mockRestore();
+        depsSpy.mockRestore();
+        initSpy.mockRestore();
+        disposeSpy.mockRestore();
+      }
+    });
   });
 
   // ─── Phase Sequencing ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes Phase 0 (KB Indexing) to work correctly with `--phase 0` and enables embedding support across all E2E fixtures.

## Bug Fixes

- **`--phase 0` silently ignored**: `this.singlePhase` was used in a truthy check — `0` is falsy in JS. Changed to `this.singlePhase != null`.
- **Resume-skip with explicit `--phase`**: The resume-point skip logic was skipping phase 0 even when explicitly requested. Now bypassed when `singlePhase` is set.

## Features

- Enable `kbIndex.embeddings.enabled` in all 6 E2E fixture configs
- Add `ensure-python-deps` helper for embedding model setup
- Update orchestrator to spawn Qwen3 embedding model during Phase 0
- Wire embedder into `KbServerProcess` for query-time semantic search
- Add config schema support for `kbIndex.embeddings` options

## Changes

- 22 files changed across source, tests, and fixtures
- Updated orchestrator, agent launcher, checkpoint, config schema, embedder, KB server
- Added corresponding test coverage