### PR TITLE
refactor(paths): remove legacy runtime paths and unify on organized layout

### DIFF
--- a/.claude/agents/failure-adjudicator.md
+++ b/.claude/agents/failure-adjudicator.md
@@ -106,7 +106,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 {
   "agent": "failure-adjudicator",
   "status": "completed",
-  "outputFiles": ["src/auth/login.ts", ".aamf/migration/my-project/progress.md"],
+  "outputFiles": ["src/auth/login.ts", ".aamf/migration/my-project/reports/progress.md"],
   "taskId": "task-001",
   "recoveryStrategy": "direct-fix",
   "resolved": true,

--- a/.claude/agents/final-parity-checker.md
+++ b/.claude/agents/final-parity-checker.md
@@ -69,7 +69,7 @@ Per-task parity verification catches issues within individual files but can miss
 
 ## Output
 
-Write to `.aamf/migration/{projectName}/final-parity-report.md`
+Write to `.aamf/migration/{projectName}/artifacts/parity/final-parity-report.md`
 
 ## Sub-Agents
 
@@ -114,7 +114,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 {
   "agent": "final-parity-checker",
   "status": "completed",
-  "outputFiles": [".aamf/migration/my-project/final-parity-report.md"],
+  "outputFiles": [".aamf/migration/my-project/artifacts/parity/final-parity-report.md"],
   "overallParity": "partial",
   "missingFiles": 0,
   "stubsFound": 2,

--- a/.claude/agents/impact-assessor.md
+++ b/.claude/agents/impact-assessor.md
@@ -63,7 +63,7 @@ The context JSON contains:
 
 ## Output
 
-Write the full assessment to `.aamf/migration/{projectName}/impact-assessment.md`:
+Write the full assessment to `.aamf/migration/{projectName}/artifacts/impact-assessment.md`:
 
 ```markdown
 # Impact Assessment: {projectName}
@@ -151,7 +151,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 {
   "agent": "impact-assessor",
   "status": "completed",
-  "outputFiles": [".aamf/migration/my-project/impact-assessment.md"],
+  "outputFiles": [".aamf/migration/my-project/artifacts/impact-assessment.md"],
   "totalFiles": 84,
   "totalLoc": 12400,
   "riskCount": 5,

--- a/.claude/agents/migration-orchestrator.md
+++ b/.claude/agents/migration-orchestrator.md
@@ -35,18 +35,18 @@ The context JSON contains:
 ## Critical Design Principles
 
 1. **Out-of-Process Execution**: You NEVER execute migration work yourself. You launch each agent as a **headless, out-of-process CLI invocation** of the same model.
-2. **Checkpointing**: After every phase completion (and at key sub-phase boundaries), write checkpoint state to `checkpoints.json` so the migration can resume from any failure point.
+2. **Checkpointing**: After every phase completion (and at key sub-phase boundaries), write checkpoint state to `state/checkpoint.json` so the migration can resume from any failure point.
 3. **Context Window Discipline**: You must NOT load source code files into your context. You only read/write progress files, checkpoint state, and phase outputs (summaries, plans, reports). All heavy analysis is delegated to sub-agents.
 4. **Read-only agents may be parallelized**: Impact assessment, knowledge building, and analysis agents can run concurrently. Code-writing agents run serially.
 
 ## Migration Phases
 
-Execute these phases in order. On resume, skip completed phases (read from `checkpoints.json`).
+Execute these phases in order. On resume, skip completed phases (read from `state/checkpoint.json`).
 
 ### Phase 1: Impact Assessment & Cost Estimation
 - Launch: `impact-assessor`
 - Input: Source codebase path, target specification
-- Output: `.aamf/migration/{projectName}/impact-assessment.md`
+- Output: `.aamf/migration/{projectName}/artifacts/impact-assessment.md`
 - Parallelizable: YES (read-only)
 
 ### Phase 2: Investigation & Knowledge Base Construction
@@ -59,7 +59,7 @@ Execute these phases in order. On resume, skip completed phases (read from `chec
 - Launch: `migration-planner` (spawns multiple investigator instances)
 - Launch: `adjudicator` (to select the best plan from competing proposals)
 - Input: Knowledge base, impact assessment
-- Output: `.aamf/migration/{projectName}/migration-plan.md`
+- Output: `.aamf/migration/{projectName}/artifacts/planning/migration-plan.md`
 - **Important**: Structural decomposition should come from KB index tools; markdown KB should stay high-level.
 
 ### Phase 4: Code Migration (Iterative Loop)
@@ -75,7 +75,7 @@ Serial execution required for code-writing. Parity verification is read-only and
 ### Phase 5: Final Parity Check
 - Launch: `final-parity-checker`
 - Input: Entire migrated codebase + original codebase
-- Output: `.aamf/migration/{projectName}/final-parity-report.md`
+- Output: `.aamf/migration/{projectName}/artifacts/parity/final-parity-report.md`
 - If gaps/stubs/differences found → Loop back to Phase 4 for targeted fixes.
 
 ### Phase 6: End-to-End Test Crafting
@@ -106,7 +106,7 @@ Serial execution required for code-writing. Parity verification is read-only and
 
 ## Checkpointing Format
 
-`checkpoints.json`:
+`state/checkpoint.json`:
 ```json
 {
   "projectName": "...",
@@ -116,9 +116,9 @@ Serial execution required for code-writing. Parity verification is read-only and
   "completedTasks": ["module-user-model", "module-db-layer"],
   "failedTasks": [],
   "phaseOutputs": {
-    "1": "impact-assessment.md",
+    "1": "artifacts/impact-assessment.md",
     "2": "knowledge-base/",
-    "3": "migration-plan.md"
+    "3": "artifacts/planning/migration-plan.md"
   },
   "lastCheckpoint": "2026-02-21T10:30:00Z"
 }
@@ -126,7 +126,7 @@ Serial execution required for code-writing. Parity verification is read-only and
 
 ## Progress Tracking
 
-Update `.aamf/migration/{projectName}/progress.md` after every phase transition and significant sub-phase event. Include:
+Update `.aamf/migration/{projectName}/reports/progress.md` after every phase transition and significant sub-phase event. Include:
 - Current phase and task
 - Completion percentages
 - Any failures with timestamps
@@ -135,8 +135,8 @@ Update `.aamf/migration/{projectName}/progress.md` after every phase transition 
 ## Failure Handling
 
 When any agent invocation fails:
-1. Record the failure in `progress.md` with full context.
-2. Add the failed task to `failedTasks` in `checkpoints.json`.
+1. Record the failure in `reports/progress.md` with full context.
+2. Add the failed task to `failedTasks` in `state/checkpoint.json`.
 3. Launch `failure-adjudicator` agent with the failure context.
 4. `failure-adjudicator` will produce a fix plan (potentially with reduced scope).
 5. Re-attempt the failed task with the fix plan.
@@ -145,7 +145,7 @@ When any agent invocation fails:
 ## Context Window Management
 
 - **Never load source code** — delegate all code reading to sub-agents.
-- Only maintain: progress.md, checkpoints.json, phase output summaries.
+- Only maintain: reports/progress.md, state/checkpoint.json, phase output summaries.
 - When passing context to sub-agents, provide only the relevant slice.
 - Use file references (paths) instead of inline content wherever possible.
 
@@ -159,7 +159,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 {
   "agent": "migration-orchestrator",
   "status": "<completed | failed | needs-review>",
-  "outputFiles": ["<paths to progress.md and checkpoints.json updated>"],
+  "outputFiles": ["<paths to reports/progress.md and state/checkpoint.json updated>"],
   "currentPhase": 0,
   "completedTasks": ["<task-NNN>"],
   "failedTasks": ["<task-NNN>"],
@@ -175,8 +175,8 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
   "agent": "migration-orchestrator",
   "status": "completed",
   "outputFiles": [
-    ".aamf/migration/my-project/progress.md",
-    ".aamf/migration/my-project/checkpoints.json"
+    ".aamf/migration/my-project/reports/progress.md",
+    ".aamf/migration/my-project/state/checkpoint.json"
   ],
   "currentPhase": 7,
   "completedTasks": ["task-001", "task-002", "task-003"],

--- a/.claude/agents/migration-planner.md
+++ b/.claude/agents/migration-planner.md
@@ -18,7 +18,7 @@ You are the **Migration Planner** — responsible for creating a comprehensive, 
 
 In the current AAMF runtime, Phase 3 is split into two steps:
 
-1. **Step 3a (this agent)** emits planning artifacts under `.aamf/migration/{projectName}/planning/`
+1. **Step 3a (this agent)** emits planning artifacts under `.aamf/migration/{projectName}/artifacts/planning/`
 2. **Step 3b (runtime)** launches `task-decomposer` in parallel per module group
 
 You must produce Step 3a artifacts and **must not** launch sub-agents directly.
@@ -44,13 +44,13 @@ The context JSON contains:
 ## Responsibilities
 
 1. **Analyze Inputs**
-   - Read the impact assessment (`.aamf/migration/{projectName}/impact-assessment.md`)
+   - Read the impact assessment (`.aamf/migration/{projectName}/artifacts/impact-assessment.md`)
    - Read the knowledge base index (`.aamf/migration/{projectName}/knowledge-base/index.md`)
 
 2. **Generate Competing Plans**
    - Produce **at least 2 competing migration strategies** (e.g., bottom-up vs top-down, by-module vs by-layer).
   - Each strategy should include: rationale, task ordering, risk analysis, estimated relative effort.
-  - Persist all alternatives in `.aamf/migration/{projectName}/competing-strategies.md`.
+  - Persist all alternatives in `.aamf/migration/{projectName}/artifacts/planning/competing-strategies.md`.
   - **Requirement:** if more than one viable strategy exists, this file is mandatory.
   - Runtime uses this file as the adjudication trigger.
 
@@ -59,17 +59,17 @@ The context JSON contains:
   - Runtime decides whether to invoke `adjudicator` based on artifact presence.
 
 4. **Emit Planning Artifacts for Step 3b**
-  - Write `.aamf/migration/{projectName}/planning/groups.json` with module groups.
-  - Write `.aamf/migration/{projectName}/planning/strategy.md` with decomposition guidance.
+  - Write `.aamf/migration/{projectName}/artifacts/planning/groups.json` with module groups.
+  - Write `.aamf/migration/{projectName}/artifacts/planning/strategy.md` with decomposition guidance.
   - Do not emit `tasks-<group>.json`; those are produced by runtime-launched `task-decomposer` agents.
 
 ## Output
 
 Write these files:
 
-1. `.aamf/migration/{projectName}/planning/groups.json`
-2. `.aamf/migration/{projectName}/planning/strategy.md`
-3. Optional: `.aamf/migration/{projectName}/competing-strategies.md`
+1. `.aamf/migration/{projectName}/artifacts/planning/groups.json`
+2. `.aamf/migration/{projectName}/artifacts/planning/strategy.md`
+3. Optional: `.aamf/migration/{projectName}/artifacts/planning/competing-strategies.md`
 
 `competing-strategies.md` requirement:
 - If only one viable strategy exists, omission is allowed.
@@ -169,9 +169,9 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
   "agent": "migration-planner",
   "status": "completed",
   "outputFiles": [
-    ".aamf/migration/my-project/planning/groups.json",
-    ".aamf/migration/my-project/planning/strategy.md",
-    ".aamf/migration/my-project/competing-strategies.md"
+    ".aamf/migration/my-project/artifacts/planning/groups.json",
+    ".aamf/migration/my-project/artifacts/planning/strategy.md",
+    ".aamf/migration/my-project/artifacts/planning/competing-strategies.md"
   ],
   "groupCount": 7,
   "strategy": "bottom-up-dependency-first",

--- a/.claude/agents/migration-runner.md
+++ b/.claude/agents/migration-runner.md
@@ -42,8 +42,8 @@ The context JSON contains:
 
 2. **Initialize Progress Tracking**
    - Create the progress directory at `.aamf/migration/{projectName}/` if it does not exist.
-   - Create the initial `progress.md` file with migration metadata.
-   - Create `checkpoints.json` to track orchestrator checkpoint state.
+   - Create the initial `reports/progress.md` file with migration metadata.
+   - Create `state/checkpoint.json` to track orchestrator checkpoint state.
 
 3. **Launch the Migration Orchestrator**
    - Invoke the `migration-orchestrator` agent with the migration configuration and progress directory path.
@@ -60,7 +60,7 @@ The context JSON contains:
 
 ## Progress File Initialization
 
-Initialize `.aamf/migration/{projectName}/progress.md` with:
+Initialize `.aamf/migration/{projectName}/reports/progress.md` with:
 
 ```markdown
 # Migration Progress: {projectName}
@@ -76,7 +76,7 @@ Initialize `.aamf/migration/{projectName}/progress.md` with:
 |-------|--------|---------|-----------|-------|
 ```
 
-Initialize `.aamf/migration/{projectName}/checkpoints.json` with:
+Initialize `.aamf/migration/{projectName}/state/checkpoint.json` with:
 
 ```json
 {
@@ -93,7 +93,7 @@ Initialize `.aamf/migration/{projectName}/checkpoints.json` with:
 
 ## Error Handling
 
-- If configuration validation fails, write the error to progress.md and terminate with a clear message.
+- If configuration validation fails, write the error to reports/progress.md and terminate with a clear message.
 - If the orchestrator invocation fails to launch, retry once. On second failure, record the error and terminate.
 - Never attempt to perform migration work yourself — always delegate to the orchestrator.
 
@@ -113,7 +113,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 {
   "agent": "migration-runner",
   "status": "<completed | failed | needs-review>",
-  "outputFiles": ["<paths to progress.md and checkpoints.json initialized>"],
+  "outputFiles": ["<paths to reports/progress.md and state/checkpoint.json initialized>"],
   "projectName": "<project name>",
   "orchestratorLaunched": true,
   "notes": "<brief summary of initialization and any validation issues>"
@@ -127,8 +127,8 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
   "agent": "migration-runner",
   "status": "completed",
   "outputFiles": [
-    ".aamf/migration/my-project/progress.md",
-    ".aamf/migration/my-project/checkpoints.json"
+    ".aamf/migration/my-project/reports/progress.md",
+    ".aamf/migration/my-project/state/checkpoint.json"
   ],
   "projectName": "my-project",
   "orchestratorLaunched": true,

--- a/.claude/agents/parity-verifier.md
+++ b/.claude/agents/parity-verifier.md
@@ -59,7 +59,7 @@ The context JSON contains:
 
 ## Output
 
-Write to `.aamf/migration/{projectName}/parity-reports/task-{taskId}.md` and also write a structured JSON result file at:
+Write to `.aamf/migration/{projectName}/artifacts/parity/task-{taskId}.md` and also write a structured JSON result file at:
 
 ```
 .aamf/migration/{projectName}/results/parity-verifier-{taskId}.result.json
@@ -72,7 +72,7 @@ The JSON must conform to this schema:
   "taskId": "task-001",
   "agent": "parity-verifier",
   "status": "completed",
-  "outputFiles": ["parity-reports/task-001.md"],
+  "outputFiles": ["artifacts/parity/task-001.md"],
   "parity": "pass",
   "issues": [
     {
@@ -134,7 +134,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 {
   "agent": "parity-verifier",
   "status": "completed",
-  "outputFiles": ["parity-reports/task-001.md"],
+  "outputFiles": ["artifacts/parity/task-001.md"],
   "taskId": "task-001",
   "parity": "partial",
   "issues": [

--- a/.github/agents/code-migrator.agent.md
+++ b/.github/agents/code-migrator.agent.md
@@ -85,7 +85,7 @@ After writing migrated code:
 
 ## Output
 
-Update `.aamf/migration/{projectName}/progress.md` with task result:
+Update `.aamf/migration/{projectName}/reports/progress.md` with task result:
 
 ```markdown
 ### Task {id}: {name}

--- a/.github/agents/e2e-test-crafter.agent.md
+++ b/.github/agents/e2e-test-crafter.agent.md
@@ -88,7 +88,7 @@ Each suite brief in the test plan should follow this template:
 
 1. `.aamf/migration/{projectName}/e2e-test-plan.md` — the full test strategy and suite briefs
 2. Test files in the target project's test directory (written by `test-writer` sub-agents)
-3. Update `.aamf/migration/{projectName}/progress.md`:
+3. Update `.aamf/migration/{projectName}/reports/progress.md`:
 
 ```markdown
 ## End-to-End Tests

--- a/.github/agents/final-parity-checker.agent.md
+++ b/.github/agents/final-parity-checker.agent.md
@@ -52,7 +52,7 @@ Per-task parity verification catches issues within individual files but can miss
 
 ## Output
 
-Write to `.aamf/migration/{projectName}/final-parity-report.md`:
+Write to `.aamf/migration/{projectName}/artifacts/parity/final-parity-report.md`:
 
 ```markdown
 # Final Parity Report: {projectName}
@@ -149,7 +149,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 {
   "agent": "final-parity-checker",
   "status": "completed",
-  "outputFiles": [".aamf/migration/my-project/final-parity-report.md"],
+  "outputFiles": [".aamf/migration/my-project/artifacts/parity/final-parity-report.md"],
   "missingFiles": 0,
   "stubsFound": 2,
   "buildPassed": true,

--- a/.github/agents/idiomatic-reviewer.agent.md
+++ b/.github/agents/idiomatic-reviewer.agent.md
@@ -75,7 +75,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 {
   "agent": "idiomatic-reviewer",
   "status": "completed",
-  "outputFiles": [".aamf/migration/my-project/idiomatic-review-report.md"],
+  "outputFiles": [".aamf/migration/my-project/artifacts/parity/idiomatic-review-report.md"],
   "issuesFound": 5,
   "notes": "Found 5 non-idiomatic patterns; most are direct transliterations of source language constructs."
 }

--- a/.github/agents/impact-assessor.agent.md
+++ b/.github/agents/impact-assessor.agent.md
@@ -45,7 +45,7 @@ When KB index tooling is available, treat it as the authoritative source of stru
 
 ## Output
 
-Write the full assessment to `.aamf/migration/{projectName}/impact-assessment.md`:
+Write the full assessment to `.aamf/migration/{projectName}/artifacts/impact-assessment.md`:
 
 ```markdown
 # Impact Assessment: {projectName}
@@ -126,7 +126,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 {
   "agent": "impact-assessor",
   "status": "completed",
-  "outputFiles": [".aamf/migration/my-project/impact-assessment.md"],
+  "outputFiles": [".aamf/migration/my-project/artifacts/impact-assessment.md"],
   "totalFiles": 84,
   "totalLoc": 12400,
   "riskCount": 5,

--- a/.github/agents/migration-orchestrator.agent.md
+++ b/.github/agents/migration-orchestrator.agent.md
@@ -11,18 +11,18 @@ You are the **Migration Orchestrator** — the central coordinator for large-sca
 ## Critical Design Principles
 
 1. **Out-of-Process Execution**: You NEVER execute migration work yourself. You launch each agent as a **headless, out-of-process CLI invocation** of the same model.
-2. **Checkpointing**: After every phase completion (and at key sub-phase boundaries), write checkpoint state to `checkpoints.json` so the migration can resume from any failure point.
+2. **Checkpointing**: After every phase completion (and at key sub-phase boundaries), write checkpoint state to `state/checkpoint.json` so the migration can resume from any failure point.
 3. **Context Window Discipline**: You must NOT load source code files into your context. You only read/write progress files, checkpoint state, and phase outputs (summaries, plans, reports). All heavy analysis is delegated to sub-agents.
 4. **Read-only agents may be parallelized**: Impact assessment, knowledge building, and analysis agents can run concurrently. Code-writing agents run serially.
 
 ## Migration Phases
 
-Execute these phases in order. On resume, skip completed phases (read from `checkpoints.json`).
+Execute these phases in order. On resume, skip completed phases (read from `state/checkpoint.json`).
 
 ### Phase 1: Impact Assessment & Cost Estimation
 - Launch: `impact-assessor`
 - Input: Source codebase path, target specification
-- Output: `.aamf/migration/{projectName}/impact-assessment.md`
+- Output: `.aamf/migration/{projectName}/artifacts/impact-assessment.md`
 - Parallelizable: YES (read-only)
 
 ### Phase 2: Investigation & Knowledge Base Construction
@@ -35,7 +35,7 @@ Execute these phases in order. On resume, skip completed phases (read from `chec
 - Launch: `migration-planner` (spawns multiple investigator instances)
 - Launch: `adjudicator` (to select the best plan from competing proposals)
 - Input: Knowledge base, impact assessment
-- Output: `.aamf/migration/{projectName}/migration-plan.md`
+- Output: `.aamf/migration/{projectName}/artifacts/planning/migration-plan.md`
 - **Important**: Structural decomposition should come from KB index tools; markdown KB should stay high-level.
 
 ### Phase 4: Code Migration (Iterative Loop)
@@ -51,7 +51,7 @@ Serial execution required for code-writing. Parity verification is read-only and
 ### Phase 5: Final Parity Check
 - Launch: `final-parity-checker`
 - Input: Entire migrated codebase + original codebase
-- Output: `.aamf/migration/{projectName}/final-parity-report.md`
+- Output: `.aamf/migration/{projectName}/artifacts/parity/final-parity-report.md`
 - If gaps/stubs/differences found → Loop back to Phase 4 for targeted fixes.
 
 ### Phase 6: End-to-End Test Crafting
@@ -93,7 +93,7 @@ copilot --agent <agent-name> \
 
 ## Checkpointing Format
 
-`checkpoints.json`:
+`state/checkpoint.json`:
 ```json
 {
   "projectName": "...",
@@ -103,9 +103,9 @@ copilot --agent <agent-name> \
   "completedTasks": ["module-user-model", "module-db-layer"],
   "failedTasks": [],
   "phaseOutputs": {
-    "1": "impact-assessment.md",
+    "1": "artifacts/impact-assessment.md",
     "2": "knowledge-base/",
-    "3": "migration-plan.md"
+    "3": "artifacts/planning/migration-plan.md"
   },
   "lastCheckpoint": "2026-02-21T10:30:00Z"
 }
@@ -113,7 +113,7 @@ copilot --agent <agent-name> \
 
 ## Progress Tracking
 
-Update `.aamf/migration/{projectName}/progress.md` after every phase transition and significant sub-phase event. Include:
+Update `.aamf/migration/{projectName}/reports/progress.md` after every phase transition and significant sub-phase event. Include:
 - Current phase and task
 - Completion percentages
 - Any failures with timestamps
@@ -122,8 +122,8 @@ Update `.aamf/migration/{projectName}/progress.md` after every phase transition 
 ## Failure Handling
 
 When any agent invocation fails:
-1. Record the failure in `progress.md` with full context.
-2. Add the failed task to `failedTasks` in `checkpoints.json`.
+1. Record the failure in `reports/progress.md` with full context.
+2. Add the failed task to `failedTasks` in `state/checkpoint.json`.
 3. Launch `failure-adjudicator` agent with the failure context.
 4. `failure-adjudicator` will produce a fix plan (potentially with reduced scope).
 5. Re-attempt the failed task with the fix plan.
@@ -132,7 +132,7 @@ When any agent invocation fails:
 ## Context Window Management
 
 - **Never load source code** — delegate all code reading to sub-agents.
-- Only maintain: progress.md, checkpoints.json, phase output summaries (impact report, knowledge base index, migration plan).
+- Only maintain: reports/progress.md, state/checkpoint.json, phase output summaries (impact report, knowledge base index, migration plan).
 - When passing context to sub-agents, provide only the relevant slice (e.g., for a code-migrator task, pass only that task's plan section and relevant knowledge base entries, not the entire knowledge base).
 - Use file references (paths) instead of inline content wherever possible.
 
@@ -146,7 +146,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 {
   "agent": "migration-orchestrator",
   "status": "<completed | failed | needs-review>",
-  "outputFiles": ["<paths to progress.md and checkpoints.json updated>"],
+  "outputFiles": ["<paths to reports/progress.md and state/checkpoint.json updated>"],
   "currentPhase": 0,
   "completedTasks": ["<task-NNN>"],
   "failedTasks": ["<task-NNN>"],
@@ -162,8 +162,8 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
   "agent": "migration-orchestrator",
   "status": "completed",
   "outputFiles": [
-    ".aamf/migration/my-project/progress.md",
-    ".aamf/migration/my-project/checkpoints.json"
+    ".aamf/migration/my-project/reports/progress.md",
+    ".aamf/migration/my-project/state/checkpoint.json"
   ],
   "currentPhase": 7,
   "completedTasks": ["task-001", "task-002", "task-003"],

--- a/.github/agents/migration-planner.agent.md
+++ b/.github/agents/migration-planner.agent.md
@@ -12,7 +12,7 @@ You are the **Migration Planner** — responsible for creating a comprehensive, 
 
 In the current AAMF runtime, Phase 3 is split into two steps:
 
-1. **Step 3a (this agent)** emits planning artifacts under `.aamf/migration/{projectName}/planning/`
+1. **Step 3a (this agent)** emits planning artifacts under `.aamf/migration/{projectName}/artifacts/planning/`
 2. **Step 3b (runtime)** launches `task-decomposer` in parallel per module group
 
 You must therefore focus on producing Phase 3a artifacts and **must not** launch sub-agents directly.
@@ -24,7 +24,7 @@ When KB index tooling is available, treat it as the authoritative source of stru
 ## Responsibilities
 
 1. **Analyze Inputs**
-   - Read the impact assessment (`.aamf/migration/{projectName}/impact-assessment.md`)
+   - Read the impact assessment (`.aamf/migration/{projectName}/artifacts/impact-assessment.md`)
    - Read the knowledge base index (`.aamf/migration/{projectName}/knowledge-base/index.md`)
    - Understand module dependencies, complexity ratings, and risk factors
   - Use KB tooling for authoritative dependency/symbol detail when available
@@ -33,8 +33,8 @@ When KB index tooling is available, treat it as the authoritative source of stru
   - Produce **at least 2 competing migration strategies** (e.g., bottom-up vs top-down, by-module vs by-layer, risk-first vs dependency-first).
   - Each strategy should include rationale, ordering, key risks, and effort trade-offs.
   - Persist candidate strategies into a single canonical file:
-    - `.aamf/migration/{projectName}/competing-strategies.md`
-  - **Requirement:** if more than one viable strategy exists, you **must** write `.aamf/migration/{projectName}/competing-strategies.md`.
+    - `.aamf/migration/{projectName}/artifacts/planning/competing-strategies.md`
+  - **Requirement:** if more than one viable strategy exists, you **must** write `.aamf/migration/{projectName}/artifacts/planning/competing-strategies.md`.
   - Runtime uses this file as the adjudication trigger.
 
 3. **Select or Prepare Final Strategy (No Agent Launching)**
@@ -42,17 +42,17 @@ When KB index tooling is available, treat it as the authoritative source of stru
   - **Do not invoke `adjudicator` yourself.** The runtime orchestrator owns agent launching.
 
 4. **Emit Planning Artifacts for Step 3b**
-  - Write `.aamf/migration/{projectName}/planning/groups.json` with module groups and their analysis files.
-  - Write `.aamf/migration/{projectName}/planning/strategy.md` with the selected strategy guidance used by `task-decomposer`.
+  - Write `.aamf/migration/{projectName}/artifacts/planning/groups.json` with module groups and their analysis files.
+  - Write `.aamf/migration/{projectName}/artifacts/planning/strategy.md` with the selected strategy guidance used by `task-decomposer`.
   - Do **not** emit per-task decomposition outputs (`tasks-<group>.json`) — those are produced by `task-decomposer` in runtime Step 3b.
 
 ## Output
 
 Write these files:
 
-1. `.aamf/migration/{projectName}/planning/groups.json`
-2. `.aamf/migration/{projectName}/planning/strategy.md`
-3. Optional: `.aamf/migration/{projectName}/competing-strategies.md` (when multiple viable strategies exist)
+1. `.aamf/migration/{projectName}/artifacts/planning/groups.json`
+2. `.aamf/migration/{projectName}/artifacts/planning/strategy.md`
+3. Optional: `.aamf/migration/{projectName}/artifacts/planning/competing-strategies.md` (when multiple viable strategies exist)
 
 `competing-strategies.md` requirement:
 - If only one viable strategy exists, omission is allowed.
@@ -147,9 +147,9 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
   "agent": "migration-planner",
   "status": "completed",
   "outputFiles": [
-    ".aamf/migration/my-project/planning/groups.json",
-    ".aamf/migration/my-project/planning/strategy.md",
-    ".aamf/migration/my-project/competing-strategies.md"
+    ".aamf/migration/my-project/artifacts/planning/groups.json",
+    ".aamf/migration/my-project/artifacts/planning/strategy.md",
+    ".aamf/migration/my-project/artifacts/planning/competing-strategies.md"
   ],
   "groupCount": 7,
   "strategy": "bottom-up-dependency-first",

--- a/.github/agents/migration-runner.agent.md
+++ b/.github/agents/migration-runner.agent.md
@@ -18,8 +18,8 @@ You are the **Migration Runner** — the top-level entry point for large-scale l
 
 2. **Initialize Progress Tracking**
    - Create the progress directory at `.aamf/migration/{projectName}/` if it does not exist.
-   - Create the initial `progress.md` file with migration metadata (start time, source path, target, status: "initializing").
-   - Create `checkpoints.json` to track orchestrator checkpoint state.
+   - Create the initial `reports/progress.md` file with migration metadata (start time, source path, target, status: "initializing").
+   - Create `state/checkpoint.json` to track orchestrator checkpoint state.
 
 3. **Launch the Migration Orchestrator**
    - Invoke the orchestrator as a **headless, out-of-process CLI invocation** of the same model.
@@ -47,7 +47,7 @@ You are the **Migration Runner** — the top-level entry point for large-scale l
 
 ## Progress File Format
 
-Initialize `.aamf/migration/{projectName}/progress.md` with:
+Initialize `.aamf/migration/{projectName}/reports/progress.md` with:
 
 ```markdown
 # Migration Progress: {projectName}
@@ -65,7 +65,7 @@ Initialize `.aamf/migration/{projectName}/progress.md` with:
 
 ## Error Handling
 
-- If configuration validation fails, write the error to progress.md and terminate with a clear message.
+- If configuration validation fails, write the error to reports/progress.md and terminate with a clear message.
 - If the orchestrator CLI invocation fails to launch, retry once. On second failure, record the error and terminate.
 - Never attempt to perform migration work yourself — always delegate to the orchestrator.
 
@@ -79,7 +79,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 {
   "agent": "migration-runner",
   "status": "<completed | failed | needs-review>",
-  "outputFiles": ["<paths to progress.md and checkpoints.json initialized>"],
+  "outputFiles": ["<paths to reports/progress.md and state/checkpoint.json initialized>"],
   "projectName": "<name of the migration project>",
   "orchestratorLaunched": true,
   "notes": "<any validation errors or startup issues>"
@@ -93,8 +93,8 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
   "agent": "migration-runner",
   "status": "completed",
   "outputFiles": [
-    ".aamf/migration/my-project/progress.md",
-    ".aamf/migration/my-project/checkpoints.json"
+    ".aamf/migration/my-project/reports/progress.md",
+    ".aamf/migration/my-project/state/checkpoint.json"
   ],
   "projectName": "my-project",
   "orchestratorLaunched": true,

--- a/.github/agents/parity-verifier.agent.md
+++ b/.github/agents/parity-verifier.agent.md
@@ -44,7 +44,7 @@ When KB index tooling is available, treat it as the authoritative source of stru
 
 ## Output
 
-Write to `.aamf/migration/{projectName}/parity-reports/task-{taskId}.md`:
+Write to `.aamf/migration/{projectName}/artifacts/parity/task-{taskId}.md`:
 
 ```markdown
 # Parity Report: Task {taskId}
@@ -116,7 +116,7 @@ The JSON must conform to this schema:
   "taskId": "task-001",
   "agent": "parity-verifier",
   "status": "completed",
-  "outputFiles": ["parity-reports/task-001.md"],
+  "outputFiles": ["artifacts/parity/task-001.md"],
   "parity": "pass",
   "issues": [
     {
@@ -174,7 +174,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 {
   "agent": "parity-verifier",
   "status": "completed",
-  "outputFiles": ["parity-reports/task-001.md"],
+  "outputFiles": ["artifacts/parity/task-001.md"],
   "taskId": "task-001",
   "parity": "partial",
   "issues": [

--- a/.github/agents/task-decomposer.agent.md
+++ b/.github/agents/task-decomposer.agent.md
@@ -29,7 +29,7 @@ When KB index tooling is available, treat it as the authoritative source of stru
 3. Keep tasks atomic, independently executable, and verifiable.
 4. Prefer KB index-derived dependency/symbol evidence when determining task boundaries and line ranges.
 5. Write the task list to:
-   - `.aamf/migration/{projectName}/planning/tasks-{groupId}.json`
+   - `.aamf/migration/{projectName}/artifacts/planning/tasks-{groupId}.json`
 
 ## Task JSON Schema
 
@@ -51,7 +51,7 @@ The same schema path is also provided in `inputFiles` so it is available even wh
 
 Your response must end with a fenced `aamf-json` code block and it must be the **last fenced block**.
 
-The file `.aamf/migration/{projectName}/planning/tasks-{groupId}.json` is the single source of truth for task payload. Do not duplicate task objects in stdout metadata.
+The file `.aamf/migration/{projectName}/artifacts/planning/tasks-{groupId}.json` is the single source of truth for task payload. Do not duplicate task objects in stdout metadata.
 
 ### Schema
 
@@ -60,7 +60,7 @@ The file `.aamf/migration/{projectName}/planning/tasks-{groupId}.json` is the si
   "agent": "task-decomposer",
   "status": "<completed | failed | needs-review>",
   "taskId": "<groupId>",
-  "outputFiles": [".aamf/migration/{projectName}/planning/tasks-{groupId}.json"],
+  "outputFiles": [".aamf/migration/{projectName}/artifacts/planning/tasks-{groupId}.json"],
   "taskCount": 0,
   "notes": "<brief decomposition summary>"
 }
@@ -78,7 +78,7 @@ The file `.aamf/migration/{projectName}/planning/tasks-{groupId}.json` is the si
   "agent": "task-decomposer",
   "status": "completed",
   "taskId": "core",
-  "outputFiles": [".aamf/migration/my-project/planning/tasks-core.json"],
+  "outputFiles": [".aamf/migration/my-project/artifacts/planning/tasks-core.json"],
   "taskCount": 8,
   "notes": "Decomposed core group into 8 tasks with no dependency cycles."
 }

--- a/runtime/src/agents/context-builder.ts
+++ b/runtime/src/agents/context-builder.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 import { AgentName, AgentContext } from './types.js';
 import { MigrationConfig } from '../config/schema.js';
 import { writeJson, ensureDir } from '../util/fs.js';
-import { buildLegacyRuntimePaths } from '../core/runtime-paths.js';
+import type { RuntimePaths } from '../core/runtime-paths.js';
 
 const TASK_DECOMPOSER_SCHEMA_PATH = fileURLToPath(
   new URL('./task-decomposer.tasks.schema.json', import.meta.url),
@@ -27,10 +27,10 @@ export interface ContextBuildOptions {
  * set of input files, an output path, and an optional payload.
  */
 export class ContextBuilder {
-  private readonly legacyPaths: ReturnType<typeof buildLegacyRuntimePaths>;
+  private readonly paths: RuntimePaths;
 
-  constructor(private config: MigrationConfig, private progressDir: string) {
-    this.legacyPaths = buildLegacyRuntimePaths(progressDir);
+  constructor(private config: MigrationConfig, private progressDir: string, paths: RuntimePaths) {
+    this.paths = paths;
   }
 
   /**
@@ -149,9 +149,9 @@ export class ContextBuilder {
     taskId?: string,
     payload?: Record<string, unknown>,
   ): { inputFiles: string[]; outputPath: string; agentPayload?: Record<string, unknown> } {
-    const kbDir = this.legacyPaths.knowledgeBaseDir;
-    const impactAssessment = this.legacyPaths.impactAssessmentFile;
-    const migrationPlan = this.legacyPaths.migrationPlanFile;
+    const kbDir = this.paths.knowledgeBaseDir;
+    const impactAssessment = this.paths.impactAssessmentFile;
+    const migrationPlan = this.paths.migrationPlanFile;
     const src = this.config.source.path;
     const out = this.config.target.outputPath;
     const remediationContext = this.getRemediationContext(payload);

--- a/runtime/src/agents/result-parser.ts
+++ b/runtime/src/agents/result-parser.ts
@@ -3,7 +3,6 @@ import { join } from 'node:path';
 import { z } from 'zod';
 import { MigrationTask } from './types.js';
 import { fileExists, readJson } from '../util/fs.js';
-import { buildLegacyRuntimePaths } from '../core/runtime-paths.js';
 
 export const MISSING_BLOCK_ERROR = 'missing aamf-json block';
 
@@ -243,12 +242,8 @@ export class ResultParser {
     agent: string,
     taskId: string,
   ): Promise<TaskResult | undefined> {
-    const normalizedPath = join(progressDir, 'artifacts', 'results', `${agent}-${taskId}.result.json`);
-    const legacyPath = join(buildLegacyRuntimePaths(progressDir).resultsDir, `${agent}-${taskId}.result.json`);
-    const sidecarPath = await fileExists(normalizedPath)
-      ? normalizedPath
-      : (await fileExists(legacyPath) ? legacyPath : undefined);
-    if (!sidecarPath) return undefined;
+    const sidecarPath = join(progressDir, 'artifacts', 'results', `${agent}-${taskId}.result.json`);
+    if (!(await fileExists(sidecarPath))) return undefined;
     try {
       const raw = await readJson<unknown>(sidecarPath);
       return TaskResultSchema.parse(raw);

--- a/runtime/src/core/checkpoint.ts
+++ b/runtime/src/core/checkpoint.ts
@@ -2,7 +2,6 @@ import { readFile } from 'node:fs/promises';
 import { atomicWrite, ensureDir, fileExists, readJson, writeJson } from '../util/fs.js';
 import { Logger } from '../logging/logger.js';
 import type { TerminalReasonCode } from '../agents/types.js';
-import { buildLegacyRuntimePaths } from './runtime-paths.js';
 
 export interface TerminalExhaustionState {
   reasonCode: TerminalReasonCode;
@@ -118,17 +117,12 @@ export class CheckpointManager {
   private state: CheckpointState | null = null;
   private readonly checkpointPath: string;
   private readonly backupPath: string;
-  private readonly legacyCheckpointPath: string;
-  private readonly legacyBackupPath: string;
   private readonly stateDir: string;
 
   constructor(private readonly progressDir: string, private readonly logger: Logger) {
     this.stateDir = `${progressDir}/state`;
-    const legacyPaths = buildLegacyRuntimePaths(progressDir);
     this.checkpointPath = `${this.stateDir}/checkpoint.json`;
     this.backupPath = `${this.stateDir}/checkpoint.backup.json`;
-    this.legacyCheckpointPath = legacyPaths.checkpointFile;
-    this.legacyBackupPath = legacyPaths.checkpointBackupFile;
   }
 
   /** Read the current checkpoint, or create initial state */
@@ -398,18 +392,12 @@ export class CheckpointManager {
     if (await fileExists(this.checkpointPath)) {
       return this.checkpointPath;
     }
-    if (await fileExists(this.legacyCheckpointPath)) {
-      return this.legacyCheckpointPath;
-    }
     return undefined;
   }
 
   private async resolveBackupReadPath(): Promise<string | undefined> {
     if (await fileExists(this.backupPath)) {
       return this.backupPath;
-    }
-    if (await fileExists(this.legacyBackupPath)) {
-      return this.legacyBackupPath;
     }
     return undefined;
   }

--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -37,7 +37,7 @@ import type { Phase4MetricsSnapshot } from '../observability/metrics-collector.j
 import { ReportGenerator } from '../observability/report-generator.js';
 import type { InvocationMetric } from '../agents/types.js';
 import { z } from 'zod';
-import { buildLegacyRuntimePaths, buildRuntimePaths } from './runtime-paths.js';
+import { buildRuntimePaths } from './runtime-paths.js';
 
 const loadLore = () => import('@aamf/lore');
 const loadKbServerProcess = () => import('./kb-server-process.js');
@@ -247,7 +247,6 @@ export class MigrationOrchestrator {
   private readonly reportGenerator: ReportGenerator;
   private readonly runId: string;
   private readonly paths: ReturnType<typeof buildRuntimePaths>;
-  private readonly legacyPaths: ReturnType<typeof buildLegacyRuntimePaths>;
   /** Tracks the maximum concurrency observed across all ParallelExecutor instances. */
   private _peakConcurrency = 0;
   /** Unique task IDs that have consumed routed-task budget (heavy/critical). */
@@ -276,8 +275,7 @@ export class MigrationOrchestrator {
     this.projectRoot = projectRoot;
     this.paths = buildRuntimePaths(projectRoot, config.projectName);
     this.progressDir = this.paths.root;
-    this.legacyPaths = buildLegacyRuntimePaths(this.progressDir);
-    this.contextBuilder = new ContextBuilder(config, this.progressDir);
+    this.contextBuilder = new ContextBuilder(config, this.progressDir, this.paths);
     this.tokenTracker = new TokenTracker();
     this.singlePhase = singlePhase;
     this.kbDbPath = this.paths.kbDbFile;
@@ -764,7 +762,7 @@ export class MigrationOrchestrator {
         phase: 1,
         name: 'Impact Assessment',
         success: true,
-        outputPath: this.legacyPaths.impactAssessmentFile,
+        outputPath: this.paths.impactAssessmentFile,
         duration: Date.now() - start,
       };
     }
@@ -774,7 +772,7 @@ export class MigrationOrchestrator {
     const result = await this.launchAgentWithEvents(inv);
     this.recordTokens(result, 1);
 
-    const outputPath = this.legacyPaths.impactAssessmentFile;
+    const outputPath = this.paths.impactAssessmentFile;
     return {
       phase: 1,
       name: 'Impact Assessment',
@@ -790,7 +788,7 @@ export class MigrationOrchestrator {
   // ─── Phase 2: Knowledge Base Construction ────────────────────────────
 
   private async executePhase2(start: number): Promise<PhaseResult> {
-    const outputPath = this.legacyPaths.knowledgeBaseDir;
+    const outputPath = this.paths.knowledgeBaseDir;
 
     // Defence-in-depth: if the knowledge-base directory already has content
     // (e.g. from a previous run that completed Phase 2 but whose checkpoint
@@ -836,12 +834,9 @@ export class MigrationOrchestrator {
 
   private async executePhase3(start: number): Promise<PhaseResult> {
     const planningDir = this.paths.artifactsPlanningDir;
-    const legacyPlanningDir = this.legacyPaths.planningDir;
     const groupsFile = join(planningDir, 'groups.json');
     const strategyFile = join(planningDir, 'strategy.md');
     const mergedTasksFile = join(planningDir, 'tasks-merged.json');
-    const legacyGroupsFile = join(legacyPlanningDir, 'groups.json');
-    const legacyStrategyFile = join(legacyPlanningDir, 'strategy.md');
 
     // ── Step 3a: migration-planner (fast, serial) ──────────────────────────
     //   Reads the knowledge base and emits planning/groups.json +
@@ -870,12 +865,10 @@ export class MigrationOrchestrator {
 
       // Adjudicator runs before task decomposition when competing strategies
       // were written to disk by the migration-planner.
-      const adjudicationFile = join(this.paths.artifactsPlanningDir, 'competing-strategies.md');
-      const legacyAdjudicationFile = this.legacyPaths.competingStrategiesFile;
-      if (await fileExists(adjudicationFile) || await fileExists(legacyAdjudicationFile)) {
-        const fileToUse = await fileExists(adjudicationFile) ? adjudicationFile : legacyAdjudicationFile;
+      const adjudicationFile = this.paths.competingStrategiesFile;
+      if (await fileExists(adjudicationFile)) {
         const adjCtx = await this.contextBuilder.buildContext('adjudicator', 3, undefined, {
-          competingStrategiesFile: fileToUse,
+          competingStrategiesFile: adjudicationFile,
           decisionType: 'migration-strategy',
         });
         const adjInv = this.buildInvocation('adjudicator', adjCtx, 3);
@@ -924,10 +917,7 @@ export class MigrationOrchestrator {
     //   Each invocation reads strategy.md + its group's analysis files and
     //   emits planning/tasks-<group>.json.  Completed groups are tracked in
     //   the checkpoint so partial failures can be retried cheaply on resume.
-    const groupsFileToRead = await fileExists(groupsFile)
-      ? groupsFile
-      : (await fileExists(legacyGroupsFile) ? legacyGroupsFile : undefined);
-    if (!groupsFileToRead) {
+    if (!(await fileExists(groupsFile))) {
       return {
         phase: 3,
         name: 'Migration Planning',
@@ -937,7 +927,7 @@ export class MigrationOrchestrator {
       };
     }
 
-    const groups = await readJson<ModuleGroup[]>(groupsFileToRead);
+    const groups = await readJson<ModuleGroup[]>(groupsFile);
     const completedGroups = new Set(this.checkpoint.getState().completedPhase3Groups ?? []);
     const remainingGroups = groups.filter(g => !completedGroups.has(g.id));
 
@@ -952,7 +942,7 @@ export class MigrationOrchestrator {
         const ctx = await this.contextBuilder.buildContext('task-decomposer', 3, group.id, {
           groupId: group.id,
           groupName: group.name,
-          strategyFile: await fileExists(strategyFile) ? strategyFile : legacyStrategyFile,
+          strategyFile,
           analysisFiles: group.analysisFiles,
         });
         invocations.push(this.buildInvocation('task-decomposer', ctx, 3, group.id));
@@ -1031,12 +1021,8 @@ export class MigrationOrchestrator {
     const allTasks: MigrationTask[] = [];
     for (const group of groups) {
       const taskFile = join(planningDir, `tasks-${group.id}.json`);
-      const legacyTaskFile = join(legacyPlanningDir, `tasks-${group.id}.json`);
-      const taskFileToRead = await fileExists(taskFile)
-        ? taskFile
-        : (await fileExists(legacyTaskFile) ? legacyTaskFile : undefined);
-      if (taskFileToRead) {
-        const groupTasksRaw = await readJson<unknown>(taskFileToRead);
+      if (await fileExists(taskFile)) {
+        const groupTasksRaw = await readJson<unknown>(taskFile);
         const parsed = TaskFileSchema.safeParse(groupTasksRaw);
         if (!parsed.success) {
           const issueSummary = parsed.error.issues
@@ -1047,7 +1033,7 @@ export class MigrationOrchestrator {
             })
             .join('; ');
           const validationError =
-            `Invalid task-decomposer output for group "${group.id}" at ${taskFileToRead}. ` +
+            `Invalid task-decomposer output for group "${group.id}" at ${taskFile}. ` +
             `Schema validation failed: ${issueSummary}`;
           this.logger.error(validationError);
           return {
@@ -1095,7 +1081,7 @@ export class MigrationOrchestrator {
   // ─── Phase 4: Iterative Migration ────────────────────────────────────
 
   private async executePhase4(start: number): Promise<PhaseResult> {
-    const planPath = this.legacyPaths.migrationPlanFile;
+    const planPath = this.paths.migrationPlanFile;
 
     // 1. Parse migration plan — prefer structuredOutput from Phase 3, fall back to file
     let tasks: MigrationTask[];
@@ -1106,13 +1092,11 @@ export class MigrationOrchestrator {
         // Also check for the newer planning/tasks-merged.json produced by the
         // two-step Phase 3 (migration-planner + parallel task-decomposer).
         const mergedPlanPath = join(this.paths.artifactsPlanningDir, 'tasks-merged.json');
-        const legacyMergedPlanPath = join(this.legacyPaths.planningDir, 'tasks-merged.json');
-        if (await fileExists(mergedPlanPath) || await fileExists(legacyMergedPlanPath)) {
-          const mergedToRead = await fileExists(mergedPlanPath) ? mergedPlanPath : legacyMergedPlanPath;
+        if (await fileExists(mergedPlanPath)) {
           this.logger.warn(
             'Phase 3 structured output unavailable — falling back to tasks-merged.json artifact',
           );
-          tasks = await readJson<MigrationTask[]>(mergedToRead);
+          tasks = await readJson<MigrationTask[]>(mergedPlanPath);
         } else {
           return {
             phase: 4,
@@ -2378,11 +2362,8 @@ export class MigrationOrchestrator {
       if (result.outputParsed && Array.isArray(result.structuredOutput?.['fixes'])) {
         fixes = result.structuredOutput['fixes'] as Array<{ description: string; sourceFile: string; targetFile: string }>;
       } else {
-        const reportPath = join(this.paths.artifactsParityDir, 'final-parity-report.md');
-        const legacyReportPath = this.legacyPaths.finalParityReportFile;
-        const reportToRead = await fileExists(reportPath)
-          ? reportPath
-          : (await fileExists(legacyReportPath) ? legacyReportPath : undefined);
+        const reportPath = this.paths.finalParityReportFile;
+        const reportToRead = await fileExists(reportPath) ? reportPath : undefined;
         if (!reportToRead) break;
         this.logger.warn('Final-parity-checker structured output unavailable — falling back to ResultParser.parseFinalParityReport');
         fixes = await ResultParser.parseFinalParityReport(reportToRead);
@@ -2617,15 +2598,13 @@ export class MigrationOrchestrator {
       }
 
       // Parse idiomatic issues
-      const reportPath = join(this.paths.artifactsParityDir, 'idiomatic-review-report.md');
-      const legacyReportPath = this.legacyPaths.idiomaticReviewReportFile;
+      const reportPath = this.paths.idiomaticReviewReportFile;
       let issues: Array<{ file: string; issue: string; suggestion: string }>;
       if (reviewResult.outputParsed && Array.isArray(reviewResult.structuredOutput?.['issues'])) {
         issues = reviewResult.structuredOutput['issues'] as Array<{ file: string; issue: string; suggestion: string }>;
       } else {
         this.logger.warn('Idiomatic-reviewer structured output unavailable — falling back to ResultParser.parseIdiomaticReport');
-        const reportToRead = await fileExists(reportPath) ? reportPath : legacyReportPath;
-        issues = await ResultParser.parseIdiomaticReport(reportToRead);
+        issues = await ResultParser.parseIdiomaticReport(reportPath);
       }
 
       if (issues.length === 0) {

--- a/runtime/src/core/runtime-paths.ts
+++ b/runtime/src/core/runtime-paths.ts
@@ -25,21 +25,8 @@ export interface RuntimePaths {
   metricsInvocationsFile: string;
   metricsSummaryFile: string;
   kbDbFile: string;
-}
-
-export interface LegacyRuntimePaths {
-  checkpointFile: string;
-  checkpointBackupFile: string;
-  contextsDir: string;
-  resultsDir: string;
-  planningDir: string;
-  parityReportsDir: string;
-  adjudicationDir: string;
-  progressReportFile: string;
-  migrationLogDir: string;
-  migrationLogFile: string;
-  impactAssessmentFile: string;
   knowledgeBaseDir: string;
+  impactAssessmentFile: string;
   migrationPlanFile: string;
   competingStrategiesFile: string;
   finalParityReportFile: string;
@@ -53,6 +40,8 @@ export function buildRuntimePaths(projectRoot: string, projectName: string): Run
   const logsAgentsDir = join(root, 'logs', 'agents');
   const logsCommandsDir = join(root, 'logs', 'commands');
   const artifactsDir = join(root, 'artifacts');
+  const artifactsPlanningDir = join(artifactsDir, 'planning');
+  const artifactsParityDir = join(artifactsDir, 'parity');
   const reportsDir = join(root, 'reports');
   const metricsDir = join(root, 'metrics');
 
@@ -71,8 +60,8 @@ export function buildRuntimePaths(projectRoot: string, projectName: string): Run
     artifactsDir,
     artifactsContextsDir: join(artifactsDir, 'contexts'),
     artifactsResultsDir: join(artifactsDir, 'results'),
-    artifactsPlanningDir: join(artifactsDir, 'planning'),
-    artifactsParityDir: join(artifactsDir, 'parity'),
+    artifactsPlanningDir,
+    artifactsParityDir,
     artifactsAdjudicationDir: join(artifactsDir, 'adjudication'),
     reportsDir,
     progressReportFile: join(reportsDir, 'progress.md'),
@@ -81,26 +70,11 @@ export function buildRuntimePaths(projectRoot: string, projectName: string): Run
     metricsInvocationsFile: join(metricsDir, 'invocations.jsonl'),
     metricsSummaryFile: join(metricsDir, 'summary.json'),
     kbDbFile: join(root, 'kb.db'),
-  };
-}
-
-export function buildLegacyRuntimePaths(progressDir: string): LegacyRuntimePaths {
-  return {
-    checkpointFile: join(progressDir, 'checkpoint.json'),
-    checkpointBackupFile: join(progressDir, 'checkpoint.backup.json'),
-    contextsDir: join(progressDir, 'contexts'),
-    resultsDir: join(progressDir, 'results'),
-    planningDir: join(progressDir, 'planning'),
-    parityReportsDir: join(progressDir, 'parity-reports'),
-    adjudicationDir: join(progressDir, 'adjudication'),
-    progressReportFile: join(progressDir, 'progress.md'),
-    migrationLogDir: join(progressDir, 'logs'),
-    migrationLogFile: join(progressDir, 'logs', 'migration.log'),
-    impactAssessmentFile: join(progressDir, 'impact-assessment.md'),
-    knowledgeBaseDir: join(progressDir, 'knowledge-base'),
-    migrationPlanFile: join(progressDir, 'migration-plan.md'),
-    competingStrategiesFile: join(progressDir, 'competing-strategies.md'),
-    finalParityReportFile: join(progressDir, 'final-parity-report.md'),
-    idiomaticReviewReportFile: join(progressDir, 'idiomatic-review-report.md'),
+    knowledgeBaseDir: join(root, 'knowledge-base'),
+    impactAssessmentFile: join(artifactsDir, 'impact-assessment.md'),
+    migrationPlanFile: join(artifactsPlanningDir, 'migration-plan.md'),
+    competingStrategiesFile: join(artifactsPlanningDir, 'competing-strategies.md'),
+    finalParityReportFile: join(artifactsParityDir, 'final-parity-report.md'),
+    idiomaticReviewReportFile: join(artifactsParityDir, 'idiomatic-review-report.md'),
   };
 }

--- a/runtime/tests/checkpoint.test.ts
+++ b/runtime/tests/checkpoint.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { CheckpointManager } from '../src/core/checkpoint.js';
 import { Logger } from '../src/logging/logger.js';
-import { fileExists, readJson } from '../src/util/fs.js';
+import { ensureDir, fileExists, readJson } from '../src/util/fs.js';
 
 describe('CheckpointManager', () => {
   let tempDir: string;
@@ -151,7 +151,8 @@ describe('CheckpointManager', () => {
       resumeCount: 1,
       // cumulativeDurationMs intentionally omitted
     };
-    await writeJson(join(tempDir, 'checkpoint.json'), oldState);
+    await ensureDir(join(tempDir, 'state'));
+    await writeJson(join(tempDir, 'state', 'checkpoint.json'), oldState);
 
     const manager3 = new CheckpointManager(tempDir, logger);
     const loaded = await manager3.load('old-project');
@@ -217,7 +218,8 @@ describe('CheckpointManager', () => {
       cumulativeDurationMs: 0,
       // completedTaskDurationsMs intentionally omitted
     };
-    await writeJson(join(tempDir, 'checkpoint.json'), oldState);
+    await ensureDir(join(tempDir, 'state'));
+    await writeJson(join(tempDir, 'state', 'checkpoint.json'), oldState);
 
     const manager3 = new CheckpointManager(tempDir, logger);
     const loaded = await manager3.load('old-project');
@@ -315,7 +317,8 @@ describe('CheckpointManager', () => {
       completedTaskDurationsMs: [],
       // metricsCount intentionally omitted
     };
-    await writeJson(join(tempDir, 'checkpoint.json'), oldState);
+    await ensureDir(join(tempDir, 'state'));
+    await writeJson(join(tempDir, 'state', 'checkpoint.json'), oldState);
 
     const manager3 = new CheckpointManager(tempDir, logger);
     const loaded = await manager3.load('old-project');
@@ -342,7 +345,8 @@ describe('CheckpointManager', () => {
       completedTaskDurationsMs: [],
       metricsCount: 0,
     };
-    await writeJson(join(tempDir, 'checkpoint.json'), oldState);
+    await ensureDir(join(tempDir, 'state'));
+    await writeJson(join(tempDir, 'state', 'checkpoint.json'), oldState);
 
     const manager3 = new CheckpointManager(tempDir, logger);
     const loaded = await manager3.load('old-project');
@@ -451,7 +455,8 @@ describe('CheckpointManager', () => {
       metricsCount: 0,
       // phase0Fingerprint intentionally omitted
     };
-    await writeJson(join(tempDir, 'checkpoint.json'), oldState);
+    await ensureDir(join(tempDir, 'state'));
+    await writeJson(join(tempDir, 'state', 'checkpoint.json'), oldState);
 
     const manager3 = new CheckpointManager(tempDir, logger);
     const loaded = await manager3.load('old-project');
@@ -533,7 +538,8 @@ describe('CheckpointManager', () => {
       metricsCount: 0,
       // adjudicationWaivers/adjudicationEvents intentionally omitted
     };
-    await writeJson(join(tempDir, 'checkpoint.json'), oldState);
+    await ensureDir(join(tempDir, 'state'));
+    await writeJson(join(tempDir, 'state', 'checkpoint.json'), oldState);
 
     const manager3 = new CheckpointManager(tempDir, logger);
     const loaded = await manager3.load('old-project');

--- a/runtime/tests/context-builder.test.ts
+++ b/runtime/tests/context-builder.test.ts
@@ -6,18 +6,65 @@ import { ContextBuilder } from '../src/agents/context-builder.js';
 import { AgentContext } from '../src/agents/types.js';
 import { createMockConfig, createSilentLogger } from './helpers/mocks.js';
 import { ensureDir, fileExists, readJson } from '../src/util/fs.js';
+import type { RuntimePaths } from '../src/core/runtime-paths.js';
 
 describe('ContextBuilder', () => {
   let tempDir: string;
   let progressDir: string;
   let builder: ContextBuilder;
+  let paths: RuntimePaths;
+
+  function buildTestPaths(root: string): RuntimePaths {
+    const stateDir = join(root, 'state');
+    const logsRuntimeDir = join(root, 'logs', 'runtime');
+    const logsAgentsDir = join(root, 'logs', 'agents');
+    const logsCommandsDir = join(root, 'logs', 'commands');
+    const artifactsDir = join(root, 'artifacts');
+    const artifactsPlanningDir = join(artifactsDir, 'planning');
+    const artifactsParityDir = join(artifactsDir, 'parity');
+    const reportsDir = join(root, 'reports');
+    const metricsDir = join(root, 'metrics');
+    return {
+      root,
+      stateDir,
+      checkpointFile: join(stateDir, 'checkpoint.json'),
+      checkpointBackupFile: join(stateDir, 'checkpoint.backup.json'),
+      runManifestFile: join(stateDir, 'run-manifest.json'),
+      logsRuntimeDir,
+      migrationLogFile: join(logsRuntimeDir, 'migration.log'),
+      logsAgentsDir,
+      logsCommandsDir,
+      logsCommandBuildDir: join(logsCommandsDir, 'build'),
+      logsCommandTestDir: join(logsCommandsDir, 'test'),
+      artifactsDir,
+      artifactsContextsDir: join(artifactsDir, 'contexts'),
+      artifactsResultsDir: join(artifactsDir, 'results'),
+      artifactsPlanningDir,
+      artifactsParityDir,
+      artifactsAdjudicationDir: join(artifactsDir, 'adjudication'),
+      reportsDir,
+      progressReportFile: join(reportsDir, 'progress.md'),
+      reportsObservabilityDir: join(reportsDir, 'observability'),
+      metricsDir,
+      metricsInvocationsFile: join(metricsDir, 'invocations.jsonl'),
+      metricsSummaryFile: join(metricsDir, 'summary.json'),
+      kbDbFile: join(root, 'kb.db'),
+      knowledgeBaseDir: join(root, 'knowledge-base'),
+      impactAssessmentFile: join(artifactsDir, 'impact-assessment.md'),
+      migrationPlanFile: join(artifactsPlanningDir, 'migration-plan.md'),
+      competingStrategiesFile: join(artifactsPlanningDir, 'competing-strategies.md'),
+      finalParityReportFile: join(artifactsParityDir, 'final-parity-report.md'),
+      idiomaticReviewReportFile: join(artifactsParityDir, 'idiomatic-review-report.md'),
+    };
+  }
 
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'aamf-ctx-test-'));
     progressDir = join(tempDir, 'progress');
     await ensureDir(progressDir);
     const config = createMockConfig();
-    builder = new ContextBuilder(config, progressDir);
+    paths = buildTestPaths(progressDir);
+    builder = new ContextBuilder(config, progressDir, paths);
   });
 
   afterEach(async () => {
@@ -468,7 +515,7 @@ describe('ContextBuilder', () => {
           contextWindowTokens: 64_000,
         },
       });
-      const b = new ContextBuilder(config, progressDir);
+      const b = new ContextBuilder(config, progressDir, paths);
       const contextPath = await b.buildContext('impact-assessor', 1);
       const context = await readJson<AgentContext & { contextWindowTokens?: number }>(contextPath);
 
@@ -500,7 +547,7 @@ describe('ContextBuilder', () => {
           contextWindowTokens: 64_000,
         },
       });
-      const b = new ContextBuilder(config, progressDir);
+      const b = new ContextBuilder(config, progressDir, paths);
       const contextPath = await b.buildContext('impact-assessor', 1);
       const context = await readJson<AgentContext & { contextWindowTokens?: number }>(contextPath);
 
@@ -532,7 +579,7 @@ describe('ContextBuilder', () => {
           contextWindowTokens: 128_000,
         },
       });
-      const b = new ContextBuilder(config, progressDir);
+      const b = new ContextBuilder(config, progressDir, paths);
       const contextPath = await b.buildContext('impact-assessor', 1);
       const context = await readJson<AgentContext & { contextWindowTokens?: number }>(contextPath);
 

--- a/runtime/tests/orchestrator.test.ts
+++ b/runtime/tests/orchestrator.test.ts
@@ -66,7 +66,9 @@ async function writeMigrationPlan(progressDir: string, content?: string): Promis
 **Parity Checks:**
 - matches
 `;
-  await writeFile(join(progressDir, 'migration-plan.md'), content ?? defaultPlan);
+  await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
+      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
+  await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), content ?? defaultPlan);
   // Also write planning artifacts required by the two-step Phase 3 design.
   await writePhase3PlanningArtifacts(progressDir);
 }
@@ -128,7 +130,7 @@ async function writePhase3PlanningArtifacts(
   progressDir: string,
   tasks: MigrationTask[] = DEFAULT_PLANNING_TASKS,
 ): Promise<void> {
-  const planningDir = join(progressDir, 'planning');
+  const planningDir = join(progressDir, 'artifacts', 'planning');
   await mkdir(planningDir, { recursive: true });
   const group = { id: 'core', name: 'Core', analysisFiles: [] };
   await writeFile(join(planningDir, 'groups.json'), JSON.stringify([group], null, 2));
@@ -150,7 +152,8 @@ async function writeParityReport(
       content += `Target file: ${issue.targetFile}\n\n`;
     }
   }
-  await writeFile(join(progressDir, 'final-parity-report.md'), content);
+  await mkdir(join(progressDir, 'artifacts', 'parity'), { recursive: true });
+  await writeFile(join(progressDir, 'artifacts', 'parity', 'final-parity-report.md'), content);
 }
 
 /**
@@ -725,9 +728,9 @@ describe('MigrationOrchestrator', () => {
       // Pre-populate checkpoint with phases 1–3 complete
       const checkpoint = new CheckpointManager(progressDir, logger);
       await checkpoint.load(config.projectName);
-      await checkpoint.completePhase(1, join(progressDir, 'impact-assessment.md'));
+      await checkpoint.completePhase(1, join(progressDir, 'artifacts', 'impact-assessment.md'));
       await checkpoint.completePhase(2, join(progressDir, 'knowledge-base'));
-      await checkpoint.completePhase(3, join(progressDir, 'migration-plan.md'));
+      await checkpoint.completePhase(3, join(progressDir, 'artifacts', 'planning', 'migration-plan.md'));
 
       const progressFile = join(progressDir, 'progress.md');
       const progress = new ProgressWriter(progressFile);
@@ -1067,7 +1070,7 @@ describe('MigrationOrchestrator', () => {
         3,
       );
 
-      const planningDir = join(progressDir, 'planning');
+      const planningDir = join(progressDir, 'artifacts', 'planning');
       await mkdir(planningDir, { recursive: true });
       await writeFile(
         join(planningDir, 'groups.json'),
@@ -1098,7 +1101,7 @@ describe('MigrationOrchestrator', () => {
         3,
       );
 
-      const planningDir = join(progressDir, 'planning');
+      const planningDir = join(progressDir, 'artifacts', 'planning');
       await mkdir(planningDir, { recursive: true });
       const group = { id: 'core', name: 'Core', analysisFiles: [] };
       await writeFile(join(planningDir, 'groups.json'), JSON.stringify([group], null, 2));
@@ -1136,7 +1139,7 @@ describe('MigrationOrchestrator', () => {
         phase3aComplete: true,
         completedPhase3Groups: [],
       };
-      await writeFile(join(progressDir, 'checkpoint.json'), JSON.stringify(checkpoint, null, 2));
+      await writeFile(join(progressDir, 'state', 'checkpoint.json'), JSON.stringify(checkpoint, null, 2));
 
       const result = await orchestrator.run();
 
@@ -1690,7 +1693,8 @@ describe('MigrationOrchestrator', () => {
       const launcherFn = createMockLauncher();
       const { orchestrator, progressDir } = await setupOrchestrator(tempDir, launcherFn);
 
-      await writeFile(join(progressDir, 'migration-plan.md'), '# Migration Plan\n\nNo tasks defined.\n');
+      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
+      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), '# Migration Plan\n\nNo tasks defined.\n');
       // Write empty planning artifacts so Phase 3 succeeds with zero tasks.
       await writePhase3PlanningArtifacts(progressDir, []);
 
@@ -1764,7 +1768,8 @@ describe('MigrationOrchestrator', () => {
 **Parity Checks:**
 - matches
 `;
-      await writeFile(join(progressDir, 'migration-plan.md'), singleTaskPlan);
+      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
+      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
       await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
 
       const result = await orchestrator.run();
@@ -1815,7 +1820,8 @@ describe('MigrationOrchestrator', () => {
 **Parity Checks:**
 - matches
 `;
-      await writeFile(join(progressDir, 'migration-plan.md'), singleTaskPlan);
+      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
+      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
       await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
 
       const result = await orchestrator.run();
@@ -1891,13 +1897,14 @@ describe('MigrationOrchestrator', () => {
 **Parity Checks:**
 - matches
 `;
-      await writeFile(join(progressDir, 'migration-plan.md'), singleTaskPlan);
+      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
+      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
       await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
 
       // Write a parity sidecar with critical issues (will be read after parity-verifier runs)
-      await ensureDir(join(progressDir, 'results'));
+      await ensureDir(join(progressDir, 'artifacts', 'results'));
       await writeFile(
-        join(progressDir, 'results', 'parity-verifier-task-001.result.json'),
+        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
         JSON.stringify({
           taskId: 'task-001',
           agent: 'parity-verifier',
@@ -1985,12 +1992,13 @@ describe('MigrationOrchestrator', () => {
 **Parity Checks:**
 - matches
 `;
-      await writeFile(join(progressDir, 'migration-plan.md'), singleTaskPlan);
+      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
+      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
       await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
 
-      await ensureDir(join(progressDir, 'results'));
+      await ensureDir(join(progressDir, 'artifacts', 'results'));
       await writeFile(
-        join(progressDir, 'results', 'parity-verifier-task-001.result.json'),
+        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
         JSON.stringify({
           taskId: 'task-001',
           agent: 'parity-verifier',
@@ -2080,13 +2088,14 @@ describe('MigrationOrchestrator', () => {
 **Parity Checks:**
 - matches
 `;
-      await writeFile(join(progressDir, 'migration-plan.md'), singleTaskPlan);
+      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
+      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
       await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
 
       // Write a parity sidecar with only minor issues
-      await ensureDir(join(progressDir, 'results'));
+      await ensureDir(join(progressDir, 'artifacts', 'results'));
       await writeFile(
-        join(progressDir, 'results', 'parity-verifier-task-001.result.json'),
+        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
         JSON.stringify({
           taskId: 'task-001',
           agent: 'parity-verifier',
@@ -2163,14 +2172,15 @@ describe('MigrationOrchestrator', () => {
 **Parity Checks:**
 - matches
 `;
-      await writeFile(join(progressDir, 'migration-plan.md'), singleTaskPlan);
+      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
+      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
       await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
 
       // Write a parity sidecar with major issues that downgrade to minor after retry
       // but since the file persists, we simulate "only minor remaining"
-      await ensureDir(join(progressDir, 'results'));
+      await ensureDir(join(progressDir, 'artifacts', 'results'));
       await writeFile(
-        join(progressDir, 'results', 'parity-verifier-task-001.result.json'),
+        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
         JSON.stringify({
           taskId: 'task-001',
           agent: 'parity-verifier',
@@ -2253,12 +2263,13 @@ describe('MigrationOrchestrator', () => {
 **Parity Checks:**
 - matches
 `;
-      await writeFile(join(progressDir, 'migration-plan.md'), singleTaskPlan);
+      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
+      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
       await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
 
-      await ensureDir(join(progressDir, 'results'));
+      await ensureDir(join(progressDir, 'artifacts', 'results'));
       await writeFile(
-        join(progressDir, 'results', 'parity-verifier-task-001.result.json'),
+        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
         JSON.stringify({
           taskId: 'task-001',
           agent: 'parity-verifier',
@@ -2782,7 +2793,8 @@ describe('MigrationOrchestrator', () => {
 **Parity Checks:**
 - matches
 `;
-      await writeFile(join(progressDir, 'migration-plan.md'), singleTaskPlan);
+      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
+      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
       await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
 
       const infoSpy = vi.spyOn(logger, 'info');
@@ -2884,7 +2896,8 @@ describe('MigrationOrchestrator', () => {
 **Parity Checks:**
 - matches
 `;
-      await writeFile(join(progressDir, 'migration-plan.md'), threeTaskPlan);
+      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
+      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), threeTaskPlan);
       // Write planning artifacts for the three tasks so Phase 3 succeeds during the resume run.
       const threeTasks: MigrationTask[] = [
         { id: 'task-001', name: 'Module A', sourceFiles: ['src/a.py'], targetFiles: ['src/a.ts'], knowledgeBaseRef: 'kb/task-001.md', dependencies: [], complexity: 'simple', description: 'Migrate A', acceptanceCriteria: ['works'], parityChecks: ['matches'], lineRange: { start: 1, end: 200 } },
@@ -3304,8 +3317,9 @@ describe('MigrationOrchestrator', () => {
       await writeMigrationPlan(progressDir);
 
       // Write an idiomatic report with issues so the loop keeps iterating
+      await mkdir(join(progressDir, 'artifacts', 'parity'), { recursive: true });
       await writeFile(
-        join(progressDir, 'idiomatic-review-report.md'),
+        join(progressDir, 'artifacts', 'parity', 'idiomatic-review-report.md'),
         '# Idiomatic Review\n\n## Issue: Use const\nFile: src/main.ts\nIssue: let used instead of const\nSuggestion: replace let with const\n',
       );
 

--- a/runtime/tests/result-parser.test.ts
+++ b/runtime/tests/result-parser.test.ts
@@ -262,6 +262,97 @@ Here are the tasks:
     });
   });
 
+  describe('readTaskResultJson', () => {
+    it('should read sidecar from artifacts/results/ path', async () => {
+      const { mkdtemp, rm, writeFile, mkdir } = await import('node:fs/promises');
+      const { tmpdir } = await import('node:os');
+      const dir = await mkdtemp(join(tmpdir(), 'aamf-rp-sidecar-'));
+      try {
+        const resultsDir = join(dir, 'artifacts', 'results');
+        await mkdir(resultsDir, { recursive: true });
+        const sidecar = {
+          taskId: 'task-001',
+          agent: 'parity-verifier',
+          status: 'completed',
+          outputFiles: [],
+          parity: 'pass',
+          issues: [],
+        };
+        await writeFile(
+          join(resultsDir, 'parity-verifier-task-001.result.json'),
+          JSON.stringify(sidecar),
+          'utf-8',
+        );
+        const result = await ResultParser.readTaskResultJson(dir, 'parity-verifier', 'task-001');
+        expect(result).toBeDefined();
+        expect(result?.parity).toBe('pass');
+        expect(result?.issues).toHaveLength(0);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return undefined when no sidecar file exists', async () => {
+      const { mkdtemp, rm } = await import('node:fs/promises');
+      const { tmpdir } = await import('node:os');
+      const dir = await mkdtemp(join(tmpdir(), 'aamf-rp-sidecar-'));
+      try {
+        const result = await ResultParser.readTaskResultJson(dir, 'parity-verifier', 'task-999');
+        expect(result).toBeUndefined();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('should ignore legacy results/ path and return undefined', async () => {
+      const { mkdtemp, rm, writeFile, mkdir } = await import('node:fs/promises');
+      const { tmpdir } = await import('node:os');
+      const dir = await mkdtemp(join(tmpdir(), 'aamf-rp-sidecar-'));
+      try {
+        // Write sidecar ONLY to legacy path
+        const legacyDir = join(dir, 'results');
+        await mkdir(legacyDir, { recursive: true });
+        const sidecar = {
+          taskId: 'task-001',
+          agent: 'parity-verifier',
+          status: 'completed',
+          outputFiles: [],
+          parity: 'pass',
+          issues: [],
+        };
+        await writeFile(
+          join(legacyDir, 'parity-verifier-task-001.result.json'),
+          JSON.stringify(sidecar),
+          'utf-8',
+        );
+        // Should NOT find it — legacy path is no longer consulted
+        const result = await ResultParser.readTaskResultJson(dir, 'parity-verifier', 'task-001');
+        expect(result).toBeUndefined();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('should return undefined for malformed JSON in sidecar', async () => {
+      const { mkdtemp, rm, writeFile, mkdir } = await import('node:fs/promises');
+      const { tmpdir } = await import('node:os');
+      const dir = await mkdtemp(join(tmpdir(), 'aamf-rp-sidecar-'));
+      try {
+        const resultsDir = join(dir, 'artifacts', 'results');
+        await mkdir(resultsDir, { recursive: true });
+        await writeFile(
+          join(resultsDir, 'parity-verifier-task-001.result.json'),
+          'not valid json {{{',
+          'utf-8',
+        );
+        const result = await ResultParser.readTaskResultJson(dir, 'parity-verifier', 'task-001');
+        expect(result).toBeUndefined();
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe('AamfOutputBase schema', () => {
     it('should accept a minimal valid output', () => {
       const result = AamfOutputBase.parse({ status: 'completed', agent: 'code-migrator' });


### PR DESCRIPTION
## Summary

Remove the `LegacyRuntimePaths` interface and `buildLegacyRuntimePaths()` function entirely. All file locations are now served exclusively by `buildRuntimePaths()` through the single `RuntimePaths` interface.

This is a breaking change but acceptable since the product is unreleased.

## New RuntimePaths properties

Six properties that previously only existed in `LegacyRuntimePaths` are added to `RuntimePaths` with organized paths:

| Property | Path |
|----------|------|
| `knowledgeBaseDir` | `{root}/knowledge-base/` |
| `impactAssessmentFile` | `{root}/artifacts/impact-assessment.md` |
| `migrationPlanFile` | `{root}/artifacts/planning/migration-plan.md` |
| `competingStrategiesFile` | `{root}/artifacts/planning/competing-strategies.md` |
| `finalParityReportFile` | `{root}/artifacts/parity/final-parity-report.md` |
| `idiomaticReviewReportFile` | `{root}/artifacts/parity/idiomatic-review-report.md` |

## Runtime changes

- **runtime-paths.ts**: Remove `LegacyRuntimePaths` and `buildLegacyRuntimePaths()`; add 6 new properties to `RuntimePaths`
- **orchestrator.ts**: Drop `legacyPaths` field, import, and all dual-path fallback logic
- **checkpoint.ts**: Remove legacy checkpoint/backup path fallback
- **context-builder.ts**: Accept `RuntimePaths` in constructor instead of building legacy paths internally
- **result-parser.ts**: Drop legacy result file fallback

## Agent definition updates (17 files)

All path references across `.github/agents/` and `.claude/agents/` updated from legacy flat layout to modern organized layout:

| Old | New |
|-----|-----|
| `{root}/impact-assessment.md` | `{root}/artifacts/impact-assessment.md` |
| `{root}/migration-plan.md` | `{root}/artifacts/planning/migration-plan.md` |
| `{root}/planning/` | `{root}/artifacts/planning/` |
| `{root}/competing-strategies.md` | `{root}/artifacts/planning/competing-strategies.md` |
| `{root}/parity-reports/` | `{root}/artifacts/parity/` |
| `{root}/final-parity-report.md` | `{root}/artifacts/parity/final-parity-report.md` |
| `{root}/idiomatic-review-report.md` | `{root}/artifacts/parity/idiomatic-review-report.md` |
| `{root}/progress.md` | `{root}/reports/progress.md` |
| `checkpoints.json` | `state/checkpoint.json` |

## Test results

All 1016 runtime tests pass with 0 failures.