### PR TITLE
Add granular git commit workflow (#39)

### DIFF
--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -188,7 +188,6 @@ export class MigrationOrchestrator {
     this.costEstimatorInstance = new CostEstimator(overrides);
     this.reportGenerator = new ReportGenerator();
     this.runId = runId;
-    this.gitLimiter = pLimit(1);
   }
 
   // ─── Public API ──────────────────────────────────────────────────────

--- a/runtime/tests/context-builder.test.ts
+++ b/runtime/tests/context-builder.test.ts
@@ -158,6 +158,37 @@ describe('ContextBuilder', () => {
       expect(context.outputPath).toBe('/tmp/target');
     });
 
+    it('should set test-writer outputPath to target root, not a subdirectory', async () => {
+      const contextPath = await builder.buildContext('test-writer', 4, 'task-001', {
+        targetFile: 'src/auth.ts',
+      });
+      const context = await readJson<AgentContext>(contextPath);
+
+      expect(context.outputPath).toBe('/tmp/target');
+      expect(context.outputPath).not.toContain('__tests__');
+    });
+
+    it('should include parityReport in test-writer inputFiles when provided', async () => {
+      const contextPath = await builder.buildContext('test-writer', 4, 'task-001', {
+        targetFile: 'src/auth.ts',
+        parityReport: '/tmp/parity/auth-report.md',
+      });
+      const context = await readJson<AgentContext>(contextPath);
+
+      expect(context.inputFiles).toContain('src/auth.ts');
+      expect(context.inputFiles).toContain('/tmp/parity/auth-report.md');
+      expect(context.outputPath).toBe('/tmp/target');
+    });
+
+    it('should default test-writer testType to unit when not specified', async () => {
+      const contextPath = await builder.buildContext('test-writer', 4, 'task-001', {
+        targetFile: 'src/auth.ts',
+      });
+      const context = await readJson<AgentContext>(contextPath);
+
+      expect(context.payload?.testType).toBe('unit');
+    });
+
     it('should route failure-recovery to failure report + source/target', async () => {
       const contextPath = await builder.buildContext('failure-recovery', 4, 'task-001', {
         failureReport: '/tmp/failure.md',

--- a/runtime/tests/orchestrator.test.ts
+++ b/runtime/tests/orchestrator.test.ts
@@ -15,8 +15,6 @@ import {
 } from './helpers/mocks.js';
 import { AgentInvocation, AgentResult, AgentName, MigrationTask } from '../src/agents/types.js';
 import { Logger } from '../src/logging/logger.js';
-import { ensureDir } from '../src/util/fs.js';
-import { spawnWithTimeout } from '../src/util/process.js';
 import { ensureDir, fileExists } from '../src/util/fs.js';
 import { spawnWithTimeout } from '../src/util/process.js';
 


### PR DESCRIPTION
## Summary

Add automatic, granular git commit support for migrated output. The orchestrator now ensures `target.outputPath` is a git repository and creates distinct commits per code-modifying agent invocation and per completed Phase 4 task. Closes #39

## Changes

### Configuration (`runtime/src/config/schema.ts`)
- Add `options.git` configuration block with `enabled`, `autoInit`, `commitByAgent`, `commitPerTask`, `authorName`, and `authorEmail` fields, all with sensible defaults.

### Orchestrator (`runtime/src/core/orchestrator.ts`)
- Add `gitLimiter = pLimit(1)` to serialize all git operations and prevent commit interleaving.
- Add `ensureGitRepositoryReady()` to auto-initialize a git repo in the output path at migration start.
- Add `commitForAgent()` to create commits after successful code-modifying agent invocations (code-migrator, test-writer, e2e-test-crafter, documentation-writer, idiomatic-refactorer).
- Add `commitForTask()` to create a task-level commit after each completed Phase 4 task.
- Add `commitIfDirty()` helper that stages changes, checks for dirty state, and commits (with optional `--allow-empty` for task markers).
- Add `runGit()` helper that spawns git subprocesses in the output directory with resolved PATH.
- When git automation is enabled, Phase 4 runs tasks sequentially and Phase 6 agents run serially to maintain deterministic commit order.
- Add `isGitAutomationEnabled()` and `isTransientModelFailure()` helpers.
- Extend infrastructure error patterns with HTTP/2 GOAWAY and 503 detection.

### Agent Launcher (`runtime/src/core/agent-launcher.ts`)
- Expose `getResolvedPath()` so the orchestrator can pass the correct PATH to git subprocesses.
- Support `modelOverride` on invocations for fallback model retry.

### Tests
- **`runtime/tests/config-schema.test.ts`**: Add tests for git config defaults and overrides.
- **`runtime/tests/orchestrator.test.ts`**: Add integration test verifying auto-init, per-agent commits, and per-task commits with readable messages. Fix duplicate imports. Add `lineRange` to all test task fixtures.
- **`runtime/tests/context-builder.test.ts`**: Add tests for test-writer output path routing and parity report inclusion.
- **`runtime/tests/agent-launcher.test.ts`**: Add test for `getResolvedPath()` exposure.
- **`runtime/tests/retry-executor.test.ts`**: Add test for transient model failure retry.

### Other
- Add `failureRecoveryModel` option to both `copilot` and `claudeCode` config sections.
- Make `lineRange` required in the task file schema (was optional).
- Update agent instruction files with git commit context.

## Testing

All existing and new tests pass (`npx vitest run`). The build (`npm run build`) completes without errors. The new orchestrator integration test verifies end-to-end git auto-init, per-agent commit creation, and per-task commit messages.

Closes #39