### PR TITLE
Runtime: remove Copilot --silent flag so token usage stats are emitted

### DIFF
--- a/runtime/src/core/agent-launcher.ts
+++ b/runtime/src/core/agent-launcher.ts
@@ -240,7 +240,6 @@ export class CopilotRunner implements AgentRunner {
       '--allow-all-tools',
       '--allow-all-paths',
       '--no-ask-user',
-      '-s',
     ];
 
     const model = invocation.modelOverride ?? this.config.copilot.model;

--- a/runtime/tests/agent-launcher.test.ts
+++ b/runtime/tests/agent-launcher.test.ts
@@ -90,7 +90,7 @@ describe('AgentLauncher', () => {
     expect(logContent).toContain('gpt-4o');
     expect(logContent).toContain('--allow-all-tools');
     expect(logContent).toContain('--no-ask-user');
-    expect(logContent).toContain('-s');
+    expect(logContent).not.toContain('-s');
   });
 
   it('should prefer invocation modelOverride over configured model', async () => {


### PR DESCRIPTION
## Summary
- remove Copilot CLI `-s/--silent` from runtime agent invocation
- keep all existing operational flags and model handling unchanged
- update `agent-launcher` test to assert silent mode is not passed

## Why
Copilot `--silent` suppresses footer stats (including `Breakdown by AI model`), which prevents token usage parsing and causes fallback estimation.

## Validation
- `npx vitest run tests/agent-launcher.test.ts tests/runtime.test.ts`
