### PR TITLE
fix: delete stale kb.db before rebuild to prevent vec0 UNIQUE constraint failure

### DIFF
--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -1,6 +1,6 @@
 import { join, resolve } from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
-import { readdir } from 'node:fs/promises';
+import { readdir, unlink } from 'node:fs/promises';
 import pLimit from 'p-limit';
 import { PHASES, PhaseDefinition } from './phase-registry.js';
 import { CheckpointManager } from './checkpoint.js';
@@ -653,6 +653,24 @@ export class MigrationOrchestrator {
     }
 
     this.logger.info('Phase 0 rebuilt — source fingerprint changed or no existing KB');
+
+    // Remove the stale DB before rebuilding.  vec0 virtual tables (symbol_embeddings)
+    // do not support INSERT OR REPLACE — inserting a duplicate rowid raises a
+    // UNIQUE constraint error.  Deleting the file is the simplest guarantee that
+    // the rebuild starts from a clean slate.
+    if (await fileExists(this.kbDbPath)) {
+      try {
+        await unlink(this.kbDbPath);
+        // Also remove WAL / SHM sidecar files if present.
+        await unlink(this.kbDbPath + '-wal').catch(() => {});
+        await unlink(this.kbDbPath + '-shm').catch(() => {});
+        this.logger.info('Removed stale KB database before rebuild');
+      } catch (err) {
+        this.logger.warn(
+          `Failed to remove stale KB database: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
 
     const maxAttempts = this.config.options.maxRetriesPerTask;
     const timeout =

--- a/runtime/src/core/phase-registry.ts
+++ b/runtime/src/core/phase-registry.ts
@@ -22,7 +22,7 @@ export const PHASES: readonly PhaseDefinition[] = [
     name: 'KB Indexing',
     description: 'Build a local knowledge-base index of the source codebase for use by subsequent agents',
     agents: [],
-    critical: false,
+    critical: true,
     parallel: false,
     optional: true,
   },

--- a/runtime/tests/phase-registry.test.ts
+++ b/runtime/tests/phase-registry.test.ts
@@ -11,8 +11,8 @@ describe('Phase Registry', () => {
     expect(ids).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
   });
 
-  it('should mark phases 1–4 as critical', () => {
-    for (const id of [1, 2, 3, 4]) {
+  it('should mark phases 0–4 as critical', () => {
+    for (const id of [0, 1, 2, 3, 4]) {
       const phase = PHASES.find(p => p.id === id);
       expect(phase?.critical).toBe(true);
     }
@@ -66,10 +66,10 @@ describe('Phase Registry', () => {
       expect(phase?.name).toBe('KB Indexing');
     });
 
-    it('should be optional and non-critical', () => {
+    it('should be optional and critical', () => {
       const phase = getPhase(0);
       expect(phase?.optional).toBe(true);
-      expect(phase?.critical).toBe(false);
+      expect(phase?.critical).toBe(true);
     });
 
     it('should have an empty agents array (Phase 0 runs in-process, no agent launched)', () => {


### PR DESCRIPTION
## Problem

When Phase 0 detects a source fingerprint mismatch and triggers a KB rebuild, the existing `kb.db` is reused. sqlite-vec `vec0` virtual tables (`symbol_embeddings`) **do not support `INSERT OR REPLACE`** — inserting a row with an existing rowid raises:

```
UNIQUE constraint failed on symbol_embeddings primary key
```

This has been happening consistently on every resume run, causing Phase 0 to fail after 3 retry attempts. Because Phase 0 was marked `critical: false`, the failure was silently swallowed and the migration continued into Phase 4 with stale/missing KB data.

## Root Cause

1. `IndexBuilder.build()` re-walks all source files and re-inserts symbols into the existing DB. Regular tables use `CREATE TABLE IF NOT EXISTS` so old rows persist. `embedStructural()` then tries `INSERT OR REPLACE INTO symbol_embeddings(rowid, ...)`, but vec0 virtual tables treat this as a plain `INSERT`, raising the UNIQUE constraint error.

2. Phase 0 (KB Indexing) had `critical: false` in the phase registry, so the orchestrator continued past the failure instead of aborting.

## Fix

- **orchestrator.ts**: Delete the stale `kb.db` (and WAL/SHM sidecar files) before calling `IndexBuilder.build()` when a fingerprint mismatch triggers a rebuild. This ensures a clean slate.
- **phase-registry.ts**: Change Phase 0 from `critical: false` to `critical: true` so KB failures properly abort the migration.
- **phase-registry.test.ts**: Updated 2 test assertions to match the new `critical: true` expectation.

## Testing

All 133 tests pass (phase-registry + orchestrator suites).