### PR TITLE
runtime fixture: enable git auto-init for zstd migration output

### DIFF
--- a/runtime/tests/fixtures/zstd-c-project/migration.config.json
+++ b/runtime/tests/fixtures/zstd-c-project/migration.config.json
@@ -39,6 +39,10 @@
     "dryRun": false,
     "resume": true,
     "keepArtifacts": true,
+    "git": {
+      "enabled": true,
+      "autoInit": true
+    },
     "kbIndex": {
       "enabled": true,
       "embeddings": {


### PR DESCRIPTION
## Summary
- Explicitly enable git automation in the zstd fixture migration config.
- Enable auto-init so target outputPath is initialized as a standalone repository.

## Why
The fixture omitted options.git, so git initialization was skipped.

## Change
- File updated: runtime/tests/fixtures/zstd-c-project/migration.config.json
- Added options.git.enabled = true
- Added options.git.autoInit = true
