### PR TITLE
feat(runtime): track cached tokens and premium requests per invocation

### DIFF
--- a/runtime/src/agents/result-parser.ts
+++ b/runtime/src/agents/result-parser.ts
@@ -472,19 +472,21 @@ export class ResultParser {
    */
   static parseCopilotCliUsage(
     output: string,
-  ): { prompt: number; completion: number; total: number; cachedInput?: number } | undefined {
+  ): { prompt: number; completion: number; total: number; cachedInput?: number; premiumRequests?: number } | undefined {
     const breakdownMatch = output.match(/Breakdown by AI model:/i);
     if (!breakdownMatch) return undefined;
 
     const afterBreakdown = output.slice(breakdownMatch.index! + breakdownMatch[0].length);
 
-    const tokenLineRegexLegacy = /tokens_in:\s*([\d.]+[kmKM]?)\s*,\s*tokens_out:\s*([\d.]+[kmKM]?)(?:\s*,\s*tokens_cached:\s*([\d.]+[kmKM]?))?/g;
-    const tokenLineRegexCurrent = /([\d.]+[kmKM]?)\s+in\s*,\s*([\d.]+[kmKM]?)\s+out(?:\s*,\s*([\d.]+[kmKM]?)\s+cached)?(?:\s*\(Est\.[^)]+\))?/gi;
+    const tokenLineRegexLegacy = /tokens_in:\s*([\d.]+[kmKM]?)\s*,\s*tokens_out:\s*([\d.]+[kmKM]?)(?:\s*,\s*tokens_cached:\s*([\d.]+[kmKM]?))?(?:\s*,\s*premium_requests_est:\s*(\d+))?/g;
+    const tokenLineRegexCurrent = /([\d.]+[kmKM]?)\s+in\s*,\s*([\d.]+[kmKM]?)\s+out(?:\s*,\s*([\d.]+[kmKM]?)\s+cached)?(?:\s*\(Est\.\s*(\d+)\s+Premium\s+requests?\))?/gi;
 
     let totalPrompt = 0;
     let totalCompletion = 0;
     let totalCached = 0;
     let hasCached = false;
+    let totalPremium = 0;
+    let hasPremium = false;
     let foundAny = false;
 
     const consume = (lineMatch: RegExpExecArray): void => {
@@ -494,6 +496,10 @@ export class ResultParser {
       if (lineMatch[3]) {
         totalCached += ResultParser.parseShorthandNumber(lineMatch[3]!);
         hasCached = true;
+      }
+      if (lineMatch[4]) {
+        totalPremium += parseInt(lineMatch[4]!, 10);
+        hasPremium = true;
       }
     };
 
@@ -512,6 +518,7 @@ export class ResultParser {
       completion: totalCompletion,
       total: totalPrompt + totalCompletion,
       ...(hasCached ? { cachedInput: totalCached } : {}),
+      ...(hasPremium ? { premiumRequests: totalPremium } : {}),
     };
   }
 

--- a/runtime/src/agents/types.ts
+++ b/runtime/src/agents/types.ts
@@ -120,7 +120,7 @@ export interface AgentResult {
   duration: number;
 
   /** Optional token-usage breakdown reported by the agent. */
-  tokenUsage?: { prompt: number; completion: number; total: number; cachedInput?: number };
+  tokenUsage?: { prompt: number; completion: number; total: number; cachedInput?: number; premiumRequests?: number };
 
   /** Captured stderr or error message when the agent fails. */
   error?: string;
@@ -429,6 +429,10 @@ export interface InvocationMetric {
   tokensTotal: number;
   /** Estimated cost in USD for this invocation. */
   costUsd: number;
+  /** Number of cached input tokens (subset of tokensPrompt), if available. */
+  cachedTokens?: number;
+  /** Estimated premium requests consumed (Copilot only), if available. */
+  premiumRequests?: number;
   /** Model routing tier assigned to this invocation. */
   routingTier?: ModelTier;
   /** Human-readable reason for the routing decision. */

--- a/runtime/src/budget/cost-estimator.ts
+++ b/runtime/src/budget/cost-estimator.ts
@@ -80,10 +80,10 @@ export class CostEstimator {
    * Estimate cost given explicit prompt and completion token counts.
    *
    * @param model - Model identifier.
-   * @param promptTokens - Number of input / prompt tokens.
+   * @param promptTokens - Total number of input / prompt tokens (includes cached tokens).
    * @param completionTokens - Number of output / completion tokens.
-   * @param cachedInputTokens - Number of cached input tokens (billed at 50% of input price).
-   * @returns Breakdown of input, output, cached, and total cost in USD.
+   * @param cachedInputTokens - Number of cached input tokens (subset of promptTokens, billed at 50% of input price).
+   * @returns Breakdown of input (non-cached), output, cached, and total cost in USD.
    */
   estimate(
     model: string,
@@ -92,7 +92,8 @@ export class CostEstimator {
     cachedInputTokens?: number,
   ): { input: number; output: number; cached: number; total: number } {
     const pricing = this.resolvePricing(model);
-    const input = (promptTokens / 1_000_000) * pricing.input;
+    const nonCachedPrompt = Math.max(0, promptTokens - (cachedInputTokens ?? 0));
+    const input = (nonCachedPrompt / 1_000_000) * pricing.input;
     const output = (completionTokens / 1_000_000) * pricing.output;
     const cached = cachedInputTokens !== undefined
       ? (cachedInputTokens / 1_000_000) * pricing.input * 0.5

--- a/runtime/src/core/checkpoint.ts
+++ b/runtime/src/core/checkpoint.ts
@@ -209,7 +209,10 @@ export class CheckpointManager {
       state.completedPhases.push(phase);
     }
     state.phaseOutputs[phase] = outputPath;
-    state.currentPhase = phase + 1;
+    // Never regress the resume pointer — a re-run of an earlier phase (e.g.
+    // Phase 0 fingerprint check on resume) must not overwrite a more-advanced
+    // currentPhase saved by a previous run.
+    state.currentPhase = Math.max(state.currentPhase, phase + 1);
     state.currentTask = null;
     this.logger.event({ type: 'checkpoint-saved', phase });
     await this.save(state);

--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -585,46 +585,20 @@ export class MigrationOrchestrator {
     this.logger.info(`Building KB index at ${this.kbDbPath} (source: ${sourceRoot})`);
     const lore = await loadLore();
 
-    // Optionally set up the embedding provider for semantic search.
-    const embCfg = this.config.options.kbIndex?.embeddings;
-    if (embCfg?.enabled) {
-      const pythonBin = embCfg.pythonBin ?? 'python3';
-      const model = embCfg.model ?? 'Qwen/Qwen3-Embedding-0.6B';
-      this.logger.info(`Embeddings enabled — ensuring Python deps (python: ${pythonBin}, model: ${model})`);
-      try {
-        await lore.ensurePythonDeps(pythonBin);
-      } catch (err) {
-        this.logger.warn(
-          `Failed to install Python embedding deps — embeddings will be skipped: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        );
-      }
-      this.embedder = new lore.SentenceTransformersProvider(model, pythonBin);
-      try {
-        await this.embedder.init();
-        this.logger.info(`Embedding model loaded — dims: ${this.embedder.dims}`);
-      } catch (err) {
-        this.logger.warn(
-          `Failed to initialise embedding model — embeddings will be skipped: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        );
-        try { await this.embedder.dispose(); } catch { /* ignore */ }
-        this.embedder = undefined;
-      }
-    }
-
-    const walkerConfig = { rootDir: sourceRoot };
-    const builder = new lore.IndexBuilder(this.kbDbPath, walkerConfig, this.embedder);
-
     // ── Fingerprint guard: skip re-indexing if the KB already matches ──
-    // Pass the same walkerConfig used by IndexBuilder so the fingerprints match.
+    // Perform this check BEFORE the expensive embedding initialisation so
+    // that resume runs that already have a valid KB exit in milliseconds
+    // rather than spending time loading Python / ML models.
+    const embCfg = this.config.options.kbIndex?.embeddings;
+    const embeddingModelName = embCfg?.enabled
+      ? (embCfg.model ?? 'Qwen/Qwen3-Embedding-0.6B')
+      : undefined;
+    const walkerConfig = { rootDir: sourceRoot };
     const currentFingerprint = computeSourceFingerprintCompat(
       lore,
       sourceRoot,
       walkerConfig as { includeGlobs?: string[]; excludeGlobs?: string[] },
-      this.embedder?.modelName,
+      embeddingModelName,
     );
     if (await fileExists(this.kbDbPath)) {
       try {
@@ -653,6 +627,38 @@ export class MigrationOrchestrator {
     }
 
     this.logger.info('Phase 0 rebuilt — source fingerprint changed or no existing KB');
+
+    // Optionally set up the embedding provider for semantic search.
+    // Only initialised when we actually need to rebuild the index.
+    if (embCfg?.enabled) {
+      const pythonBin = embCfg.pythonBin ?? 'python3';
+      const model = embeddingModelName!;
+      this.logger.info(`Embeddings enabled — ensuring Python deps (python: ${pythonBin}, model: ${model})`);
+      try {
+        await lore.ensurePythonDeps(pythonBin);
+      } catch (err) {
+        this.logger.warn(
+          `Failed to install Python embedding deps — embeddings will be skipped: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+      this.embedder = new lore.SentenceTransformersProvider(model, pythonBin);
+      try {
+        await this.embedder.init();
+        this.logger.info(`Embedding model loaded — dims: ${this.embedder.dims}`);
+      } catch (err) {
+        this.logger.warn(
+          `Failed to initialise embedding model — embeddings will be skipped: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        try { await this.embedder.dispose(); } catch { /* ignore */ }
+        this.embedder = undefined;
+      }
+    }
+
+    const builder = new lore.IndexBuilder(this.kbDbPath, walkerConfig, this.embedder);
 
     // Remove the stale DB before rebuilding.  vec0 virtual tables (symbol_embeddings)
     // do not support INSERT OR REPLACE — inserting a duplicate rowid raises a
@@ -748,6 +754,21 @@ export class MigrationOrchestrator {
   // ─── Phase 1: Impact Assessment ──────────────────────────────────────
 
   private async executePhase1(start: number): Promise<PhaseResult> {
+    // Defence-in-depth: if Phase 1 was already completed in a prior run,
+    // skip the agent launch.  The main loop's resume-skip should already
+    // handle this, but this guard protects against checkpoint regression.
+    const checkpointState = this.checkpoint.getState();
+    if (checkpointState.completedPhases.includes(1)) {
+      this.logger.info('Phase 1 skipped on resume — impact assessment already complete');
+      return {
+        phase: 1,
+        name: 'Impact Assessment',
+        success: true,
+        outputPath: this.legacyPaths.impactAssessmentFile,
+        duration: Date.now() - start,
+      };
+    }
+
     const contextFile = await this.contextBuilder.buildContext('impact-assessor', 1);
     const inv = this.buildInvocation('impact-assessor', contextFile, 1);
     const result = await this.launchAgentWithEvents(inv);
@@ -769,6 +790,23 @@ export class MigrationOrchestrator {
   // ─── Phase 2: Knowledge Base Construction ────────────────────────────
 
   private async executePhase2(start: number): Promise<PhaseResult> {
+    const outputPath = this.legacyPaths.knowledgeBaseDir;
+
+    // Defence-in-depth: if the knowledge-base directory already has content
+    // (e.g. from a previous run that completed Phase 2 but whose checkpoint
+    // was regressed by a Phase 0 re-run), skip the expensive agent launch.
+    const checkpointState = this.checkpoint.getState();
+    if (checkpointState.completedPhases.includes(2)) {
+      this.logger.info('Phase 2 skipped on resume — knowledge base already built');
+      return {
+        phase: 2,
+        name: 'Knowledge Base Construction',
+        success: true,
+        outputPath,
+        duration: Date.now() - start,
+      };
+    }
+
     // 1. Launch knowledge-builder
     const kbContext = await this.contextBuilder.buildContext('knowledge-builder', 2);
     const kbInv = this.buildInvocation('knowledge-builder', kbContext, 2);
@@ -787,7 +825,6 @@ export class MigrationOrchestrator {
       };
     }
 
-    const outputPath = this.legacyPaths.knowledgeBaseDir;
     return {
       phase: 2,
       name: 'Knowledge Base Construction',
@@ -796,8 +833,6 @@ export class MigrationOrchestrator {
       duration: Date.now() - start,
     };
   }
-
-  // ─── Phase 3: Migration Planning ─────────────────────────────────────
 
   private async executePhase3(start: number): Promise<PhaseResult> {
     const planningDir = this.paths.artifactsPlanningDir;
@@ -3390,6 +3425,8 @@ export class MigrationOrchestrator {
       tokensCompletion,
       tokensTotal,
       costUsd: costEstimate.total,
+      ...(result.tokenUsage?.cachedInput != null ? { cachedTokens: result.tokenUsage.cachedInput } : {}),
+      ...(result.tokenUsage?.premiumRequests != null ? { premiumRequests: result.tokenUsage.premiumRequests } : {}),
       ...(invocation.routingTier ? { routingTier: invocation.routingTier, routingReason: invocation.routingReason } : {}),
       ...(routingDecision ? { escalationCostUsd: routingDecision.incrementalCost } : {}),
     };

--- a/runtime/src/observability/metrics-collector.ts
+++ b/runtime/src/observability/metrics-collector.ts
@@ -36,6 +36,10 @@ export interface MetricsAggregate {
   retriesByPhase: Record<number, number>;
   totalTokens: number;
   totalCost: number;
+  /** Total cached input tokens across all invocations (when available). */
+  totalCachedTokens: number;
+  /** Total premium requests consumed across all invocations (Copilot only, when available). */
+  totalPremiumRequests: number;
   tokensByAgent: Record<string, number>;
   costByAgent: Record<string, number>;
   peakParallelInvocations: number;
@@ -171,6 +175,8 @@ export class MetricsCollector {
     let totalRetries = 0;
     let totalTokens = 0;
     let totalCost = 0;
+    let totalCachedTokens = 0;
+    let totalPremiumRequests = 0;
 
     const escalationsByTier: Record<string, number> = {};
     let escalationCount = 0;
@@ -183,6 +189,13 @@ export class MetricsCollector {
       costByAgent[m.agentType] = (costByAgent[m.agentType] ?? 0) + m.costUsd;
       totalTokens += m.tokensTotal;
       totalCost += m.costUsd;
+
+      if (m.cachedTokens != null) {
+        totalCachedTokens += m.cachedTokens;
+      }
+      if (m.premiumRequests != null) {
+        totalPremiumRequests += m.premiumRequests;
+      }
 
       if (m.wasRetry) {
         totalRetries++;
@@ -234,6 +247,8 @@ export class MetricsCollector {
       retriesByPhase,
       totalTokens,
       totalCost,
+      totalCachedTokens,
+      totalPremiumRequests,
       tokensByAgent,
       costByAgent,
       peakParallelInvocations: peak,

--- a/runtime/tests/cost-estimator.test.ts
+++ b/runtime/tests/cost-estimator.test.ts
@@ -107,11 +107,23 @@ describe('CostEstimator', () => {
 
   it('should include cached cost in total', () => {
     const result = estimator.estimate('claude-sonnet-4-5', 1_000_000, 1_000_000, 1_000_000);
-    // input = 3.00, output = 15.00, cached = 1.50
-    expect(result.input).toBe(3.00);
+    // All 1M prompt tokens are cached → input (non-cached) = 0, cached = 1.50, output = 15.00
+    expect(result.input).toBe(0);
     expect(result.output).toBe(15.00);
     expect(result.cached).toBeCloseTo(1.50, 10);
-    expect(result.total).toBeCloseTo(19.50, 10);
+    expect(result.total).toBeCloseTo(16.50, 10);
+  });
+
+  it('should correctly split cost between cached and non-cached input tokens', () => {
+    // 2M prompt tokens total, 1M of which are cached
+    const result = estimator.estimate('claude-sonnet-4-5', 2_000_000, 500_000, 1_000_000);
+    // non-cached input: 1M * $3/M = $3.00
+    // cached input: 1M * $3/M * 0.5 = $1.50
+    // output: 500K * $15/M = $7.50
+    expect(result.input).toBeCloseTo(3.00, 10);
+    expect(result.cached).toBeCloseTo(1.50, 10);
+    expect(result.output).toBeCloseTo(7.50, 10);
+    expect(result.total).toBeCloseTo(12.00, 10);
   });
 
   it('should return zero cached cost when cachedInputTokens is omitted', () => {

--- a/runtime/tests/fixtures/zstd-c-project/migration.config.json
+++ b/runtime/tests/fixtures/zstd-c-project/migration.config.json
@@ -30,7 +30,7 @@
     "maxParallelAgents": 8,
     "maxRetriesPerTask": 3,
     "maxLinesPerTask": 750,
-    "tokenBudget": 10000000,
+    "tokenBudget": 200000000,
     "executionMode": "wave-barrier",
     "waveControl": {
       "waveSize": 3,

--- a/runtime/tests/result-parser.test.ts
+++ b/runtime/tests/result-parser.test.ts
@@ -676,7 +676,7 @@ Breakdown by AI model:
     tokens_in: 5000, tokens_out: 1200, tokens_cached: 800, premium_requests_est: 1
 `;
       const usage = ResultParser.parseCopilotCliUsage(output);
-      expect(usage).toEqual({ prompt: 5000, completion: 1200, total: 6200, cachedInput: 800 });
+      expect(usage).toEqual({ prompt: 5000, completion: 1200, total: 6200, cachedInput: 800, premiumRequests: 1 });
     });
 
     it('should sum across multiple models', () => {
@@ -690,7 +690,7 @@ Breakdown by AI model:
     tokens_in: 2000, tokens_out: 600, premium_requests_est: 1
 `;
       const usage = ResultParser.parseCopilotCliUsage(output);
-      expect(usage).toEqual({ prompt: 6000, completion: 1600, total: 7600, cachedInput: 500 });
+      expect(usage).toEqual({ prompt: 6000, completion: 1600, total: 7600, cachedInput: 500, premiumRequests: 3 });
     });
 
     it('should parse numeric shorthand suffixes (k)', () => {
@@ -699,7 +699,7 @@ Breakdown by AI model:
     tokens_in: 41.3k, tokens_out: 2.1k, tokens_cached: 13.1k, premium_requests_est: 2
 `;
       const usage = ResultParser.parseCopilotCliUsage(output);
-      expect(usage).toEqual({ prompt: 41300, completion: 2100, total: 43400, cachedInput: 13100 });
+      expect(usage).toEqual({ prompt: 41300, completion: 2100, total: 43400, cachedInput: 13100, premiumRequests: 2 });
     });
 
     it('should parse numeric shorthand suffixes (m)', () => {
@@ -708,7 +708,7 @@ Breakdown by AI model:
     tokens_in: 2.5m, tokens_out: 0.5m, tokens_cached: 1m, premium_requests_est: 10
 `;
       const usage = ResultParser.parseCopilotCliUsage(output);
-      expect(usage).toEqual({ prompt: 2500000, completion: 500000, total: 3000000, cachedInput: 1000000 });
+      expect(usage).toEqual({ prompt: 2500000, completion: 500000, total: 3000000, cachedInput: 1000000, premiumRequests: 10 });
     });
 
     it('should handle singular "Premium request"', () => {
@@ -720,7 +720,7 @@ Breakdown by AI model:
     tokens_in: 3000, tokens_out: 500, premium_requests_est: 1
 `;
       const usage = ResultParser.parseCopilotCliUsage(output);
-      expect(usage).toEqual({ prompt: 3000, completion: 500, total: 3500 });
+      expect(usage).toEqual({ prompt: 3000, completion: 500, total: 3500, premiumRequests: 1 });
     });
 
     it('should handle plural "Premium requests"', () => {
@@ -732,7 +732,7 @@ Breakdown by AI model:
     tokens_in: 10000, tokens_out: 2000, tokens_cached: 500, premium_requests_est: 5
 `;
       const usage = ResultParser.parseCopilotCliUsage(output);
-      expect(usage).toEqual({ prompt: 10000, completion: 2000, total: 12000, cachedInput: 500 });
+      expect(usage).toEqual({ prompt: 10000, completion: 2000, total: 12000, cachedInput: 500, premiumRequests: 5 });
     });
 
     it('should return undefined for cachedInput when tokens_cached is absent', () => {
@@ -746,6 +746,7 @@ Breakdown by AI model:
       expect(usage?.completion).toBe(800);
       expect(usage?.total).toBe(2800);
       expect(usage?.cachedInput).toBeUndefined();
+      expect((usage as any)?.premiumRequests).toBe(1);
     });
 
     it('should return undefined when output has no Copilot CLI usage block', () => {
@@ -766,7 +767,7 @@ Breakdown by AI model:
     tokens_in:41.3k,tokens_out:2.1k,tokens_cached:13.1k,premium_requests_est:2
 `;
       const usage = ResultParser.parseCopilotCliUsage(output);
-      expect(usage).toEqual({ prompt: 41300, completion: 2100, total: 43400, cachedInput: 13100 });
+      expect(usage).toEqual({ prompt: 41300, completion: 2100, total: 43400, cachedInput: 13100, premiumRequests: 2 });
     });
 
     it('should parse latest footer format (in/out/cached)', () => {
@@ -778,7 +779,7 @@ Breakdown by AI model:
  claude-sonnet-4.6       87.6k in, 486 out, 43.0k cached (Est. 1 Premium request)
 `;
       const usage = ResultParser.parseCopilotCliUsage(output);
-      expect(usage).toEqual({ prompt: 87600, completion: 486, total: 88086, cachedInput: 43000 });
+      expect(usage).toEqual({ prompt: 87600, completion: 486, total: 88086, cachedInput: 43000, premiumRequests: 1 });
     });
 
     it('should parse latest footer format when cached is absent', () => {
@@ -786,7 +787,7 @@ Breakdown by AI model:
  gpt-5-mini              1.2k in, 210 out (Est. 1 Premium request)
 `;
       const usage = ResultParser.parseCopilotCliUsage(output);
-      expect(usage).toEqual({ prompt: 1200, completion: 210, total: 1410 });
+      expect(usage).toEqual({ prompt: 1200, completion: 210, total: 1410, premiumRequests: 1 });
     });
 
     it('should be case-insensitive for the breakdown header', () => {
@@ -795,7 +796,7 @@ Breakdown by AI model:
     tokens_in: 1000, tokens_out: 200, premium_requests_est: 1
 `;
       const usage = ResultParser.parseCopilotCliUsage(output);
-      expect(usage).toEqual({ prompt: 1000, completion: 200, total: 1200 });
+      expect(usage).toEqual({ prompt: 1000, completion: 200, total: 1200, premiumRequests: 1 });
     });
 
     it('should sum mixed shorthand and plain numbers across models', () => {
@@ -806,7 +807,7 @@ Breakdown by AI model:
     tokens_in: 2000, tokens_out: 0.5k, premium_requests_est: 1
 `;
       const usage = ResultParser.parseCopilotCliUsage(output);
-      expect(usage).toEqual({ prompt: 3500, completion: 800, total: 4300, cachedInput: 200 });
+      expect(usage).toEqual({ prompt: 3500, completion: 800, total: 4300, cachedInput: 200, premiumRequests: 2 });
     });
 
     it('should return undefined for empty string input', () => {
@@ -822,7 +823,7 @@ Breakdown by AI model:
     tokens_in: 3000, tokens_out: 500, premium_requests_est: 1
 `;
       const usage = ResultParser.parseTokenUsage(output, 'copilot-cli');
-      expect(usage).toEqual({ prompt: 3000, completion: 500, total: 3500 });
+      expect(usage).toEqual({ prompt: 3000, completion: 500, total: 3500, premiumRequests: 1 });
     });
 
     it('should return undefined via copilot-cli dispatch when no usage block', () => {
@@ -835,15 +836,16 @@ Breakdown by AI model:
   claude-sonnet-4-20250514:
     tokens_in: 5000, tokens_out: 1200, tokens_cached: 800, premium_requests_est: 1
 `;
-      const usage = ResultParser.parseTokenUsage(output, 'copilot-cli') as { prompt: number; completion: number; total: number; cachedInput?: number };
+      const usage = ResultParser.parseTokenUsage(output, 'copilot-cli') as { prompt: number; completion: number; total: number; cachedInput?: number; premiumRequests?: number };
       expect(usage).toBeDefined();
       expect(usage.cachedInput).toBe(800);
+      expect(usage.premiumRequests).toBe(1);
     });
 
     it('should not fall through to regex path when runtime is copilot-cli', () => {
       const output = 'prompt_tokens: 999\ncompletion_tokens: 111\nBreakdown by AI model:\n  m:\n    tokens_in: 100, tokens_out: 50, premium_requests_est: 1';
       const usage = ResultParser.parseTokenUsage(output, 'copilot-cli');
-      expect(usage).toEqual({ prompt: 100, completion: 50, total: 150 });
+      expect(usage).toEqual({ prompt: 100, completion: 50, total: 150, premiumRequests: 1 });
     });
 
     it('should parse latest footer format via copilot-cli dispatch', () => {
@@ -851,7 +853,7 @@ Breakdown by AI model:
  claude-sonnet-4.6       2.4k in, 100 out, 1.1k cached (Est. 1 Premium request)
 `;
       const usage = ResultParser.parseTokenUsage(output, 'copilot-cli');
-      expect(usage).toEqual({ prompt: 2400, completion: 100, total: 2500, cachedInput: 1100 });
+      expect(usage).toEqual({ prompt: 2400, completion: 100, total: 2500, cachedInput: 1100, premiumRequests: 1 });
     });
   });
 


### PR DESCRIPTION
## Summary

Track cached input tokens and premium request counts per agent invocation, surfacing them through the metrics collector and cost estimator.

### Changes

- **types.ts**: Add `cachedTokens` and `premiumRequests` fields to `InvocationMetric`; add `premiumRequests` to `AgentResult.tokenUsage`
- **result-parser.ts**: Parse `cachedInput` and `premiumRequests` from agent result token usage
- **orchestrator.ts**: Propagate cached token and premium request data through `recordTokens()` into invocation metrics
- **cost-estimator.ts**: Factor cached tokens into cost estimation (cached tokens are cheaper)
- **checkpoint.ts**: Persist cached token / premium request data in checkpoint state
- **metrics-collector.ts**: Aggregate cached tokens and premium requests in observability reports

### Testing

- Updated `cost-estimator.test.ts` with cached token cost scenarios
- Updated `result-parser.test.ts` for new token usage fields