### PR TITLE
fix(lore): avoid install-order failure by using prepack

### DIFF
--- a/lore/package.json
+++ b/lore/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "tsc --noEmit",
-    "prepare": "npm run build"
+    "prepack": "npm run build"
   },
   "dependencies": {
     "@types/better-sqlite3": "^7.6.13",


### PR DESCRIPTION
## Summary
- replace Lore lifecycle script `prepare` with `prepack`
- keep `build` as `tsc`

## Why
`runtime` depends on `@aamf/lore` via `file:../lore`. Running `prepare` during dependency installation can invoke `tsc` before Lore's own dev dependencies are guaranteed in that install context, which blocks installs based on order.

Switching to `prepack` preserves build-on-package behavior without forcing a build during dependency install.

## Validation
- `rm -rf lore/node_modules && npm install --prefix runtime` succeeds
