### PR TITLE
Add Copilot CLI usage summary parser (#42)

### DIFF
--- a/runtime/src/agents/result-parser.ts
+++ b/runtime/src/agents/result-parser.ts
@@ -420,6 +420,68 @@ export class ResultParser {
   }
 
   /**
+   * Parse a numeric value that may use shorthand suffixes (e.g. `41.3k` → 41300).
+   */
+  private static parseShorthandNumber(value: string): number {
+    const match = value.trim().match(/^([\d.]+)\s*([kmKM])?$/);
+    if (!match) return NaN;
+    const num = parseFloat(match[1]!);
+    const suffix = match[2]?.toLowerCase();
+    if (suffix === 'k') return Math.round(num * 1000);
+    if (suffix === 'm') return Math.round(num * 1000000);
+    return Math.round(num);
+  }
+
+  /**
+   * Parse token usage from Copilot CLI headless usage summary format.
+   *
+   * Extracts per-model `tokens_in`, `tokens_out`, and `tokens_cached` from
+   * the `Breakdown by AI model:` section, sums them across models, and
+   * returns the standard token usage shape. Supports numeric shorthand
+   * suffixes (e.g. `41.3k` → 41300, `2.5m` → 2500000) and both singular
+   * and plural `Premium request(s)` variants.
+   *
+   * @param output - Raw agent output text (stdout or stderr).
+   * @returns Parsed token counts, or `undefined` if no Copilot CLI usage block is found.
+   */
+  static parseCopilotCliUsage(
+    output: string,
+  ): { prompt: number; completion: number; total: number; cachedInput?: number } | undefined {
+    const breakdownMatch = output.match(/Breakdown by AI model:/i);
+    if (!breakdownMatch) return undefined;
+
+    const afterBreakdown = output.slice(breakdownMatch.index! + breakdownMatch[0].length);
+
+    const tokenLineRegex = /tokens_in:\s*([\d.]+[kmKM]?)\s*,\s*tokens_out:\s*([\d.]+[kmKM]?)(?:\s*,\s*tokens_cached:\s*([\d.]+[kmKM]?))?/g;
+
+    let totalPrompt = 0;
+    let totalCompletion = 0;
+    let totalCached = 0;
+    let hasCached = false;
+    let foundAny = false;
+
+    let lineMatch: RegExpExecArray | null;
+    while ((lineMatch = tokenLineRegex.exec(afterBreakdown)) !== null) {
+      foundAny = true;
+      totalPrompt += ResultParser.parseShorthandNumber(lineMatch[1]!);
+      totalCompletion += ResultParser.parseShorthandNumber(lineMatch[2]!);
+      if (lineMatch[3]) {
+        totalCached += ResultParser.parseShorthandNumber(lineMatch[3]);
+        hasCached = true;
+      }
+    }
+
+    if (!foundAny) return undefined;
+
+    return {
+      prompt: totalPrompt,
+      completion: totalCompletion,
+      total: totalPrompt + totalCompletion,
+      ...(hasCached && { cachedInput: totalCached }),
+    };
+  }
+
+  /**
    * Parse token usage from agent stdout/stderr output.
    *
    * Recognises formats such as `prompt_tokens: 1234`, `completion-tokens: 567`,
@@ -428,14 +490,15 @@ export class ResultParser {
    * {@link CostEstimator.estimateFromTotal}).
    *
    * When `runtime` is `'claude-code'`, delegates to {@link parseClaudeTokenUsage}
-   * to handle Claude's JSON-based usage format instead.
+   * to handle Claude's JSON-based usage format instead. When `runtime` is
+   * `'copilot-cli'`, delegates to {@link parseCopilotCliUsage}.
    *
    * **Note:** Regex-based token extraction from free-form text is unreliable.
    * Agents should emit structured token data inside their `aamf-json` block
    * under the `tokenUsage` field for accurate accounting.
    *
    * @param output - Raw agent output text.
-   * @param runtime - Optional runtime identifier; pass `'claude-code'` to parse Claude JSON format.
+   * @param runtime - Optional runtime identifier; pass `'claude-code'` or `'copilot-cli'` for specialised parsers.
    * @returns Parsed token counts, or `undefined` if no usage data is found.
    */
   static parseTokenUsage(
@@ -444,6 +507,9 @@ export class ResultParser {
   ): { prompt: number; completion: number; total: number } | undefined {
     if (runtime === 'claude-code') {
       return ResultParser.parseClaudeTokenUsage(output);
+    }
+    if (runtime === 'copilot-cli') {
+      return ResultParser.parseCopilotCliUsage(output);
     }
 
     const promptMatch = output.match(/prompt[\s_-]*tokens?:?\s*(\d+)/i);

--- a/runtime/src/core/agent-launcher.ts
+++ b/runtime/src/core/agent-launcher.ts
@@ -337,7 +337,7 @@ export class CopilotRunner implements AgentRunner {
       await writeAgentLog(this.logDir, invocation.agent, taskId, result.stdout, result.stderr, invocationId);
 
       const outputFiles = await detectOutputFiles(invocation);
-      const tokenUsage = ResultParser.parseTokenUsage(result.stdout + '\n' + result.stderr);
+      const tokenUsage = ResultParser.parseTokenUsage(result.stdout + '\n' + result.stderr, 'copilot-cli');
 
       const agentResult: AgentResult = {
         agent: invocation.agent,

--- a/runtime/tests/agent-launcher.test.ts
+++ b/runtime/tests/agent-launcher.test.ts
@@ -275,9 +275,9 @@ describe('AgentLauncher', () => {
 
   it('should parse token usage from stdout', async () => {
     const script = await createScript('tokens.sh', [
-      'echo "prompt_tokens: 100"',
-      'echo "completion_tokens: 50"',
-      'echo "total_tokens: 150"',
+      'echo "Breakdown by AI model:"',
+      'echo "  claude-sonnet-4-20250514:"',
+      'echo "    tokens_in: 100, tokens_out: 50, premium_requests_est: 1"',
       'exit 0',
     ].join('\n'));
     const launcher = makeLauncher(script);

--- a/runtime/tests/result-parser.test.ts
+++ b/runtime/tests/result-parser.test.ts
@@ -639,6 +639,167 @@ intermediate text
     });
   });
 
+  describe('parseCopilotCliUsage', () => {
+    it('should parse a single-model breakdown with tokens_in, tokens_out, tokens_cached', () => {
+      const output = `Total usage est:
+  1 Premium request
+
+Breakdown by AI model:
+  claude-sonnet-4-20250514:
+    tokens_in: 5000, tokens_out: 1200, tokens_cached: 800, premium_requests_est: 1
+`;
+      const usage = ResultParser.parseCopilotCliUsage(output);
+      expect(usage).toEqual({ prompt: 5000, completion: 1200, total: 6200, cachedInput: 800 });
+    });
+
+    it('should sum across multiple models', () => {
+      const output = `Total usage est:
+  3 Premium requests
+
+Breakdown by AI model:
+  claude-sonnet-4-20250514:
+    tokens_in: 4000, tokens_out: 1000, tokens_cached: 500, premium_requests_est: 2
+  gpt-4o:
+    tokens_in: 2000, tokens_out: 600, premium_requests_est: 1
+`;
+      const usage = ResultParser.parseCopilotCliUsage(output);
+      expect(usage).toEqual({ prompt: 6000, completion: 1600, total: 7600, cachedInput: 500 });
+    });
+
+    it('should parse numeric shorthand suffixes (k)', () => {
+      const output = `Breakdown by AI model:
+  claude-sonnet-4-20250514:
+    tokens_in: 41.3k, tokens_out: 2.1k, tokens_cached: 13.1k, premium_requests_est: 2
+`;
+      const usage = ResultParser.parseCopilotCliUsage(output);
+      expect(usage).toEqual({ prompt: 41300, completion: 2100, total: 43400, cachedInput: 13100 });
+    });
+
+    it('should parse numeric shorthand suffixes (m)', () => {
+      const output = `Breakdown by AI model:
+  large-model:
+    tokens_in: 2.5m, tokens_out: 0.5m, tokens_cached: 1m, premium_requests_est: 10
+`;
+      const usage = ResultParser.parseCopilotCliUsage(output);
+      expect(usage).toEqual({ prompt: 2500000, completion: 500000, total: 3000000, cachedInput: 1000000 });
+    });
+
+    it('should handle singular "Premium request"', () => {
+      const output = `Total usage est:
+  1 Premium request
+
+Breakdown by AI model:
+  gpt-4o:
+    tokens_in: 3000, tokens_out: 500, premium_requests_est: 1
+`;
+      const usage = ResultParser.parseCopilotCliUsage(output);
+      expect(usage).toEqual({ prompt: 3000, completion: 500, total: 3500 });
+    });
+
+    it('should handle plural "Premium requests"', () => {
+      const output = `Total usage est:
+  5 Premium requests
+
+Breakdown by AI model:
+  gpt-4o:
+    tokens_in: 10000, tokens_out: 2000, tokens_cached: 500, premium_requests_est: 5
+`;
+      const usage = ResultParser.parseCopilotCliUsage(output);
+      expect(usage).toEqual({ prompt: 10000, completion: 2000, total: 12000, cachedInput: 500 });
+    });
+
+    it('should return undefined for cachedInput when tokens_cached is absent', () => {
+      const output = `Breakdown by AI model:
+  gpt-4o:
+    tokens_in: 2000, tokens_out: 800, premium_requests_est: 1
+`;
+      const usage = ResultParser.parseCopilotCliUsage(output);
+      expect(usage).toBeDefined();
+      expect(usage?.prompt).toBe(2000);
+      expect(usage?.completion).toBe(800);
+      expect(usage?.total).toBe(2800);
+      expect(usage?.cachedInput).toBeUndefined();
+    });
+
+    it('should return undefined when output has no Copilot CLI usage block', () => {
+      const output = 'Some random agent output\nprompt_tokens: 100\ncompletion_tokens: 50';
+      const usage = ResultParser.parseCopilotCliUsage(output);
+      expect(usage).toBeUndefined();
+    });
+
+    it('should return undefined when breakdown header exists but no token lines follow', () => {
+      const output = `Breakdown by AI model:\n  (no models used)\n`;
+      const usage = ResultParser.parseCopilotCliUsage(output);
+      expect(usage).toBeUndefined();
+    });
+
+    it('should handle minor spacing variations', () => {
+      const output = `Breakdown by AI model:
+  model-a:
+    tokens_in:41.3k,tokens_out:2.1k,tokens_cached:13.1k,premium_requests_est:2
+`;
+      const usage = ResultParser.parseCopilotCliUsage(output);
+      expect(usage).toEqual({ prompt: 41300, completion: 2100, total: 43400, cachedInput: 13100 });
+    });
+
+    it('should be case-insensitive for the breakdown header', () => {
+      const output = `breakdown by ai model:
+  gpt-4o:
+    tokens_in: 1000, tokens_out: 200, premium_requests_est: 1
+`;
+      const usage = ResultParser.parseCopilotCliUsage(output);
+      expect(usage).toEqual({ prompt: 1000, completion: 200, total: 1200 });
+    });
+
+    it('should sum mixed shorthand and plain numbers across models', () => {
+      const output = `Breakdown by AI model:
+  model-a:
+    tokens_in: 1.5k, tokens_out: 300, tokens_cached: 200, premium_requests_est: 1
+  model-b:
+    tokens_in: 2000, tokens_out: 0.5k, premium_requests_est: 1
+`;
+      const usage = ResultParser.parseCopilotCliUsage(output);
+      expect(usage).toEqual({ prompt: 3500, completion: 800, total: 4300, cachedInput: 200 });
+    });
+
+    it('should return undefined for empty string input', () => {
+      const usage = ResultParser.parseCopilotCliUsage('');
+      expect(usage).toBeUndefined();
+    });
+  });
+
+  describe('parseTokenUsage (copilot-cli dispatch)', () => {
+    it('should route to parseCopilotCliUsage when runtime is copilot-cli', () => {
+      const output = `Breakdown by AI model:
+  gpt-4o:
+    tokens_in: 3000, tokens_out: 500, premium_requests_est: 1
+`;
+      const usage = ResultParser.parseTokenUsage(output, 'copilot-cli');
+      expect(usage).toEqual({ prompt: 3000, completion: 500, total: 3500 });
+    });
+
+    it('should return undefined via copilot-cli dispatch when no usage block', () => {
+      const usage = ResultParser.parseTokenUsage('no copilot cli output here', 'copilot-cli');
+      expect(usage).toBeUndefined();
+    });
+
+    it('should preserve cachedInput through copilot-cli dispatch', () => {
+      const output = `Breakdown by AI model:
+  claude-sonnet-4-20250514:
+    tokens_in: 5000, tokens_out: 1200, tokens_cached: 800, premium_requests_est: 1
+`;
+      const usage = ResultParser.parseTokenUsage(output, 'copilot-cli') as { prompt: number; completion: number; total: number; cachedInput?: number };
+      expect(usage).toBeDefined();
+      expect(usage.cachedInput).toBe(800);
+    });
+
+    it('should not fall through to regex path when runtime is copilot-cli', () => {
+      const output = 'prompt_tokens: 999\ncompletion_tokens: 111\nBreakdown by AI model:\n  m:\n    tokens_in: 100, tokens_out: 50, premium_requests_est: 1';
+      const usage = ResultParser.parseTokenUsage(output, 'copilot-cli');
+      expect(usage).toEqual({ prompt: 100, completion: 50, total: 150 });
+    });
+  });
+
   describe('parseIdiomaticReport', () => {
     it('should return an empty array for a non-existent file', async () => {
       const entries = await ResultParser.parseIdiomaticReport('/nonexistent/path/report.md');


### PR DESCRIPTION
## Summary

Add a `parseCopilotCliUsage` method to `ResultParser` that extracts token usage from the Copilot CLI headless usage summary format and integrates it into the existing token tracking pipeline. Closes #42

## Changes

### Parser (`runtime/src/agents/result-parser.ts`)
- Add `parseShorthandNumber` private helper to convert shorthand suffixes (`41.3k` → 41300, `2.5m` → 2500000)
- Add `parseCopilotCliUsage` static method that extracts `tokens_in`, `tokens_out`, and `tokens_cached` from the `Breakdown by AI model:` section, sums across models, and returns the standard `{ prompt, completion, total, cachedInput? }` shape
- Add `'copilot-cli'` branch to `parseTokenUsage` dispatch alongside existing `'claude-code'` branch

### Wiring (`runtime/src/core/agent-launcher.ts`)
- Update `CopilotRunner.run()` to pass `'copilot-cli'` as the runtime argument to `parseTokenUsage`

### Tests (`runtime/tests/result-parser.test.ts`)
- Add `parseCopilotCliUsage` describe block with 12 tests covering:
  - Single-model and multi-model breakdowns
  - Numeric shorthand suffixes (`k`, `m`)
  - Singular/plural `Premium request(s)`
  - Missing `tokens_cached` field
  - Minor spacing variations and case-insensitive header matching
  - Empty and non-matching input
- Add `parseTokenUsage (copilot-cli dispatch)` describe block with 4 tests verifying dispatch routing

## Testing

All existing and new tests pass (`npx vitest run`). Build succeeds (`npm run build`). No regressions detected.

Closes #42