### PR TITLE
Runtime: normalize .aamf log/output artifact directory structure

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -154,7 +154,7 @@ In `wave-barrier` mode, each cycle is:
 3. **Fix wave (if needed)** — rerun targeted migration tasks for failed validation and repeat validation until convergence or `options.waveControl.maxConvergenceIterations` is reached.
 
 Blocked-task policy (`continueOnBlocked`, `maxBlockedTasks`) is still enforced in wave mode, but evaluated after each wave.
-Wave lifecycle and convergence are observable in `.aamf/migration/{projectName}/progress.md` (**Wave Lifecycle** table) and in observability outputs under `metrics/summary.json` and `reports/observability/report.md`.
+Wave lifecycle and convergence are observable in `.aamf/migration/{projectName}/reports/progress.md` (**Wave Lifecycle** table) and in observability outputs under `metrics/summary.json` and `reports/observability/index.md`.
 
 When migration/parity retries are exhausted, Phase 4 invokes `failure-adjudicator` and applies decision outcomes:
 
@@ -202,10 +202,11 @@ runtime/src/
 
 The runtime writes several artifacts to track migration progress:
 
-- **`progress.md`** — Human-readable progress report, updated after each phase. Located at `.aamf/migration/{projectName}/progress.md`.
-- **`checkpoint.json`** — Machine-readable snapshot of migration state, enabling `--resume`. Located alongside `progress.md`.
-- **Per-agent logs** — Each agent invocation writes stdout/stderr to the `logs/` directory with timestamped filenames.
-- **`migration.log`** — Unified log of all runtime events (phase transitions, task completions, errors, timing).
+- **`reports/progress.md`** — Human-readable progress report, updated after each phase.
+- **`state/checkpoint.json`** — Machine-readable snapshot of migration state, enabling `--resume` (with `state/checkpoint.backup.json` backup).
+- **Per-agent logs** — Each agent invocation writes stdout/stderr to `logs/agents/{agent}/{taskId}/...`.
+- **Command logs** — Build/test command output is written to `logs/commands/{build|test}/...`.
+- **`logs/runtime/migration.log`** — Unified log of all runtime events (phase transitions, task completions, errors, timing).
 
 ## Artifact Retention
 
@@ -244,10 +245,10 @@ In addition to their markdown output, agents can (and should) write a structured
 ### Sidecar Location
 
 ```
-{progressDir}/results/{agent}-{taskId}.result.json
+{progressDir}/artifacts/results/{agent}-{taskId}.result.json
 ```
 
-For example: `.aamf/migration/my-project/results/code-migrator-task-001.result.json`
+For example: `.aamf/migration/my-project/artifacts/results/code-migrator-task-001.result.json`
 
 ### JSON Schema
 

--- a/runtime/src/agents/context-builder.ts
+++ b/runtime/src/agents/context-builder.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { AgentName, AgentContext } from './types.js';
 import { MigrationConfig } from '../config/schema.js';
 import { writeJson, ensureDir } from '../util/fs.js';
+import { buildLegacyRuntimePaths } from '../core/runtime-paths.js';
 
 const TASK_DECOMPOSER_SCHEMA_PATH = fileURLToPath(
   new URL('./task-decomposer.tasks.schema.json', import.meta.url),
@@ -26,8 +27,11 @@ export interface ContextBuildOptions {
  * set of input files, an output path, and an optional payload.
  */
 export class ContextBuilder {
+  private readonly legacyPaths: ReturnType<typeof buildLegacyRuntimePaths>;
 
-  constructor(private config: MigrationConfig, private progressDir: string) {}
+  constructor(private config: MigrationConfig, private progressDir: string) {
+    this.legacyPaths = buildLegacyRuntimePaths(progressDir);
+  }
 
   /**
    * Build and write the context file for a given agent invocation.
@@ -46,7 +50,7 @@ export class ContextBuilder {
     const context = this.createContext(agent, phase, taskId, payload);
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
     const filename = `${agent}-${taskId ?? 'main'}-${timestamp}.json`;
-    const contextDir = join(this.progressDir, 'contexts');
+    const contextDir = join(this.progressDir, 'artifacts', 'contexts');
     await ensureDir(contextDir);
     const contextPath = join(contextDir, filename);
     await writeJson(contextPath, context);
@@ -136,9 +140,9 @@ export class ContextBuilder {
     taskId?: string,
     payload?: Record<string, unknown>,
   ): { inputFiles: string[]; outputPath: string; agentPayload?: Record<string, unknown> } {
-    const kbDir = join(this.progressDir, 'knowledge-base');
-    const impactAssessment = join(this.progressDir, 'impact-assessment.md');
-    const migrationPlan = join(this.progressDir, 'migration-plan.md');
+    const kbDir = this.legacyPaths.knowledgeBaseDir;
+    const impactAssessment = this.legacyPaths.impactAssessmentFile;
+    const migrationPlan = this.legacyPaths.migrationPlanFile;
     const src = this.config.source.path;
     const out = this.config.target.outputPath;
     const remediationContext = this.getRemediationContext(payload);
@@ -156,17 +160,17 @@ export class ContextBuilder {
       case 'migration-planner':
         return {
           inputFiles: [join(kbDir, 'index.md'), impactAssessment],
-          outputPath: join(this.progressDir, 'planning'),
+          outputPath: join(this.progressDir, 'artifacts', 'planning'),
         };
 
       case 'task-decomposer': {
-        const strategyFile = String(payload?.strategyFile ?? join(this.progressDir, 'planning', 'strategy.md'));
+        const strategyFile = String(payload?.strategyFile ?? join(this.progressDir, 'artifacts', 'planning', 'strategy.md'));
         const analysisFiles = Array.isArray(payload?.analysisFiles)
           ? (payload.analysisFiles as string[])
           : [];
         return {
           inputFiles: [TASK_DECOMPOSER_SCHEMA_PATH, strategyFile, ...analysisFiles],
-          outputPath: join(this.progressDir, 'planning', `tasks-${taskId ?? 'unknown'}.json`),
+          outputPath: join(this.progressDir, 'artifacts', 'planning', `tasks-${taskId ?? 'unknown'}.json`),
           agentPayload: {
             groupId: payload?.groupId,
             groupName: payload?.groupName,
@@ -181,7 +185,7 @@ export class ContextBuilder {
           inputFiles: payload?.competingStrategiesFile
             ? [String(payload.competingStrategiesFile)]
             : [],
-          outputPath: join(this.progressDir, 'adjudication-result.md'),
+          outputPath: join(this.progressDir, 'artifacts', 'adjudication', 'adjudication-result.md'),
           agentPayload: { decisionType: payload?.decisionType ?? 'migration-strategy' },
         };
 
@@ -207,7 +211,7 @@ export class ContextBuilder {
             ...(payload?.targetFile ? [String(payload.targetFile)] : []),
             ...(payload?.taskPlanSlice ? [String(payload.taskPlanSlice)] : [migrationPlan]),
           ],
-          outputPath: join(this.progressDir, 'parity-reports', `${taskId ?? 'main'}.md`),
+          outputPath: join(this.progressDir, 'artifacts', 'parity', `${taskId ?? 'main'}.md`),
           agentPayload: { taskId },
         };
 
@@ -230,7 +234,7 @@ export class ContextBuilder {
             ...(payload?.targetFile ? [String(payload.targetFile)] : []),
             ...(payload?.kbEntry ? [String(payload.kbEntry)] : []),
           ],
-          outputPath: join(this.progressDir, 'adjudication', `${taskId ?? 'main'}.md`),
+          outputPath: join(this.progressDir, 'artifacts', 'adjudication', `${taskId ?? 'main'}.md`),
           agentPayload: {
             taskId,
             attemptNumber: payload?.attemptNumber ?? 1,
@@ -241,7 +245,7 @@ export class ContextBuilder {
       case 'final-parity-checker':
         return {
           inputFiles: [src, out, migrationPlan],
-          outputPath: join(this.progressDir, 'final-parity-report.md'),
+          outputPath: join(this.progressDir, 'artifacts', 'parity', 'final-parity-report.md'),
         };
 
       case 'e2e-test-crafter':
@@ -256,14 +260,14 @@ export class ContextBuilder {
 
       case 'documentation-writer':
         return {
-          inputFiles: [kbDir, migrationPlan, join(this.progressDir, 'final-parity-report.md')],
+          inputFiles: [kbDir, migrationPlan, join(this.progressDir, 'artifacts', 'parity', 'final-parity-report.md')],
           outputPath: join(out, 'docs'),
         };
 
       case 'idiomatic-reviewer':
         return {
           inputFiles: [out],
-          outputPath: join(this.progressDir, 'idiomatic-review-report.md'),
+          outputPath: join(this.progressDir, 'artifacts', 'parity', 'idiomatic-review-report.md'),
         };
 
       case 'idiomatic-refactorer':

--- a/runtime/src/agents/result-parser.ts
+++ b/runtime/src/agents/result-parser.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { z } from 'zod';
 import { MigrationTask } from './types.js';
 import { fileExists, readJson } from '../util/fs.js';
+import { buildLegacyRuntimePaths } from '../core/runtime-paths.js';
 
 export const MISSING_BLOCK_ERROR = 'missing aamf-json block';
 
@@ -242,8 +243,12 @@ export class ResultParser {
     agent: string,
     taskId: string,
   ): Promise<TaskResult | undefined> {
-    const sidecarPath = join(progressDir, 'results', `${agent}-${taskId}.result.json`);
-    if (!(await fileExists(sidecarPath))) return undefined;
+    const normalizedPath = join(progressDir, 'artifacts', 'results', `${agent}-${taskId}.result.json`);
+    const legacyPath = join(buildLegacyRuntimePaths(progressDir).resultsDir, `${agent}-${taskId}.result.json`);
+    const sidecarPath = await fileExists(normalizedPath)
+      ? normalizedPath
+      : (await fileExists(legacyPath) ? legacyPath : undefined);
+    if (!sidecarPath) return undefined;
     try {
       const raw = await readJson<unknown>(sidecarPath);
       return TaskResultSchema.parse(raw);

--- a/runtime/src/core/agent-launcher.ts
+++ b/runtime/src/core/agent-launcher.ts
@@ -28,6 +28,7 @@ import {
 import { Logger } from '../logging/logger.js';
 import { TokenTracker } from '../budget/token-tracker.js';
 import { z } from 'zod';
+import { buildRuntimePaths } from './runtime-paths.js';
 
 /** Map each known agent name to its Zod output schema. */
 const agentOutputSchemas: Record<AgentName, z.ZodTypeAny> = {
@@ -84,13 +85,12 @@ function stripVSCodeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
 
 /** Shared helper: write stdout/stderr to a per-agent log file. */
 async function writeAgentLog(logDir: string, agent: string, taskId: string, stdout: string, stderr: string, invocationId?: string): Promise<void> {
-  await ensureDir(logDir);
+  const targetDir = join(logDir, agent, taskId);
+  await ensureDir(targetDir);
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-  const filename = invocationId
-    ? `${agent}-${taskId}-${invocationId}-${timestamp}.log`
-    : `${agent}-${taskId}-${timestamp}.log`;
+  const filename = invocationId ? `${invocationId}-${timestamp}.log` : `${timestamp}.log`;
   const content = `=== STDOUT ===\n${stdout}\n\n=== STDERR ===\n${stderr}\n`;
-  await atomicWrite(join(logDir, filename), content);
+  await atomicWrite(join(targetDir, filename), content);
 }
 
 /** Shared helper: detect output files created by the agent in the progress directory. */
@@ -208,7 +208,7 @@ export class CopilotRunner implements AgentRunner {
     private readonly projectRoot: string,
     private readonly logger: Logger,
   ) {
-    this.logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
+    this.logDir = buildRuntimePaths(projectRoot, config.projectName).logsAgentsDir;
   }
 
   getResolvedPath(): string | undefined {
@@ -405,7 +405,7 @@ export class ClaudeCodeRunner implements AgentRunner {
     private readonly projectRoot: string,
     private readonly logger: Logger,
   ) {
-    this.logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
+    this.logDir = buildRuntimePaths(projectRoot, config.projectName).logsAgentsDir;
   }
 
   getResolvedPath(): string | undefined {

--- a/runtime/src/core/checkpoint.ts
+++ b/runtime/src/core/checkpoint.ts
@@ -1,8 +1,8 @@
-import { join } from 'node:path';
 import { readFile } from 'node:fs/promises';
 import { atomicWrite, ensureDir, fileExists, readJson, writeJson } from '../util/fs.js';
 import { Logger } from '../logging/logger.js';
 import type { TerminalReasonCode } from '../agents/types.js';
+import { buildLegacyRuntimePaths } from './runtime-paths.js';
 
 export interface TerminalExhaustionState {
   reasonCode: TerminalReasonCode;
@@ -113,22 +113,27 @@ export interface AdjudicationEventRecord {
 }
 
 const CHECKPOINT_VERSION = 1;
-const CHECKPOINT_FILE = 'checkpoint.json';
-const CHECKPOINT_BACKUP = 'checkpoint.backup.json';
 
 export class CheckpointManager {
   private state: CheckpointState | null = null;
   private readonly checkpointPath: string;
   private readonly backupPath: string;
+  private readonly legacyCheckpointPath: string;
+  private readonly legacyBackupPath: string;
+  private readonly stateDir: string;
 
   constructor(private readonly progressDir: string, private readonly logger: Logger) {
-    this.checkpointPath = join(progressDir, CHECKPOINT_FILE);
-    this.backupPath = join(progressDir, CHECKPOINT_BACKUP);
+    this.stateDir = `${progressDir}/state`;
+    const legacyPaths = buildLegacyRuntimePaths(progressDir);
+    this.checkpointPath = `${this.stateDir}/checkpoint.json`;
+    this.backupPath = `${this.stateDir}/checkpoint.backup.json`;
+    this.legacyCheckpointPath = legacyPaths.checkpointFile;
+    this.legacyBackupPath = legacyPaths.checkpointBackupFile;
   }
 
   /** Read the current checkpoint, or create initial state */
   async load(projectName: string, options: { fresh?: boolean } = {}): Promise<CheckpointState> {
-    await ensureDir(this.progressDir);
+    await ensureDir(this.stateDir);
 
     if (options.fresh) {
       this.logger.info('Fresh start requested (resume=false) — ignoring prior checkpoint state');
@@ -137,9 +142,12 @@ export class CheckpointManager {
       return this.state;
     }
 
-    if (await fileExists(this.checkpointPath)) {
+    const checkpointToRead = await this.resolveCheckpointReadPath();
+    const backupToRead = await this.resolveBackupReadPath();
+
+    if (checkpointToRead) {
       try {
-        this.state = await readJson<CheckpointState>(this.checkpointPath);
+        this.state = await readJson<CheckpointState>(checkpointToRead);
         this.applyBackwardCompatibleDefaults(this.state);
         this.state.resumeCount += 1;
         this.logger.info(`Loaded checkpoint: Phase ${this.state.currentPhase}, ${this.state.completedTasks.length} tasks completed, resume #${this.state.resumeCount}`);
@@ -148,9 +156,9 @@ export class CheckpointManager {
       } catch (err) {
         this.logger.warn(`Failed to read checkpoint, trying backup: ${(err as Error).message}`);
         // Try backup
-        if (await fileExists(this.backupPath)) {
+        if (backupToRead) {
           try {
-            this.state = await readJson<CheckpointState>(this.backupPath);
+            this.state = await readJson<CheckpointState>(backupToRead);
             this.applyBackwardCompatibleDefaults(this.state);
             this.state.resumeCount += 1;
             this.logger.info(`Loaded backup checkpoint: Phase ${this.state.currentPhase}`);
@@ -381,5 +389,25 @@ export class CheckpointManager {
     state.phaseCursors['8'] ??= { iteration: 0, issueIndex: 0 };
     state.phaseCursors['4'].tasks ??= {};
     state.phaseCursors['6'].completedAgents ??= [];
+  }
+
+  private async resolveCheckpointReadPath(): Promise<string | undefined> {
+    if (await fileExists(this.checkpointPath)) {
+      return this.checkpointPath;
+    }
+    if (await fileExists(this.legacyCheckpointPath)) {
+      return this.legacyCheckpointPath;
+    }
+    return undefined;
+  }
+
+  private async resolveBackupReadPath(): Promise<string | undefined> {
+    if (await fileExists(this.backupPath)) {
+      return this.backupPath;
+    }
+    if (await fileExists(this.legacyBackupPath)) {
+      return this.legacyBackupPath;
+    }
+    return undefined;
   }
 }

--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -37,6 +37,7 @@ import type { Phase4MetricsSnapshot } from '../observability/metrics-collector.j
 import { ReportGenerator } from '../observability/report-generator.js';
 import type { InvocationMetric } from '../agents/types.js';
 import { z } from 'zod';
+import { buildLegacyRuntimePaths, buildRuntimePaths } from './runtime-paths.js';
 
 const loadLore = () => import('@aamf/lore');
 const loadKbServerProcess = () => import('./kb-server-process.js');
@@ -230,6 +231,8 @@ export class MigrationOrchestrator {
   private readonly costEstimatorInstance: CostEstimator;
   private readonly reportGenerator: ReportGenerator;
   private readonly runId: string;
+  private readonly paths: ReturnType<typeof buildRuntimePaths>;
+  private readonly legacyPaths: ReturnType<typeof buildLegacyRuntimePaths>;
   /** Tracks the maximum concurrency observed across all ParallelExecutor instances. */
   private _peakConcurrency = 0;
   /** Unique task IDs that have consumed routed-task budget (heavy/critical). */
@@ -250,11 +253,13 @@ export class MigrationOrchestrator {
     singlePhase?: number,
   ) {
     this.projectRoot = projectRoot;
-    this.progressDir = join(projectRoot, '.aamf', 'migration', config.projectName);
+    this.paths = buildRuntimePaths(projectRoot, config.projectName);
+    this.progressDir = this.paths.root;
+    this.legacyPaths = buildLegacyRuntimePaths(this.progressDir);
     this.contextBuilder = new ContextBuilder(config, this.progressDir);
     this.tokenTracker = new TokenTracker();
     this.singlePhase = singlePhase;
-    this.kbDbPath = join(this.progressDir, 'kb.db');
+    this.kbDbPath = this.paths.kbDbFile;
 
     const bc = config.options.buildConcurrency ?? 1;
     // 0 means unlimited → use maxParallelAgents
@@ -504,8 +509,8 @@ export class MigrationOrchestrator {
     // Write observability metrics summary and report
     try {
       await this.metricsCollector.writeSummary(this.progressDir, this._peakConcurrency);
-      const metricsDir = join(this.progressDir, 'metrics');
-      const reportDir = join(this.progressDir, 'reports', 'observability');
+      const metricsDir = this.paths.metricsDir;
+      const reportDir = this.paths.reportsObservabilityDir;
       const aggregates = this.metricsCollector.getAggregates(this._peakConcurrency);
       await this.reportGenerator.generate(
         metricsDir,
@@ -709,7 +714,7 @@ export class MigrationOrchestrator {
     const result = await this.launchAgentWithEvents(inv);
     this.recordTokens(result, 1);
 
-    const outputPath = join(this.progressDir, 'impact-assessment.md');
+    const outputPath = this.legacyPaths.impactAssessmentFile;
     return {
       phase: 1,
       name: 'Impact Assessment',
@@ -743,7 +748,7 @@ export class MigrationOrchestrator {
       };
     }
 
-    const outputPath = join(this.progressDir, 'knowledge-base');
+    const outputPath = this.legacyPaths.knowledgeBaseDir;
     return {
       phase: 2,
       name: 'Knowledge Base Construction',
@@ -756,10 +761,13 @@ export class MigrationOrchestrator {
   // ─── Phase 3: Migration Planning ─────────────────────────────────────
 
   private async executePhase3(start: number): Promise<PhaseResult> {
-    const planningDir = join(this.progressDir, 'planning');
+    const planningDir = this.paths.artifactsPlanningDir;
+    const legacyPlanningDir = this.legacyPaths.planningDir;
     const groupsFile = join(planningDir, 'groups.json');
     const strategyFile = join(planningDir, 'strategy.md');
     const mergedTasksFile = join(planningDir, 'tasks-merged.json');
+    const legacyGroupsFile = join(legacyPlanningDir, 'groups.json');
+    const legacyStrategyFile = join(legacyPlanningDir, 'strategy.md');
 
     // ── Step 3a: migration-planner (fast, serial) ──────────────────────────
     //   Reads the knowledge base and emits planning/groups.json +
@@ -788,10 +796,12 @@ export class MigrationOrchestrator {
 
       // Adjudicator runs before task decomposition when competing strategies
       // were written to disk by the migration-planner.
-      const adjudicationFile = join(this.progressDir, 'competing-strategies.md');
-      if (await fileExists(adjudicationFile)) {
+      const adjudicationFile = join(this.paths.artifactsPlanningDir, 'competing-strategies.md');
+      const legacyAdjudicationFile = this.legacyPaths.competingStrategiesFile;
+      if (await fileExists(adjudicationFile) || await fileExists(legacyAdjudicationFile)) {
+        const fileToUse = await fileExists(adjudicationFile) ? adjudicationFile : legacyAdjudicationFile;
         const adjCtx = await this.contextBuilder.buildContext('adjudicator', 3, undefined, {
-          competingStrategiesFile: adjudicationFile,
+          competingStrategiesFile: fileToUse,
           decisionType: 'migration-strategy',
         });
         const adjInv = this.buildInvocation('adjudicator', adjCtx, 3);
@@ -840,7 +850,10 @@ export class MigrationOrchestrator {
     //   Each invocation reads strategy.md + its group's analysis files and
     //   emits planning/tasks-<group>.json.  Completed groups are tracked in
     //   the checkpoint so partial failures can be retried cheaply on resume.
-    if (!(await fileExists(groupsFile))) {
+    const groupsFileToRead = await fileExists(groupsFile)
+      ? groupsFile
+      : (await fileExists(legacyGroupsFile) ? legacyGroupsFile : undefined);
+    if (!groupsFileToRead) {
       return {
         phase: 3,
         name: 'Migration Planning',
@@ -850,7 +863,7 @@ export class MigrationOrchestrator {
       };
     }
 
-    const groups = await readJson<ModuleGroup[]>(groupsFile);
+    const groups = await readJson<ModuleGroup[]>(groupsFileToRead);
     const completedGroups = new Set(this.checkpoint.getState().completedPhase3Groups ?? []);
     const remainingGroups = groups.filter(g => !completedGroups.has(g.id));
 
@@ -865,7 +878,7 @@ export class MigrationOrchestrator {
         const ctx = await this.contextBuilder.buildContext('task-decomposer', 3, group.id, {
           groupId: group.id,
           groupName: group.name,
-          strategyFile,
+          strategyFile: await fileExists(strategyFile) ? strategyFile : legacyStrategyFile,
           analysisFiles: group.analysisFiles,
         });
         invocations.push(this.buildInvocation('task-decomposer', ctx, 3, group.id));
@@ -944,8 +957,12 @@ export class MigrationOrchestrator {
     const allTasks: MigrationTask[] = [];
     for (const group of groups) {
       const taskFile = join(planningDir, `tasks-${group.id}.json`);
-      if (await fileExists(taskFile)) {
-        const groupTasksRaw = await readJson<unknown>(taskFile);
+      const legacyTaskFile = join(legacyPlanningDir, `tasks-${group.id}.json`);
+      const taskFileToRead = await fileExists(taskFile)
+        ? taskFile
+        : (await fileExists(legacyTaskFile) ? legacyTaskFile : undefined);
+      if (taskFileToRead) {
+        const groupTasksRaw = await readJson<unknown>(taskFileToRead);
         const parsed = TaskFileSchema.safeParse(groupTasksRaw);
         if (!parsed.success) {
           const issueSummary = parsed.error.issues
@@ -956,7 +973,7 @@ export class MigrationOrchestrator {
             })
             .join('; ');
           const validationError =
-            `Invalid task-decomposer output for group "${group.id}" at ${taskFile}. ` +
+            `Invalid task-decomposer output for group "${group.id}" at ${taskFileToRead}. ` +
             `Schema validation failed: ${issueSummary}`;
           this.logger.error(validationError);
           return {
@@ -1004,7 +1021,7 @@ export class MigrationOrchestrator {
   // ─── Phase 4: Iterative Migration ────────────────────────────────────
 
   private async executePhase4(start: number): Promise<PhaseResult> {
-    const planPath = join(this.progressDir, 'migration-plan.md');
+    const planPath = this.legacyPaths.migrationPlanFile;
 
     // 1. Parse migration plan — prefer structuredOutput from Phase 3, fall back to file
     let tasks: MigrationTask[];
@@ -1014,19 +1031,21 @@ export class MigrationOrchestrator {
       if (!(await fileExists(planPath))) {
         // Also check for the newer planning/tasks-merged.json produced by the
         // two-step Phase 3 (migration-planner + parallel task-decomposer).
-        const mergedPlanPath = join(this.progressDir, 'planning', 'tasks-merged.json');
-        if (await fileExists(mergedPlanPath)) {
+        const mergedPlanPath = join(this.paths.artifactsPlanningDir, 'tasks-merged.json');
+        const legacyMergedPlanPath = join(this.legacyPaths.planningDir, 'tasks-merged.json');
+        if (await fileExists(mergedPlanPath) || await fileExists(legacyMergedPlanPath)) {
+          const mergedToRead = await fileExists(mergedPlanPath) ? mergedPlanPath : legacyMergedPlanPath;
           this.logger.warn(
-            'Phase 3 structured output unavailable — falling back to planning/tasks-merged.json',
+            'Phase 3 structured output unavailable — falling back to tasks-merged.json artifact',
           );
-          tasks = await readJson<MigrationTask[]>(mergedPlanPath);
+          tasks = await readJson<MigrationTask[]>(mergedToRead);
         } else {
           return {
             phase: 4,
             name: 'Iterative Migration',
             success: false,
             duration: Date.now() - start,
-            error: 'migration-plan.md and planning/tasks-merged.json not found — Phase 3 may not have completed',
+            error: 'migration-plan.md and tasks-merged.json not found — Phase 3 may not have completed',
           };
         }
       } else {
@@ -1882,8 +1901,7 @@ export class MigrationOrchestrator {
         for (let attempt = 1; attempt <= maxParityRetries; attempt++) {
           // Launch failure-adjudicator with parity report
           const parityReportPath = join(
-            this.progressDir,
-            'parity-reports',
+            this.paths.artifactsParityDir,
             `${task.id}.md`,
           );
           const parityRemediation = this.buildRemediationContext({
@@ -2121,7 +2139,7 @@ export class MigrationOrchestrator {
     const MAX_LOOPBACK = 2;
     const phase5Cursor = this.getPhase5Cursor();
     if (phase5Cursor.lastSuccessfulStep === 'complete' || phase5Cursor.iteration > MAX_LOOPBACK) {
-      const outputPath = join(this.progressDir, 'final-parity-report.md');
+      const outputPath = join(this.paths.artifactsParityDir, 'final-parity-report.md');
       return {
         phase: 5,
         name: 'Final Parity Verification',
@@ -2162,10 +2180,14 @@ export class MigrationOrchestrator {
       if (result.outputParsed && Array.isArray(result.structuredOutput?.['fixes'])) {
         fixes = result.structuredOutput['fixes'] as Array<{ description: string; sourceFile: string; targetFile: string }>;
       } else {
-        const reportPath = join(this.progressDir, 'final-parity-report.md');
-        if (!(await fileExists(reportPath))) break;
+        const reportPath = join(this.paths.artifactsParityDir, 'final-parity-report.md');
+        const legacyReportPath = this.legacyPaths.finalParityReportFile;
+        const reportToRead = await fileExists(reportPath)
+          ? reportPath
+          : (await fileExists(legacyReportPath) ? legacyReportPath : undefined);
+        if (!reportToRead) break;
         this.logger.warn('Final-parity-checker structured output unavailable — falling back to ResultParser.parseFinalParityReport');
-        fixes = await ResultParser.parseFinalParityReport(reportPath);
+        fixes = await ResultParser.parseFinalParityReport(reportToRead);
       }
       if (fixes.length === 0) {
         await this.savePhase5Cursor({
@@ -2234,7 +2256,7 @@ export class MigrationOrchestrator {
       lastSuccessfulStep: 'complete',
     });
 
-    const outputPath = join(this.progressDir, 'final-parity-report.md');
+    const outputPath = join(this.paths.artifactsParityDir, 'final-parity-report.md');
     return {
       phase: 5,
       name: 'Final Parity Verification',
@@ -2360,7 +2382,7 @@ export class MigrationOrchestrator {
     const maxIterations = this.config.options.idiomaticRefactor?.maxIterations ?? 2;
     const phase8Cursor = this.getPhase8Cursor();
     if (phase8Cursor.lastSuccessfulStep === 'complete' || phase8Cursor.iteration >= maxIterations) {
-      const outputPath = join(this.progressDir, 'idiomatic-review-report.md');
+      const outputPath = join(this.paths.artifactsParityDir, 'idiomatic-review-report.md');
       return {
         phase: 8,
         name: 'Idiomatic Refactor',
@@ -2397,13 +2419,15 @@ export class MigrationOrchestrator {
       }
 
       // Parse idiomatic issues
-      const reportPath = join(this.progressDir, 'idiomatic-review-report.md');
+      const reportPath = join(this.paths.artifactsParityDir, 'idiomatic-review-report.md');
+      const legacyReportPath = this.legacyPaths.idiomaticReviewReportFile;
       let issues: Array<{ file: string; issue: string; suggestion: string }>;
       if (reviewResult.outputParsed && Array.isArray(reviewResult.structuredOutput?.['issues'])) {
         issues = reviewResult.structuredOutput['issues'] as Array<{ file: string; issue: string; suggestion: string }>;
       } else {
         this.logger.warn('Idiomatic-reviewer structured output unavailable — falling back to ResultParser.parseIdiomaticReport');
-        issues = await ResultParser.parseIdiomaticReport(reportPath);
+        const reportToRead = await fileExists(reportPath) ? reportPath : legacyReportPath;
+        issues = await ResultParser.parseIdiomaticReport(reportToRead);
       }
 
       if (issues.length === 0) {
@@ -2470,7 +2494,7 @@ export class MigrationOrchestrator {
       lastSuccessfulStep: 'complete',
     });
 
-    const outputPath = join(this.progressDir, 'idiomatic-review-report.md');
+    const outputPath = join(this.paths.artifactsParityDir, 'idiomatic-review-report.md');
     return {
       phase: 8,
       name: 'Idiomatic Refactor',
@@ -2514,7 +2538,9 @@ export class MigrationOrchestrator {
 
         // Log the output
         const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-        const logPath = join(this.progressDir, 'logs', `${label}-${taskId}-${timestamp}.log`);
+        const commandLogDir = label === 'build' ? this.paths.logsCommandBuildDir : this.paths.logsCommandTestDir;
+        await ensureDir(commandLogDir);
+        const logPath = join(commandLogDir, `${taskId}-${timestamp}.log`);
         const logContent = `=== COMMAND: ${command} ===\n=== EXIT CODE: ${result.exitCode} ===\n\n=== STDOUT ===\n${result.stdout}\n\n=== STDERR ===\n${result.stderr}\n`;
         await atomicWrite(logPath, logContent);
 

--- a/runtime/src/core/progress.ts
+++ b/runtime/src/core/progress.ts
@@ -43,7 +43,7 @@ export class ProgressWriter {
   private agentStatuses: Map<string, string> = new Map();
   private cumulativeDurationMs: number = 0;
 
-  constructor(private filePath: string) {}
+  constructor(private filePath: string, private readonly projectNameOverride?: string) {}
 
   /** Initialize fresh progress.md */
   async initialize(config: MigrationConfig): Promise<void> {
@@ -199,10 +199,17 @@ export class ProgressWriter {
   }
 
   private async writeCurrentState(): Promise<void> {
-    // infer project name from filepath
-    const parts = this.filePath.split('/');
-    const projectName = parts[parts.length - 2] ?? 'unknown';
+    const projectName = this.projectNameOverride ?? this.inferProjectNameFromPath();
     await this.write(projectName);
+  }
+
+  private inferProjectNameFromPath(): string {
+    const parts = this.filePath.split('/');
+    const migrationIndex = parts.lastIndexOf('migration');
+    if (migrationIndex >= 0 && migrationIndex + 1 < parts.length) {
+      return parts[migrationIndex + 1] ?? 'unknown';
+    }
+    return parts[parts.length - 2] ?? 'unknown';
   }
 
   private async write(projectName: string): Promise<void> {

--- a/runtime/src/core/runtime-paths.ts
+++ b/runtime/src/core/runtime-paths.ts
@@ -1,0 +1,106 @@
+import { join } from 'node:path';
+
+export interface RuntimePaths {
+  root: string;
+  stateDir: string;
+  checkpointFile: string;
+  checkpointBackupFile: string;
+  runManifestFile: string;
+  logsRuntimeDir: string;
+  migrationLogFile: string;
+  logsAgentsDir: string;
+  logsCommandsDir: string;
+  logsCommandBuildDir: string;
+  logsCommandTestDir: string;
+  artifactsDir: string;
+  artifactsContextsDir: string;
+  artifactsResultsDir: string;
+  artifactsPlanningDir: string;
+  artifactsParityDir: string;
+  artifactsAdjudicationDir: string;
+  reportsDir: string;
+  progressReportFile: string;
+  reportsObservabilityDir: string;
+  metricsDir: string;
+  metricsInvocationsFile: string;
+  metricsSummaryFile: string;
+  kbDbFile: string;
+}
+
+export interface LegacyRuntimePaths {
+  checkpointFile: string;
+  checkpointBackupFile: string;
+  contextsDir: string;
+  resultsDir: string;
+  planningDir: string;
+  parityReportsDir: string;
+  adjudicationDir: string;
+  progressReportFile: string;
+  migrationLogDir: string;
+  migrationLogFile: string;
+  impactAssessmentFile: string;
+  knowledgeBaseDir: string;
+  migrationPlanFile: string;
+  competingStrategiesFile: string;
+  finalParityReportFile: string;
+  idiomaticReviewReportFile: string;
+}
+
+export function buildRuntimePaths(projectRoot: string, projectName: string): RuntimePaths {
+  const root = join(projectRoot, '.aamf', 'migration', projectName);
+  const stateDir = join(root, 'state');
+  const logsRuntimeDir = join(root, 'logs', 'runtime');
+  const logsAgentsDir = join(root, 'logs', 'agents');
+  const logsCommandsDir = join(root, 'logs', 'commands');
+  const artifactsDir = join(root, 'artifacts');
+  const reportsDir = join(root, 'reports');
+  const metricsDir = join(root, 'metrics');
+
+  return {
+    root,
+    stateDir,
+    checkpointFile: join(stateDir, 'checkpoint.json'),
+    checkpointBackupFile: join(stateDir, 'checkpoint.backup.json'),
+    runManifestFile: join(stateDir, 'run-manifest.json'),
+    logsRuntimeDir,
+    migrationLogFile: join(logsRuntimeDir, 'migration.log'),
+    logsAgentsDir,
+    logsCommandsDir,
+    logsCommandBuildDir: join(logsCommandsDir, 'build'),
+    logsCommandTestDir: join(logsCommandsDir, 'test'),
+    artifactsDir,
+    artifactsContextsDir: join(artifactsDir, 'contexts'),
+    artifactsResultsDir: join(artifactsDir, 'results'),
+    artifactsPlanningDir: join(artifactsDir, 'planning'),
+    artifactsParityDir: join(artifactsDir, 'parity'),
+    artifactsAdjudicationDir: join(artifactsDir, 'adjudication'),
+    reportsDir,
+    progressReportFile: join(reportsDir, 'progress.md'),
+    reportsObservabilityDir: join(reportsDir, 'observability'),
+    metricsDir,
+    metricsInvocationsFile: join(metricsDir, 'invocations.jsonl'),
+    metricsSummaryFile: join(metricsDir, 'summary.json'),
+    kbDbFile: join(root, 'kb.db'),
+  };
+}
+
+export function buildLegacyRuntimePaths(progressDir: string): LegacyRuntimePaths {
+  return {
+    checkpointFile: join(progressDir, 'checkpoint.json'),
+    checkpointBackupFile: join(progressDir, 'checkpoint.backup.json'),
+    contextsDir: join(progressDir, 'contexts'),
+    resultsDir: join(progressDir, 'results'),
+    planningDir: join(progressDir, 'planning'),
+    parityReportsDir: join(progressDir, 'parity-reports'),
+    adjudicationDir: join(progressDir, 'adjudication'),
+    progressReportFile: join(progressDir, 'progress.md'),
+    migrationLogDir: join(progressDir, 'logs'),
+    migrationLogFile: join(progressDir, 'logs', 'migration.log'),
+    impactAssessmentFile: join(progressDir, 'impact-assessment.md'),
+    knowledgeBaseDir: join(progressDir, 'knowledge-base'),
+    migrationPlanFile: join(progressDir, 'migration-plan.md'),
+    competingStrategiesFile: join(progressDir, 'competing-strategies.md'),
+    finalParityReportFile: join(progressDir, 'final-parity-report.md'),
+    idiomaticReviewReportFile: join(progressDir, 'idiomatic-review-report.md'),
+  };
+}

--- a/runtime/src/core/runtime.ts
+++ b/runtime/src/core/runtime.ts
@@ -12,6 +12,7 @@ import { Logger } from '../logging/logger.js';
 import { MigrationResult } from '../agents/types.js';
 import { CostEstimator } from '../budget/cost-estimator.js';
 import { fileExists } from '../util/fs.js';
+import { buildRuntimePaths } from './runtime-paths.js';
 
 export interface RuntimeOptions {
   configPath: string;
@@ -70,6 +71,7 @@ export class MigrationRuntime {
   private progress!: ProgressWriter;
   private launcher!: AgentLauncher;
   private progressDir!: string;
+  private paths!: ReturnType<typeof buildRuntimePaths>;
   private projectRoot!: string;
   private phase?: number;
   private runId!: string;
@@ -90,8 +92,9 @@ export class MigrationRuntime {
     await validateSourceAvailability(this.config);
 
     // 2. Setup directories
-    this.progressDir = join(this.projectRoot, '.aamf', 'migration', this.config.projectName);
-    const logDir = join(this.progressDir, 'logs');
+    this.paths = buildRuntimePaths(this.projectRoot, this.config.projectName);
+    this.progressDir = this.paths.root;
+    const logDir = this.paths.logsRuntimeDir;
 
     // 3. Create logger
     this.logger = new Logger({
@@ -108,7 +111,7 @@ export class MigrationRuntime {
     this.checkpoint = new CheckpointManager(this.progressDir, this.logger);
 
     // 5. Create progress writer
-    this.progress = new ProgressWriter(join(this.progressDir, 'progress.md'));
+    this.progress = new ProgressWriter(this.paths.progressReportFile, this.config.projectName);
 
     // 6. Create agent launcher
     this.launcher = new AgentLauncher(this.config, this.projectRoot, this.logger);

--- a/runtime/tests/agent-launcher.test.ts
+++ b/runtime/tests/agent-launcher.test.ts
@@ -53,6 +53,15 @@ describe('AgentLauncher', () => {
     return { contextFile, progressDir };
   }
 
+  async function readLatestAgentLog(agent: string, taskId: string): Promise<{ fileName: string; content: string }> {
+    const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs', 'agents', agent, taskId);
+    const logFiles = await readdir(logDir);
+    const fileName = [...logFiles].sort().at(-1);
+    expect(fileName).toBeDefined();
+    const content = await readFile(join(logDir, fileName!), 'utf-8');
+    return { fileName: fileName!, content };
+  }
+
   it('should be importable', () => {
     expect(AgentLauncher).toBeDefined();
   });
@@ -72,12 +81,7 @@ describe('AgentLauncher', () => {
 
     expect(result.success).toBe(true);
 
-    const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
-    const logFiles = await readdir(logDir);
-    const agentLog = logFiles.find(f => f.startsWith('code-migrator-cli-args'));
-    expect(agentLog).toBeDefined();
-
-    const logContent = await readFile(join(logDir, agentLog!), 'utf-8');
+    const { content: logContent } = await readLatestAgentLog('code-migrator', 'cli-args');
     expect(logContent).toContain('--agent');
     expect(logContent).toContain('code-migrator');
     expect(logContent).toContain('-p');
@@ -105,12 +109,7 @@ describe('AgentLauncher', () => {
 
     expect(result.success).toBe(true);
 
-    const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
-    const logFiles = await readdir(logDir);
-    const agentLog = logFiles.find(f => f.startsWith('code-migrator-model-override'));
-    expect(agentLog).toBeDefined();
-
-    const logContent = await readFile(join(logDir, agentLog!), 'utf-8');
+    const { content: logContent } = await readLatestAgentLog('code-migrator', 'model-override');
     expect(logContent).toContain('--model');
     expect(logContent).toContain('fallback-model');
     expect(logContent).not.toContain('primary-model');
@@ -137,12 +136,7 @@ describe('AgentLauncher', () => {
 
     expect(result.success).toBe(true);
 
-    const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
-    const logFiles = await readdir(logDir);
-    const agentLog = logFiles.find(f => f.startsWith('impact-assessor-env-test'));
-    expect(agentLog).toBeDefined();
-
-    const logContent = await readFile(join(logDir, agentLog!), 'utf-8');
+    const { content: logContent } = await readLatestAgentLog('impact-assessor', 'env-test');
     expect(logContent).toContain(`PROGRESS_DIR:${progressDir}`);
     expect(logContent).toContain(`CONTEXT_FILE:${contextFile}`);
     expect(logContent).toContain('PHASE:1');
@@ -177,12 +171,7 @@ describe('AgentLauncher', () => {
 
       expect(result.success).toBe(true);
 
-      const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
-      const logFiles = await readdir(logDir);
-      const agentLog = logFiles.find(f => f.startsWith('impact-assessor-env-filter'));
-      expect(agentLog).toBeDefined();
-
-      const logContent = await readFile(join(logDir, agentLog!), 'utf-8');
+      const { content: logContent } = await readLatestAgentLog('impact-assessor', 'env-filter');
       expect(logContent).toContain('VSCODE_IPC_HOOK_CLI:');
       expect(logContent).not.toContain('vscode-ipc-token');
       expect(logContent).toContain('TERM_PROGRAM:');
@@ -378,12 +367,7 @@ describe('AgentLauncher', () => {
       taskId: 'log-001',
     });
 
-    const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
-    const logFiles = await readdir(logDir);
-    const agentLog = logFiles.find(f => f.startsWith('code-migrator-log-001-') && f.endsWith('.log'));
-    expect(agentLog).toBeDefined();
-
-    const logContent = await readFile(join(logDir, agentLog!), 'utf-8');
+    const { content: logContent } = await readLatestAgentLog('code-migrator', 'log-001');
     expect(logContent).toContain('stdout output');
     expect(logContent).toContain('stderr output');
     expect(logContent).toContain('=== STDOUT ===');
@@ -404,12 +388,7 @@ describe('AgentLauncher', () => {
       additionalArgs: { foo: 'bar' },
     });
 
-    const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
-    const logFiles = await readdir(logDir);
-    const agentLog = logFiles.find(f => f.startsWith('code-migrator-args-001'));
-    expect(agentLog).toBeDefined();
-
-    const logContent = await readFile(join(logDir, agentLog!), 'utf-8');
+    const { content: logContent } = await readLatestAgentLog('code-migrator', 'args-001');
     expect(logContent).toContain('--foo');
     expect(logContent).toContain('bar');
   });
@@ -725,14 +704,8 @@ describe('AgentLauncher', () => {
 
       expect(result.invocationId).toBeDefined();
 
-      const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
-      const logFiles = await readdir(logDir);
-      const agentLog = logFiles.find(f =>
-        f.startsWith('code-migrator-inv-log-001-') &&
-        f.includes(result.invocationId!) &&
-        f.endsWith('.log'),
-      );
-      expect(agentLog).toBeDefined();
+      const { fileName } = await readLatestAgentLog('code-migrator', 'inv-log-001');
+      expect(fileName).toContain(result.invocationId!);
     });
 
     it('should include invocationId on error/catch path', async () => {
@@ -849,12 +822,7 @@ describe('AgentLauncher', () => {
 
       expect(result.success).toBe(true);
 
-      const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
-      const logFiles = await readdir(logDir);
-      const agentLog = logFiles.find(f => f.startsWith('code-migrator-extra-path-001'));
-      expect(agentLog).toBeDefined();
-
-      const logContent = await readFile(join(logDir, agentLog!), 'utf-8');
+      const { content: logContent } = await readLatestAgentLog('code-migrator', 'extra-path-001');
       expect(logContent).toContain('PATH_VALUE:/tmp/aamf-extra-bin:');
     });
 
@@ -944,12 +912,7 @@ describe('AgentLauncher', () => {
 
       expect(result.success).toBe(true);
 
-      const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
-      const logFiles = await readdir(logDir);
-      const agentLog = logFiles.find(f => f.startsWith('impact-assessor-mcp-config-001'));
-      expect(agentLog).toBeDefined();
-
-      const logContent = await readFile(join(logDir, agentLog!), 'utf-8');
+      const { content: logContent } = await readLatestAgentLog('impact-assessor', 'mcp-config-001');
       expect(logContent).toContain('--additional-mcp-config');
       expect(logContent).toContain('aamf-kb');
       expect(logContent).toContain('localhost:4321');
@@ -970,12 +933,7 @@ describe('AgentLauncher', () => {
 
       expect(result.success).toBe(true);
 
-      const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
-      const logFiles = await readdir(logDir);
-      const agentLog = logFiles.find(f => f.startsWith('code-migrator-no-mcp-001'));
-      expect(agentLog).toBeDefined();
-
-      const logContent = await readFile(join(logDir, agentLog!), 'utf-8');
+      const { content: logContent } = await readLatestAgentLog('code-migrator', 'no-mcp-001');
       expect(logContent).not.toContain('--additional-mcp-config');
     });
 
@@ -1010,12 +968,7 @@ describe('AgentLauncher', () => {
 
       expect(result.success).toBe(true);
 
-      const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
-      const logFiles = await readdir(logDir);
-      const agentLog = logFiles.find(f => f.startsWith('impact-assessor-claude-mcp-001'));
-      expect(agentLog).toBeDefined();
-
-      const logContent = await readFile(join(logDir, agentLog!), 'utf-8');
+      const { content: logContent } = await readLatestAgentLog('impact-assessor', 'claude-mcp-001');
       expect(logContent).toContain('--mcp-config');
       expect(logContent).toContain('aamf-kb');
       expect(logContent).toContain('localhost:4545');

--- a/runtime/tests/checkpoint.test.ts
+++ b/runtime/tests/checkpoint.test.ts
@@ -227,11 +227,11 @@ describe('CheckpointManager', () => {
   it('should write checkpoint atomically', async () => {    await manager.load('test-project');
     
     // Verify checkpoint file exists
-    const exists = await fileExists(join(tempDir, 'checkpoint.json'));
+    const exists = await fileExists(join(tempDir, 'state', 'checkpoint.json'));
     expect(exists).toBe(true);
     
     // Verify it's valid JSON
-    const data = await readJson(join(tempDir, 'checkpoint.json'));
+    const data = await readJson(join(tempDir, 'state', 'checkpoint.json'));
     expect(data).toBeDefined();
   });
 

--- a/runtime/tests/claude-runner.test.ts
+++ b/runtime/tests/claude-runner.test.ts
@@ -75,6 +75,15 @@ describe('ClaudeCodeRunner', () => {
     return { contextFile, progressDir };
   }
 
+  async function readLatestAgentLog(agent: string, taskId: string): Promise<{ fileName: string; content: string }> {
+    const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs', 'agents', agent, taskId);
+    const logFiles = await readdir(logDir);
+    const fileName = [...logFiles].sort().at(-1);
+    expect(fileName).toBeDefined();
+    const content = await readFile(join(logDir, fileName!), 'utf-8');
+    return { fileName: fileName!, content };
+  }
+
   /** Helper to create a mock agent definition file */
   async function createAgentFile(agentName: string, content = '---\nname: test\n---\n# Agent') {
     const agentDir = join(projectRoot, '.claude', 'agents');
@@ -111,12 +120,7 @@ describe('ClaudeCodeRunner', () => {
 
     expect(result.success).toBe(true);
 
-    const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
-    const logFiles = await readdir(logDir);
-    const agentLog = logFiles.find(f => f.startsWith('code-migrator-claude-args'));
-    expect(agentLog).toBeDefined();
-
-    const logContent = await readFile(join(logDir, agentLog!), 'utf-8');
+    const { content: logContent } = await readLatestAgentLog('code-migrator', 'claude-args');
     expect(logContent).toContain('--agent');
     expect(logContent).toContain('code-migrator');
     expect(logContent).toContain('-p');
@@ -149,12 +153,7 @@ describe('ClaudeCodeRunner', () => {
 
     expect(result.success).toBe(true);
 
-    const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
-    const logFiles = await readdir(logDir);
-    const agentLog = logFiles.find(f => f.startsWith('impact-assessor-claude-env'));
-    expect(agentLog).toBeDefined();
-
-    const logContent = await readFile(join(logDir, agentLog!), 'utf-8');
+    const { content: logContent } = await readLatestAgentLog('impact-assessor', 'claude-env');
     expect(logContent).toContain(`PROGRESS_DIR:${progressDir}`);
     expect(logContent).toContain(`CONTEXT_FILE:${contextFile}`);
     expect(logContent).toContain('PHASE:2');
@@ -378,12 +377,7 @@ describe('ClaudeCodeRunner', () => {
       taskId: 'claude-log',
     });
 
-    const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
-    const logFiles = await readdir(logDir);
-    const agentLog = logFiles.find(f => f.startsWith('code-migrator-claude-log-') && f.endsWith('.log'));
-    expect(agentLog).toBeDefined();
-
-    const logContent = await readFile(join(logDir, agentLog!), 'utf-8');
+    const { content: logContent } = await readLatestAgentLog('code-migrator', 'claude-log');
     expect(logContent).toContain('stdout');
     expect(logContent).toContain('stderr');
     expect(logContent).toContain('=== STDOUT ===');
@@ -441,14 +435,8 @@ describe('ClaudeCodeRunner', () => {
         taskId: 'claude-inv-log',
       });
 
-      const logDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs');
-      const logFiles = await readdir(logDir);
-      const agentLog = logFiles.find(f =>
-        f.startsWith('code-migrator-claude-inv-log-') &&
-        f.includes(result.invocationId!) &&
-        f.endsWith('.log'),
-      );
-      expect(agentLog).toBeDefined();
+      const { fileName } = await readLatestAgentLog('code-migrator', 'claude-inv-log');
+      expect(fileName).toContain(result.invocationId!);
     });
 
     it('should include invocationId on error/catch path', async () => {

--- a/runtime/tests/context-builder.test.ts
+++ b/runtime/tests/context-builder.test.ts
@@ -194,7 +194,7 @@ describe('ContextBuilder', () => {
 
       expect(context.inputFiles).toContain('src/auth.py');
       expect(context.inputFiles).toContain('src/auth.ts');
-      expect(context.outputPath).toContain('parity-reports');
+      expect(context.outputPath).toContain('artifacts/parity');
     });
 
     it('should route test-writer to target file + KB entry', async () => {


### PR DESCRIPTION
## Summary
- centralize runtime artifact path derivation for normalized .aamf migration layout
- route checkpoint/log/context/result/report/metrics paths through normalized directories
- keep backward-compatible read fallbacks for legacy path locations
- update runtime docs and affected tests for the new filesystem contract

Depends on #90
Refs #89