### PR TITLE
Apply retries to Phase 3 task-decomposer invocations

### DIFF
--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -692,23 +692,45 @@ export class MigrationOrchestrator {
 
       const parallel = new ParallelExecutor(
         this.config.options.maxParallelAgents,
-        (inv) => this.launcher.launchAgent(inv),
+        async (inv) => {
+          const retryExec = new RetryExecutor(
+            (attemptInv) => this.launcher.launchAgent(attemptInv),
+            this.logger,
+          );
+          return retryExec.executeWithRetry(inv, {
+            maxAttempts: this.config.options.maxRetriesPerTask,
+            onRetry: async (attempt, error) => {
+              this.logger.warn(
+                `Retry ${attempt} for task-decomposer${inv.taskId ? ` (${inv.taskId})` : ''}: ${error}`,
+              );
+            },
+          });
+        },
         this.logger,
       );
       const results = await parallel.executeAll(invocations);
 
-      const failedGroups: Array<{ id: string; reason: string }> = [];
+      const failedGroups: Array<{ id: string; reason: string; attempts: number }> = [];
       for (const [i, r] of results.entries()) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const group = remainingGroups[i]!;
+        const attempts =
+          'attempts' in r && typeof (r as { attempts?: unknown }).attempts === 'number'
+            ? (r as { attempts: number }).attempts
+            : 1;
         this.recordTokens(r, 3);
         if (r.success) {
           await this.checkpoint.completePhase3Group(group.id);
+          if (attempts > 1) {
+            this.logger.info(
+              `task-decomposer recovered for group "${group.id}" after ${attempts} attempt(s)`,
+            );
+          }
         } else {
           const reason = r.error ?? r.parseError ?? 'unknown';
-          failedGroups.push({ id: group.id, reason });
+          failedGroups.push({ id: group.id, reason, attempts });
           this.logger.error(
-            `task-decomposer failed for group "${group.id}": ${reason}`,
+            `task-decomposer failed for group "${group.id}" after ${attempts} attempt(s): ${reason}`,
           );
         }
       }
@@ -716,7 +738,7 @@ export class MigrationOrchestrator {
       if (failedGroups.length > 0) {
         const failedGroupIds = failedGroups.map(f => f.id);
         const details = failedGroups
-          .map(f => `${f.id} (${f.reason})`)
+          .map(f => `${f.id} (${f.reason}; attempts=${f.attempts})`)
           .join('; ');
         return {
           phase: 3,

--- a/runtime/tests/orchestrator.test.ts
+++ b/runtime/tests/orchestrator.test.ts
@@ -785,6 +785,77 @@ describe('MigrationOrchestrator', () => {
   // ─── structuredOutput Integration ──────────────────────────────────
 
   describe('structuredOutput Integration', () => {
+    it('should apply maxRetriesPerTask to Phase 3 task-decomposer invocations', async () => {
+      const launcherFn = vi.fn(async (inv: AgentInvocation): Promise<AgentResult> => {
+        if (inv.agent === 'task-decomposer' && inv.taskId === 'core') {
+          return {
+            agent: inv.agent,
+            taskId: inv.taskId,
+            exitCode: 1,
+            success: false,
+            outputFiles: [],
+            duration: 100,
+            tokenUsage: { prompt: 100, completion: 0, total: 100 },
+            outputParsed: false,
+            error: 'transient task-decomposer failure',
+          };
+        }
+
+        return {
+          agent: inv.agent,
+          taskId: inv.taskId,
+          exitCode: 0,
+          success: true,
+          outputFiles: [],
+          duration: 100,
+          tokenUsage: { prompt: 100, completion: 0, total: 100 },
+          outputParsed: true,
+        };
+      });
+
+      const { orchestrator, checkpoint, mockLauncher, progressDir } = await setupOrchestrator(
+        tempDir,
+        launcherFn,
+        {
+          options: {
+            maxParallelAgents: 3,
+            maxRetriesPerTask: 2,
+            maxLinesPerTask: 500,
+            dryRun: false,
+            resume: false,
+            invocationDelayMs: 0,
+            buildConcurrency: 1,
+            continueOnBlocked: true,
+            maxBlockedTasks: 0,
+            maxInfraRetries: 3,
+            avgTokensPerTask: 5000,
+          },
+        },
+        3,
+      );
+
+      const planningDir = join(progressDir, 'planning');
+      await mkdir(planningDir, { recursive: true });
+      await writeFile(
+        join(planningDir, 'groups.json'),
+        JSON.stringify([{ id: 'core', name: 'Core', analysisFiles: [] }], null, 2),
+      );
+      await writeFile(join(planningDir, 'strategy.md'), '# strategy\n');
+
+      await checkpoint.completePhase3a();
+
+      const result = await orchestrator.run();
+
+      expect(result.success).toBe(false);
+      const phase3 = result.phases.find((p) => p.phase === 3);
+      expect(phase3?.error).toContain('task-decomposer failed for 1 group(s): core');
+
+      const coreTaskDecomposerInvocations = mockLauncher.invocations.filter(
+        (inv) => inv.agent === 'task-decomposer' && inv.taskId === 'core',
+      );
+      expect(coreTaskDecomposerInvocations).toHaveLength(2);
+    });
+
     it('should fail Phase 3 when a task-decomposer output file violates schema', async () => {
       const launcherFn = createMockLauncher();
       const { orchestrator, progressDir } = await setupOrchestrator(


### PR DESCRIPTION
## Summary
- apply maxRetriesPerTask to Phase 3 task-decomposer fan-out invocations
- add retry attempt details to Phase 3 failure logs and final error summary
- log when a task-decomposer group recovers after retry
- add regression coverage for Phase 3 retry behavior in orchestrator tests

## Notes
- validation in this environment is limited by missing module resolution for @aamf/lore when running vitest
- only staged changes were included in this PR