### PR TITLE
Clear blockedTasks on task success (#52)

### DIFF
--- a/runtime/src/core/checkpoint.ts
+++ b/runtime/src/core/checkpoint.ts
@@ -165,6 +165,8 @@ export class CheckpointManager {
     state.currentTask = null;
     // Remove from failed if it was there
     state.failedTasks = state.failedTasks.filter(f => f.taskId !== taskId);
+    // Remove from blocked if it was there
+    state.blockedTasks = state.blockedTasks.filter(id => id !== taskId);
     await this.save(state);
   }
 

--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -395,6 +395,20 @@ export class MigrationOrchestrator {
     finalState.cumulativeDurationMs = cumulativeDurationMs;
     await this.checkpoint.save(finalState);
 
+    // Invariant: completed tasks must not appear in failed or blocked lists.
+    // Filter out stale entries that survived prior checkpoint writes.
+    const completedSet = new Set(finalState.completedTasks);
+    const filteredFailed = finalState.failedTasks.filter((f) => !completedSet.has(f.taskId));
+    const filteredBlocked = finalState.blockedTasks.filter((id) => !completedSet.has(id));
+    const staleCount =
+      (finalState.failedTasks.length - filteredFailed.length) +
+      (finalState.blockedTasks.length - filteredBlocked.length);
+    if (staleCount > 0) {
+      this.logger.warn(
+        `Removed ${staleCount} stale entries from failedTasks/blockedTasks that were already in completedTasks`,
+      );
+    }
+
     const migrationResult: MigrationResult = {
       success: !aborted && phaseResults.every((r) => r.success),
       projectName: this.config.projectName,
@@ -402,8 +416,8 @@ export class MigrationOrchestrator {
       totalDuration,
       cumulativeDuration: cumulativeDurationMs,
       tokenUsage: this.tokenTracker.toCheckpointData(),
-      failedTasks: finalState.failedTasks.map((f) => f.taskId),
-      blockedTasks: finalState.blockedTasks,
+      failedTasks: filteredFailed.map((f) => f.taskId),
+      blockedTasks: filteredBlocked,
     };
 
     this.logger.event({

--- a/runtime/tests/checkpoint.test.ts
+++ b/runtime/tests/checkpoint.test.ts
@@ -215,6 +215,49 @@ describe('CheckpointManager', () => {
     expect(data).toBeDefined();
   });
 
+  it('should remove task from blocked when completed', async () => {
+    await manager.load('test-project');
+    await manager.blockTask('task-001');
+    await manager.completeTask('task-001');
+
+    const state = manager.getState();
+    expect(state.blockedTasks).not.toContain('task-001');
+    expect(state.completedTasks).toContain('task-001');
+  });
+
+  it('should remove task from both failed and blocked when completed', async () => {
+    await manager.load('test-project');
+    await manager.failTask('task-001', 'some error', 1, false);
+    await manager.blockTask('task-001');
+    await manager.completeTask('task-001');
+
+    const state = manager.getState();
+    expect(state.failedTasks).toHaveLength(0);
+    expect(state.blockedTasks).not.toContain('task-001');
+    expect(state.completedTasks).toContain('task-001');
+  });
+
+  it('should not affect other blocked tasks when completing one', async () => {
+    await manager.load('test-project');
+    await manager.blockTask('task-001');
+    await manager.blockTask('task-002');
+    await manager.completeTask('task-001');
+
+    const state = manager.getState();
+    expect(state.blockedTasks).not.toContain('task-001');
+    expect(state.blockedTasks).toContain('task-002');
+    expect(state.completedTasks).toContain('task-001');
+  });
+
+  it('should handle completing a task that was never blocked', async () => {
+    await manager.load('test-project');
+    await manager.completeTask('task-001');
+
+    const state = manager.getState();
+    expect(state.blockedTasks).toHaveLength(0);
+    expect(state.completedTasks).toContain('task-001');
+  });
+
   // ─── metricsCount ─────────────────────────────────────────────────
 
   it('should initialize metricsCount to 0 on fresh state', async () => {

--- a/runtime/tests/orchestrator.test.ts
+++ b/runtime/tests/orchestrator.test.ts
@@ -3212,6 +3212,95 @@ describe('MigrationOrchestrator', () => {
     });
   });
 
+  // ─── Invariant: completed tasks excluded from failed/blocked ────────
+
+  describe('Completed-task invariant filtering', () => {
+    it('should exclude completed tasks from failedTasks and blockedTasks in the result', async () => {
+      const launcherFn = createMockLauncher();
+      const { orchestrator, checkpoint, progressDir } = await setupOrchestrator(tempDir, launcherFn);
+      await writeMigrationPlan(progressDir);
+
+      // Pre-populate checkpoint so task-001 is completed but also stale in blocked/failed
+      const state = checkpoint.getState();
+      state.completedTasks.push('task-001');
+      state.blockedTasks.push('task-001');
+      state.failedTasks.push({
+        taskId: 'task-001',
+        attempts: 2,
+        lastError: 'stale error',
+        recoveryAttempted: false,
+      });
+      await checkpoint.save(state);
+
+      const result = await orchestrator.run();
+
+      expect(result.failedTasks).not.toContain('task-001');
+      expect(result.blockedTasks).not.toContain('task-001');
+      // task-001 should still be completed
+      expect(checkpoint.getState().completedTasks).toContain('task-001');
+    });
+
+    it('should exclude completed task from failedTasks only when not in blockedTasks', async () => {
+      const launcherFn = createMockLauncher();
+      const { orchestrator, checkpoint, progressDir } = await setupOrchestrator(tempDir, launcherFn);
+      await writeMigrationPlan(progressDir);
+
+      const state = checkpoint.getState();
+      state.completedTasks.push('task-001');
+      state.failedTasks.push({
+        taskId: 'task-001',
+        attempts: 1,
+        lastError: 'stale',
+        recoveryAttempted: false,
+      });
+      await checkpoint.save(state);
+
+      const result = await orchestrator.run();
+
+      expect(result.failedTasks).not.toContain('task-001');
+      expect(result.blockedTasks).not.toContain('task-001');
+    });
+
+    it('should exclude completed task from blockedTasks only when not in failedTasks', async () => {
+      const launcherFn = createMockLauncher();
+      const { orchestrator, checkpoint, progressDir } = await setupOrchestrator(tempDir, launcherFn);
+      await writeMigrationPlan(progressDir);
+
+      const state = checkpoint.getState();
+      state.completedTasks.push('task-001');
+      state.blockedTasks.push('task-001');
+      await checkpoint.save(state);
+
+      const result = await orchestrator.run();
+
+      expect(result.blockedTasks).not.toContain('task-001');
+      expect(result.failedTasks).not.toContain('task-001');
+    });
+
+    it('should preserve non-completed tasks in failedTasks and blockedTasks', async () => {
+      const launcherFn = createMockLauncher();
+      const { orchestrator, checkpoint, progressDir } = await setupOrchestrator(tempDir, launcherFn);
+      await writeMigrationPlan(progressDir);
+
+      // Use task IDs outside the migration plan so the orchestrator doesn't complete them
+      const state = checkpoint.getState();
+      state.completedTasks.push('task-001');
+      state.blockedTasks.push('task-001', 'orphan-blocked');
+      state.failedTasks.push(
+        { taskId: 'task-001', attempts: 2, lastError: 'stale', recoveryAttempted: false },
+        { taskId: 'orphan-failed', attempts: 1, lastError: 'real error', recoveryAttempted: false },
+      );
+      await checkpoint.save(state);
+
+      const result = await orchestrator.run();
+
+      expect(result.failedTasks).not.toContain('task-001');
+      expect(result.blockedTasks).not.toContain('task-001');
+      expect(result.blockedTasks).toContain('orphan-blocked');
+      expect(result.failedTasks).toContain('orphan-failed');
+    });
+  });
+
   // ─── Git Automation ───────────────────────────────────────────────────
 
   describe('Git Automation', () => {


### PR DESCRIPTION
## Summary

Fix stale `blockedTasks` state persisting after a previously-blocked task completes successfully. On task completion, `blockedTasks` is now cleared alongside `failedTasks`, and an invariant filter in the orchestrator's result assembly ensures completed tasks never appear in failed/blocked lists. Closes #52

## Changes

- **`runtime/src/core/checkpoint.ts`** — In `completeTask()`, filter the completed task out of `state.blockedTasks` (mirroring the existing `failedTasks` cleanup) before persisting.
- **`runtime/src/core/orchestrator.ts`** — Add invariant filtering before `MigrationResult` construction: build a `completedSet`, remove any stale entries from `failedTasks`/`blockedTasks`, and log a warning when stale entries are detected.
- **`runtime/tests/checkpoint.test.ts`** — Add four tests covering blocked→complete, failed+blocked→complete, multi-task isolation, and completing a never-blocked task.
- **`runtime/tests/orchestrator.test.ts`** — Add four tests under a new `Completed-task invariant filtering` suite verifying stale entries are excluded from the result while non-completed entries are preserved.

## Testing

All existing and new tests pass (`npx vitest run`). Build succeeds with no errors (`npm run build`). No regressions detected.

Closes #52