### PR TITLE
fix(ci): build lore before runtime typecheck/install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
         working-directory: lore
         run: npm ci
 
+      - name: Build Lore
+        working-directory: lore
+        run: npm run build
+
       - name: Install dependencies
         working-directory: runtime
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,20 @@ jobs:
       - name: Cache node_modules
         uses: actions/cache@v4
         with:
-          path: runtime/node_modules
+          path: |
+            lore/node_modules
+            runtime/node_modules
           key: ${{ runner.os }}-node-20.x-${{ hashFiles('runtime/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-20.x-
+
+      - name: Install Lore dependencies
+        working-directory: lore
+        run: npm ci
+
+      - name: Build Lore
+        working-directory: lore
+        run: npm run build
 
       - name: Install dependencies
         working-directory: runtime


### PR DESCRIPTION
## Summary
- add explicit `lore` build step in CI before `runtime` install/type-check
- add explicit `lore` install/build steps in release workflow before `runtime` install/type-check
- include `lore/node_modules` in release workflow cache path

## Why
After moving Lore from `prepare` to `prepack`, `runtime`'s `file:../lore` dependency can be installed without prebuilt `dist` artifacts unless Lore is built explicitly. This caused CI TS2307 errors resolving `@aamf/lore` during `npx tsc --noEmit`.

## Validation
- clean local reproduction of failure
- clean local flow with Lore build passes (`npx tsc --noEmit` in `runtime`)
- `npx vitest run tests/ci-workflow.test.ts tests/release-workflow.test.ts` passes
