### PR TITLE
refactor(agents): reduce definition size and name Lore MCP tools

### DIFF
--- a/.github/agents/code-migrator.agent.md
+++ b/.github/agents/code-migrator.agent.md
@@ -10,7 +10,18 @@ You are the **Code Migrator** — responsible for executing a single migration t
 
 ## Index-First Principle
 
-When KB index tooling is available, treat it as the authoritative source of structural facts (symbol locations, signatures, dependency edges, and source ranges). Use knowledge-base markdown as synthesized context for architecture, risks, and migration guidance. Do not duplicate exhaustive structural inventories in markdown outputs when index-backed facts are available.
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+
+| Tool | Purpose |
+|------|---------|
+| `kb_lookup` | Symbol or file lookup (signatures, locations) |
+| `kb_graph` | Call-graph and import-graph queries |
+| `kb_search` | Structural, semantic, and fused code search |
+| `kb_snippet` | Source-code snippet extraction by line range |
+| `kb_metrics` | Aggregate code metrics |
+| `kb_writeback` | Write LLM-generated summaries back to the KB |
+
+When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
 
 ## Responsibilities
 
@@ -97,45 +108,11 @@ Update `.aamf/migration/{projectName}/reports/progress.md` with task result:
 - **Notes**: {any migration decisions, concerns, or assumptions}
 ```
 
-### Structured JSON Sidecar (Required)
-
-In addition to the markdown output above, you **must** write a structured JSON result file at:
-
-```
-.aamf/migration/{projectName}/results/code-migrator-{taskId}.result.json
-```
-
-The JSON must conform to this schema:
-
-```json
-{
-  "taskId": "task-001",
-  "agent": "code-migrator",
-  "status": "completed",
-  "outputFiles": ["src/auth/login.ts"],
-  "parity": "pass",
-  "issues": [],
-  "metrics": {
-    "linesOfCode": 150,
-    "tokensUsed": 5000,
-    "durationMs": 30000
-  },
-  "notes": "Migration notes here"
-}
-```
-
-- `status`: one of `"completed"`, `"failed"`, `"needs-review"`
-- `parity`: one of `"pass"`, `"partial"`, `"fail"` (set after parity verification)
-- `issues`: array of `{ severity, description, sourceLocation?, targetLocation? }`
-- `severity`: one of `"critical"`, `"major"`, `"minor"`
-
-The runtime reads this file first. If it is missing or invalid, the runtime falls back to parsing your markdown output.
-
 ## Context Window Management
 
 - **Only read the files specified in your task** — never browse the broader codebase.
 - Read the knowledge base document for your module FIRST (this is a compact summary). Only then read the actual source file(s).
-- Use KB tooling for fast symbol/dependency lookup when available instead of expanding context with broad markdown inventories.
+- Use Lore tools (`kb_lookup`, `kb_graph`, `kb_snippet`) for fast symbol/dependency lookup when available instead of expanding context with broad markdown inventories.
 - For large file chunks, read ONLY the specified line range, plus ~20 lines before/after for context.
 - If the task involves multiple source files, process them one at a time: read source → write target → move to next.
 - After writing each target file, release the source file from your working memory (don't re-read it).
@@ -157,33 +134,7 @@ The runtime reads this file first. If it is missing or invalid, the runtime fall
 
 ## Output Format
 
-Your response must end with a fenced `aamf-json` code block. This block is parsed by the AAMF runtime to track migration task results. It **must** be the last fenced code block in your output.
-
-### Schema
-
-```json
-{
-  "agent": "code-migrator",
-  "status": "<completed | failed | needs-review>",
-  "outputFiles": ["<target file paths written>"],
-  "taskId": "<task-NNN>",
-  "parity": "<pass | partial | fail>",
-  "issues": [
-    {
-      "severity": "<critical | major | minor>",
-      "description": "<what the issue is>",
-      "sourceLocation": "<file:line, optional>",
-      "targetLocation": "<file:line, optional>"
-    }
-  ],
-  "metrics": {
-    "linesOfCode": 0,
-    "tokensUsed": 0,
-    "durationMs": 0
-  },
-  "notes": "<migration decisions, concerns, or assumptions>"
-}
-```
+Your response must end with a fenced `aamf-json` code block conforming to the Output Schema below. It **must** be the last fenced code block in your output.
 
 ### Example
 
@@ -204,7 +155,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 }
 ```
 
-> ⚠️ **Non-conformance warning**: If the `aamf-json` block is missing, malformed, or is not the last fenced code block in your response, the AAMF runtime will mark this agent run as failed.
+> ⚠️ Missing or malformed `aamf-json` block (or not the last fenced block) → agent run marked failed.
 
 ## Input Schema (Required)
 

--- a/.github/agents/documentation-writer.agent.md
+++ b/.github/agents/documentation-writer.agent.md
@@ -10,7 +10,18 @@ You are the **Documentation Writer** — responsible for producing comprehensive
 
 ## Index-First Principle
 
-When KB index tooling is available, treat it as the authoritative source of structural facts (symbol locations, signatures, dependency edges, and source ranges). Use knowledge-base markdown as synthesized context for architecture, risks, and migration guidance. Do not duplicate exhaustive structural inventories in markdown outputs when index-backed facts are available.
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+
+| Tool | Purpose |
+|------|---------|
+| `kb_lookup` | Symbol or file lookup (signatures, locations) |
+| `kb_graph` | Call-graph and import-graph queries |
+| `kb_search` | Structural, semantic, and fused code search |
+| `kb_snippet` | Source-code snippet extraction by line range |
+| `kb_metrics` | Aggregate code metrics |
+| `kb_writeback` | Write LLM-generated summaries back to the KB |
+
+When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
 
 ## Responsibilities
 
@@ -80,7 +91,7 @@ None — this is a **leaf agent**.
 - Read the migration plan and parity reports for migration-specific context.
 - When adding inline docs to migrated files, process one file at a time: read → add docs → save → move to next.
 - Write each documentation file completely before starting the next.
-- For API reference generation, prefer KB index lookups for exhaustive signatures/dependencies; keep markdown/api docs concise and reader-oriented.
+- For API reference generation, prefer Lore tools (`kb_lookup`, `kb_graph`) for exhaustive signatures/dependencies; keep markdown/api docs concise and reader-oriented.
 - Do NOT re-read source (pre-migration) files — only the migrated target files and knowledge base.
 
 ## Constraints
@@ -90,7 +101,7 @@ None — this is a **leaf agent**.
 - Keep documentation proportional — more detail for complex modules, less for simple utilities.
 - All documentation should be written in Markdown for consistency.
 - Include the date and migration version in the documentation header.
-- Do not duplicate full symbol inventories or exhaustive dependency graphs in narrative docs when KB index already provides them.
+- Do not duplicate full symbol inventories or exhaustive dependency graphs in narrative docs when Lore tools already provide them.
 
 ## Git Commit Requirement
 
@@ -101,19 +112,7 @@ None — this is a **leaf agent**.
 
 ## Output Format
 
-Your response must end with a fenced `aamf-json` code block. This block is parsed by the AAMF runtime to track documentation writing results. It **must** be the last fenced code block in your output.
-
-### Schema
-
-```json
-{
-  "agent": "documentation-writer",
-  "status": "<completed | failed | needs-review>",
-  "outputFiles": ["<paths to all documentation files written>"],
-  "documentsWritten": 0,
-  "notes": "<summary of documentation produced and any known gaps>"
-}
-```
+Your response must end with a fenced `aamf-json` code block conforming to the Output Schema below. It **must** be the last fenced code block in your output.
 
 ### Example
 
@@ -134,7 +133,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 }
 ```
 
-> ⚠️ **Non-conformance warning**: If the `aamf-json` block is missing, malformed, or is not the last fenced code block in your response, the AAMF runtime will mark this agent run as failed.
+> ⚠️ Missing or malformed `aamf-json` block (or not the last fenced block) → agent run marked failed.
 
 ## Input Schema (Required)
 

--- a/.github/agents/e2e-test-crafter.agent.md
+++ b/.github/agents/e2e-test-crafter.agent.md
@@ -10,7 +10,18 @@ You are the **E2E Test Crafter** — a coordinating agent that plans comprehensi
 
 ## Index-First Principle
 
-When KB index tooling is available, treat it as the authoritative source of structural facts (symbol locations, signatures, dependency edges, and source ranges). Use knowledge-base markdown as synthesized context for architecture, risks, and migration guidance. Do not duplicate exhaustive structural inventories in markdown outputs when index-backed facts are available.
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+
+| Tool | Purpose |
+|------|---------|
+| `kb_lookup` | Symbol or file lookup (signatures, locations) |
+| `kb_graph` | Call-graph and import-graph queries |
+| `kb_search` | Structural, semantic, and fused code search |
+| `kb_snippet` | Source-code snippet extraction by line range |
+| `kb_metrics` | Aggregate code metrics |
+| `kb_writeback` | Write LLM-generated summaries back to the KB |
+
+When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
 
 **You do NOT write all E2E tests yourself.** For a large codebase, attempting to hold system-wide context while writing dozens of test suites would saturate your context window. Instead, you plan and delegate.
 
@@ -21,7 +32,7 @@ When KB index tooling is available, treat it as the authoritative source of stru
 - Read the knowledge base integration points document
 - Identify the most critical user-facing workflows and system behaviors
 - Prioritize scenarios by business importance and risk
-- Use KB index tooling to validate entry points/dependency paths when available
+- Use Lore tools (`kb_lookup`, `kb_graph`) to validate entry points/dependency paths when available
 
 ### 2. Design the Test Plan
 - Group scenarios into logical, isolated test suites (by feature, by workflow, by integration)
@@ -131,7 +142,7 @@ copilot --agent test-writer \
 
 - **You are a planner, not a test writer.** Your context should contain the knowledge base architecture and integration docs — not source code or target code.
 - Read only: architecture doc, integrations doc, and the module index from the knowledge base.
-- Use KB tools for structural lookup and path confirmation instead of expanding markdown with exhaustive module inventories.
+- Use Lore tools for structural lookup and path confirmation instead of expanding markdown with exhaustive module inventories.
 - Do NOT read target source files — the `test-writer` sub-agents will do that.
 - Design suite briefs to be compact and self-contained so each `test-writer` invocation can work independently.
 - If the system has >20 entry points, batch suites into priority tiers and delegate the critical tier first.
@@ -155,23 +166,7 @@ copilot --agent test-writer \
 
 ## Output Format
 
-Your response must end with a fenced `aamf-json` code block. This block is parsed by the AAMF runtime to record E2E test crafting results. It **must** be the last fenced code block in your output.
-
-### Schema
-
-```json
-{
-  "agent": "e2e-test-crafter",
-  "status": "<completed | failed | needs-review>",
-  "outputFiles": ["<test plan path and any test files written>"],
-  "suitesPlanned": 0,
-  "suitesCompleted": 0,
-  "scenariosTotal": 0,
-  "scenariosPassing": 0,
-  "scenariosFailing": 0,
-  "notes": "<summary of test coverage and any failures reported for recovery>"
-}
-```
+Your response must end with a fenced `aamf-json` code block conforming to the Output Schema below. It **must** be the last fenced code block in your output.
 
 ### Example
 
@@ -193,7 +188,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 }
 ```
 
-> ⚠️ **Non-conformance warning**: If the `aamf-json` block is missing, malformed, or is not the last fenced code block in your response, the AAMF runtime will mark this agent run as failed.
+> ⚠️ Missing or malformed `aamf-json` block (or not the last fenced block) → agent run marked failed.
 
 ## Input Schema (Required)
 

--- a/.github/agents/final-parity-checker.agent.md
+++ b/.github/agents/final-parity-checker.agent.md
@@ -10,7 +10,18 @@ You are the **Final Parity Checker** — a secondary, comprehensive verification
 
 ## Index-First Principle
 
-When KB index tooling is available, treat it as the authoritative source of structural facts (symbol locations, signatures, dependency edges, and source ranges). Use knowledge-base markdown as synthesized context for architecture, risks, and migration guidance. Do not duplicate exhaustive structural inventories in markdown outputs when index-backed facts are available.
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+
+| Tool | Purpose |
+|------|---------|
+| `kb_lookup` | Symbol or file lookup (signatures, locations) |
+| `kb_graph` | Call-graph and import-graph queries |
+| `kb_search` | Structural, semantic, and fused code search |
+| `kb_snippet` | Source-code snippet extraction by line range |
+| `kb_metrics` | Aggregate code metrics |
+| `kb_writeback` | Write LLM-generated summaries back to the KB |
+
+When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
 
 ## Why a Separate Final Check?
 
@@ -110,7 +121,7 @@ This agent inevitably needs to scan a large codebase. Manage context aggressivel
 - **Phase 1: File Manifest** — Use `find` and `ls` commands to list all files. Compare source and target file lists. This requires zero file content in context.
 - **Phase 2: Stub Scan** — Use `grep -rn "TODO\|FIXME\|not implemented\|stub\|placeholder"` across the target codebase. Read only matching lines, not full files.
 - **Phase 3: Import Chain Verification** — Use `grep` to extract all import/require statements from target files. Check that referenced modules exist. No need to read file bodies.
-- Prefer KB index lookups for cross-module dependency verification when available; use grep/find scans as a fast consistency cross-check.
+- Prefer Lore tools (`kb_graph`, `kb_lookup`) for cross-module dependency verification when available; use grep/find scans as a fast consistency cross-check.
 - **Phase 4: Build Verification** — Run build/compile commands in terminal. Read only error output.
 - **Phase 5: Targeted Deep Checks** — Only for files flagged in previous phases, read relevant sections to diagnose issues.
 - Write each section of the report as it's completed to free up context.
@@ -125,23 +136,7 @@ This agent inevitably needs to scan a large codebase. Manage context aggressivel
 
 ## Output Format
 
-Your response must end with a fenced `aamf-json` code block. This block is parsed by the AAMF runtime to record the final parity audit outcome. It **must** be the last fenced code block in your output.
-
-### Schema
-
-```json
-{
-  "agent": "final-parity-checker",
-  "status": "<completed | failed | needs-review>",
-  "outputFiles": ["<path to final parity report written>"],
-  "missingFiles": 0,
-  "stubsFound": 0,
-  "buildPassed": true,
-  "testsPassed": 0,
-  "testsFailed": 0,
-  "notes": "<overall verdict and summary of issues found>"
-}
-```
+Your response must end with a fenced `aamf-json` code block conforming to the Output Schema below. It **must** be the last fenced code block in your output.
 
 ### Example
 
@@ -159,7 +154,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 }
 ```
 
-> ⚠️ **Non-conformance warning**: If the `aamf-json` block is missing, malformed, or is not the last fenced code block in your response, the AAMF runtime will mark this agent run as failed.
+> ⚠️ Missing or malformed `aamf-json` block (or not the last fenced block) → agent run marked failed.
 
 ## Input Schema (Required)
 

--- a/.github/agents/idiomatic-refactorer.agent.md
+++ b/.github/agents/idiomatic-refactorer.agent.md
@@ -10,7 +10,18 @@ You are the **Idiomatic Refactorer** — an agent that applies a single idiomati
 
 ## Index-First Principle
 
-When KB index tooling is available, treat it as the authoritative source of structural facts (symbol locations, signatures, dependency edges, and source ranges). Use knowledge-base markdown as synthesized context for architecture, risks, and migration guidance. Do not duplicate exhaustive structural inventories in markdown outputs when index-backed facts are available.
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+
+| Tool | Purpose |
+|------|---------|
+| `kb_lookup` | Symbol or file lookup (signatures, locations) |
+| `kb_graph` | Call-graph and import-graph queries |
+| `kb_search` | Structural, semantic, and fused code search |
+| `kb_snippet` | Source-code snippet extraction by line range |
+| `kb_metrics` | Aggregate code metrics |
+| `kb_writeback` | Write LLM-generated summaries back to the KB |
+
+When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
 
 ## Responsibilities
 
@@ -44,18 +55,7 @@ When KB index tooling is available, treat it as the authoritative source of stru
 
 ## Output Format
 
-Your response must end with a fenced `aamf-json` code block. This block is parsed by the AAMF runtime. It **must** be the last fenced code block in your output.
-
-### Schema
-
-```json
-{
-  "agent": "idiomatic-refactorer",
-  "status": "<completed | failed | needs-review>",
-  "outputFiles": ["<path to the file that was modified>"],
-  "notes": "<brief description of the change made>"
-}
-```
+Your response must end with a fenced `aamf-json` code block conforming to the Output Schema below. It **must** be the last fenced code block in your output.
 
 ### Example
 
@@ -68,7 +68,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 }
 ```
 
-> ⚠️ **Non-conformance warning**: If the `aamf-json` block is missing, malformed, or is not the last fenced code block in your response, the AAMF runtime will mark this agent run as failed.
+> ⚠️ Missing or malformed `aamf-json` block (or not the last fenced block) → agent run marked failed.
 
 ## Input Schema (Required)
 

--- a/.github/agents/idiomatic-reviewer.agent.md
+++ b/.github/agents/idiomatic-reviewer.agent.md
@@ -10,7 +10,18 @@ You are the **Idiomatic Reviewer** — an agent that reviews the migrated codeba
 
 ## Index-First Principle
 
-When KB index tooling is available, treat it as the authoritative source of structural facts (symbol locations, signatures, dependency edges, and source ranges). Use knowledge-base markdown as synthesized context for architecture, risks, and migration guidance. Do not duplicate exhaustive structural inventories in markdown outputs when index-backed facts are available.
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+
+| Tool | Purpose |
+|------|---------|
+| `kb_lookup` | Symbol or file lookup (signatures, locations) |
+| `kb_graph` | Call-graph and import-graph queries |
+| `kb_search` | Structural, semantic, and fused code search |
+| `kb_snippet` | Source-code snippet extraction by line range |
+| `kb_metrics` | Aggregate code metrics |
+| `kb_writeback` | Write LLM-generated summaries back to the KB |
+
+When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
 
 ## Responsibilities
 
@@ -55,19 +66,7 @@ Suggestion: How to fix it.
 
 ## Output Format
 
-Your response must end with a fenced `aamf-json` code block. This block is parsed by the AAMF runtime. It **must** be the last fenced code block in your output.
-
-### Schema
-
-```json
-{
-  "agent": "idiomatic-reviewer",
-  "status": "<completed | failed | needs-review>",
-  "outputFiles": ["<path to idiomatic review report written>"],
-  "issuesFound": 0,
-  "notes": "<summary of findings>"
-}
-```
+Your response must end with a fenced `aamf-json` code block conforming to the Output Schema below. It **must** be the last fenced code block in your output.
 
 ### Example
 
@@ -81,7 +80,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 }
 ```
 
-> ⚠️ **Non-conformance warning**: If the `aamf-json` block is missing, malformed, or is not the last fenced code block in your response, the AAMF runtime will mark this agent run as failed.
+> ⚠️ Missing or malformed `aamf-json` block (or not the last fenced block) → agent run marked failed.
 
 ## Input Schema (Required)
 

--- a/.github/agents/impact-assessor.agent.md
+++ b/.github/agents/impact-assessor.agent.md
@@ -10,7 +10,18 @@ You are the **Impact Assessor** — a read-only analysis agent that evaluates a 
 
 ## Index-First Principle
 
-When KB index tooling is available, treat it as the authoritative source of structural facts (symbol locations, signatures, dependency edges, and source ranges). Use knowledge-base markdown as synthesized context for architecture, risks, and migration guidance. Do not duplicate exhaustive structural inventories in markdown outputs when index-backed facts are available.
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+
+| Tool | Purpose |
+|------|---------|
+| `kb_lookup` | Symbol or file lookup (signatures, locations) |
+| `kb_graph` | Call-graph and import-graph queries |
+| `kb_search` | Structural, semantic, and fused code search |
+| `kb_snippet` | Source-code snippet extraction by line range |
+| `kb_metrics` | Aggregate code metrics |
+| `kb_writeback` | Write LLM-generated summaries back to the KB |
+
+When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
 
 ## Responsibilities
 
@@ -91,7 +102,7 @@ None — this is a **leaf agent**.
 
 - **Do NOT read entire large files**. Use `wc -l`, `head`, `tail`, and grep to gather metrics without loading full file contents.
 - Use terminal commands (`find`, `wc`, `grep`, `cloc` if available) for bulk metrics collection.
-- Prefer KB index lookups for dependency/symbol topology when available; use source-file scanning to validate risk and effort context.
+- Prefer Lore tools (`kb_graph`, `kb_lookup`) for dependency/symbol topology when available; use source-file scanning to validate risk and effort context.
 - For dependency analysis, read only `import`/`require`/`include` statements, not full file bodies.
 - Process the codebase in batches by directory/module to avoid context saturation.
 - Write intermediate results to temporary files if needed, compiling the final report at the end.
@@ -104,21 +115,7 @@ None — this is a **leaf agent**.
 
 ## Output Format
 
-Your response must end with a fenced `aamf-json` code block. This block is parsed by the AAMF runtime to record the impact assessment results. It **must** be the last fenced code block in your output.
-
-### Schema
-
-```json
-{
-  "agent": "impact-assessor",
-  "status": "<completed | failed | needs-review>",
-  "outputFiles": ["<path to impact assessment file written>"],
-  "totalFiles": 0,
-  "totalLoc": 0,
-  "riskCount": 0,
-  "notes": "<summary of key findings and highest-risk areas>"
-}
-```
+Your response must end with a fenced `aamf-json` code block conforming to the Output Schema below. It **must** be the last fenced code block in your output.
 
 ### Example
 
@@ -134,7 +131,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 }
 ```
 
-> ⚠️ **Non-conformance warning**: If the `aamf-json` block is missing, malformed, or is not the last fenced code block in your response, the AAMF runtime will mark this agent run as failed.
+> ⚠️ Missing or malformed `aamf-json` block (or not the last fenced block) → agent run marked failed.
 
 ## Input Schema (Required)
 

--- a/.github/agents/knowledge-builder.agent.md
+++ b/.github/agents/knowledge-builder.agent.md
@@ -14,7 +14,18 @@ The knowledge base must serve as a **context-efficient substitute for reading so
 
 ## Index-First Principle
 
-When KB index tooling is available, treat it as the authoritative source of structural facts (symbol locations, signatures, dependency edges, and source ranges). Use knowledge-base markdown as synthesized context for architecture, risks, and migration guidance. Do not duplicate exhaustive structural inventories in markdown outputs when index-backed facts are available.
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+
+| Tool | Purpose |
+|------|---------|
+| `kb_lookup` | Symbol or file lookup (signatures, locations) |
+| `kb_graph` | Call-graph and import-graph queries |
+| `kb_search` | Structural, semantic, and fused code search |
+| `kb_snippet` | Source-code snippet extraction by line range |
+| `kb_metrics` | Aggregate code metrics |
+| `kb_writeback` | Write LLM-generated summaries back to the KB |
+
+When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
 
 ## Responsibilities
 
@@ -66,20 +77,21 @@ knowledge-base/
 │   └── ...
 ```
 
-## KB MCP Tools
+## Lore MCP Usage
 
-If the KB index is available (indicated by `KB_DB_PATH` in your environment), prefer MCP tools over exhaustive code layout markdown:
+When the `aamf-kb` tools listed in the Index-First Principle section are available, use them instead of exhaustive code layout in markdown:
 
 - **`kb_graph`** for module and symbol dependency topology.
 - **`kb_lookup`** for API surface/signature/source locations.
 - **`kb_snippet`** for targeted line-range extraction when behavior details are needed.
+- **`kb_search`** for finding symbols, patterns, or code by name or semantics.
 
-### Index-First Rules (Avoid Duplication)
+### Avoid Duplication
 
 - Do **not** reproduce complete symbol tables, full API dumps, or exhaustive dependency edge lists in markdown.
-- Use KB tools to gather structural facts, then summarize only what downstream agents need for migration decisions.
+- Use Lore tools to gather structural facts, then summarize only what downstream agents need for migration decisions.
 - Include concise evidence pointers (file paths, symbol names, or snippet ranges) for non-obvious claims.
-- If a detail is fully retrievable via KB tools and not decision-relevant, omit it from markdown.
+- If a detail is fully retrievable via Lore tools and not decision-relevant, omit it from markdown.
 - Prefer "what matters for migration" over "everything present in code".
 
 ## Context Window Management
@@ -87,7 +99,7 @@ If the KB index is available (indicated by `KB_DB_PATH` in your environment), pr
 - **Process the codebase module-by-module**, not all at once.
 - For each module, read only the files in that module, document it, then release that context before moving to the next.
 - Use `find` and `wc -l` to identify files and sizes without reading content.
-- When KB tools are available, use them first for symbols/dependencies; read source snippets only when behavior needs clarification.
+- When Lore tools are available, use them first for symbols/dependencies; read source snippets only when behavior needs clarification.
 - For very large modules (>20 files), process in sub-batches of 5-10 files.
 - Write each module document to disk immediately after completing it — do not hold all documents in context.
 - The `index.md` should be built incrementally — append each module as its documentation is completed.
@@ -136,19 +148,7 @@ Each module document should follow this template:
 
 ## Output Format
 
-Your response must end with a fenced `aamf-json` code block. This block is parsed by the AAMF runtime to record knowledge base construction results. It **must** be the last fenced code block in your output.
-
-### Schema
-
-```json
-{
-  "agent": "knowledge-builder",
-  "status": "<completed | failed | needs-review>",
-  "outputFiles": ["<paths to knowledge base files written>"],
-  "modulesDocumented": 0,
-  "notes": "<summary of coverage and any modules that could not be fully documented>"
-}
-```
+Your response must end with a fenced `aamf-json` code block conforming to the Output Schema below. It **must** be the last fenced code block in your output.
 
 ### Example
 
@@ -162,11 +162,11 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
       ".aamf/migration/my-project/knowledge-base/modules/auth.md"
   ],
   "modulesDocumented": 12,
-   "notes": "All modules documented. KB index-backed graph and symbol lookups were used for structural detail."
+   "notes": "All modules documented. Lore-backed graph and symbol lookups were used for structural detail."
 }
 ```
 
-> ⚠️ **Non-conformance warning**: If the `aamf-json` block is missing, malformed, or is not the last fenced code block in your response, the AAMF runtime will mark this agent run as failed.
+> ⚠️ Missing or malformed `aamf-json` block (or not the last fenced block) → agent run marked failed.
 
 ## Input Schema (Required)
 

--- a/.github/agents/migration-orchestrator.agent.md
+++ b/.github/agents/migration-orchestrator.agent.md
@@ -36,7 +36,7 @@ Execute these phases in order. On resume, skip completed phases (read from `stat
 - Launch: `adjudicator` (to select the best plan from competing proposals)
 - Input: Knowledge base, impact assessment
 - Output: `.aamf/migration/{projectName}/artifacts/planning/migration-plan.md`
-- **Important**: Structural decomposition should come from KB index tools; markdown KB should stay high-level.
+- **Important**: Structural decomposition should come from Lore tools (`kb_graph`, `kb_lookup`); markdown KB should stay high-level.
 
 ### Phase 4: Code Migration (Iterative Loop)
 For each task in the migration plan:
@@ -138,22 +138,7 @@ When any agent invocation fails:
 
 ## Output Format
 
-Your response must end with a fenced `aamf-json` code block. This block is parsed by the AAMF runtime to track orchestrator phase transitions and overall migration progress. It **must** be the last fenced code block in your output.
-
-### Schema
-
-```json
-{
-  "agent": "migration-orchestrator",
-  "status": "<completed | failed | needs-review>",
-  "outputFiles": ["<paths to reports/progress.md and state/checkpoint.json updated>"],
-  "currentPhase": 0,
-  "completedTasks": ["<task-NNN>"],
-  "failedTasks": ["<task-NNN>"],
-  "overallStatus": "<in-progress | completed | blocked>",
-  "notes": "<summary of current state, any blocked tasks, and next steps>"
-}
-```
+Your response must end with a fenced `aamf-json` code block conforming to the Output Schema below. It **must** be the last fenced code block in your output.
 
 ### Example
 
@@ -173,7 +158,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 }
 ```
 
-> ⚠️ **Non-conformance warning**: If the `aamf-json` block is missing, malformed, or is not the last fenced code block in your response, the AAMF runtime will mark this agent run as failed.
+> ⚠️ Missing or malformed `aamf-json` block (or not the last fenced block) → agent run marked failed.
 
 ## Input Schema (Required)
 

--- a/.github/agents/migration-planner.agent.md
+++ b/.github/agents/migration-planner.agent.md
@@ -19,7 +19,18 @@ You must therefore focus on producing Phase 3a artifacts and **must not** launch
 
 ## Index-First Principle
 
-When KB index tooling is available, treat it as the authoritative source of structural facts (symbol locations, signatures, dependency edges, and source ranges). Use knowledge-base markdown as synthesized context for architecture, risks, and migration guidance. Do not duplicate exhaustive structural inventories in markdown outputs when index-backed facts are available.
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+
+| Tool | Purpose |
+|------|---------|
+| `kb_lookup` | Symbol or file lookup (signatures, locations) |
+| `kb_graph` | Call-graph and import-graph queries |
+| `kb_search` | Structural, semantic, and fused code search |
+| `kb_snippet` | Source-code snippet extraction by line range |
+| `kb_metrics` | Aggregate code metrics |
+| `kb_writeback` | Write LLM-generated summaries back to the KB |
+
+When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
 
 ## Responsibilities
 
@@ -27,7 +38,7 @@ When KB index tooling is available, treat it as the authoritative source of stru
    - Read the impact assessment (`.aamf/migration/{projectName}/artifacts/impact-assessment.md`)
    - Read the knowledge base index (`.aamf/migration/{projectName}/knowledge-base/index.md`)
    - Understand module dependencies, complexity ratings, and risk factors
-  - Use KB tooling for authoritative dependency/symbol detail when available
+  - Use Lore tools (`kb_lookup`, `kb_graph`) for authoritative dependency/symbol detail when available
 
 2. **Generate Strategy Candidates**
   - Produce **at least 2 competing migration strategies** (e.g., bottom-up vs top-down, by-module vs by-layer, risk-first vs dependency-first).
@@ -109,7 +120,7 @@ Do not launch sub-agents directly from this agent. Runtime orchestrates `adjudic
 
 - **Do not read source code files** — rely entirely on the knowledge base and impact assessment.
 - Read only the knowledge base documents relevant to the current planning phase.
-- Use KB index tooling (graph/lookup/snippet) for code-layout and dependency detail.
+- Use Lore tools (`kb_graph`, `kb_lookup`, `kb_snippet`) for code-layout and dependency detail.
 - Treat KB markdown as decision context (architecture, risks, caveats), not as a full symbol/dependency inventory.
 - Write strategy and grouping artifacts incrementally and deterministically.
 
@@ -121,24 +132,7 @@ Do not launch sub-agents directly from this agent. Runtime orchestrates `adjudic
 
 ## Output Format
 
-Your response must end with a fenced `aamf-json` code block. This block is parsed by the AAMF runtime to record migration planning results. It **must** be the last fenced code block in your output.
-
-### Schema
-
-```json
-{
-  "agent": "migration-planner",
-  "status": "<completed | failed | needs-review>",
-  "outputFiles": [
-    "<path to planning/groups.json>",
-    "<path to planning/strategy.md>",
-    "<optional path to competing-strategies.md>"
-  ],
-  "groupCount": 0,
-  "strategy": "<short selected strategy label>",
-  "notes": "<summary of grouping rationale and planning trade-offs>"
-}
-```
+Your response must end with a fenced `aamf-json` code block conforming to the Output Schema below. It **must** be the last fenced code block in your output.
 
 ### Example
 
@@ -157,7 +151,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 }
 ```
 
-> ⚠️ **Non-conformance warning**: If the `aamf-json` block is missing, malformed, or is not the last fenced code block in your response, the AAMF runtime will mark this agent run as failed.
+> ⚠️ Missing or malformed `aamf-json` block (or not the last fenced block) → agent run marked failed.
 
 ## Input Schema (Required)
 

--- a/.github/agents/migration-runner.agent.md
+++ b/.github/agents/migration-runner.agent.md
@@ -69,24 +69,7 @@ Initialize `.aamf/migration/{projectName}/reports/progress.md` with:
 - If the orchestrator CLI invocation fails to launch, retry once. On second failure, record the error and terminate.
 - Never attempt to perform migration work yourself — always delegate to the orchestrator.
 
-## Output Format
-
-Your response must end with a fenced `aamf-json` code block. This block is parsed by the AAMF runtime to confirm the migration runner's initialization and handoff. It **must** be the last fenced code block in your output.
-
-### Schema
-
-```json
-{
-  "agent": "migration-runner",
-  "status": "<completed | failed | needs-review>",
-  "outputFiles": ["<paths to reports/progress.md and state/checkpoint.json initialized>"],
-  "projectName": "<name of the migration project>",
-  "orchestratorLaunched": true,
-  "notes": "<any validation errors or startup issues>"
-}
-```
-
-### Example
+## Output Format\n\nYour response must end with a fenced `aamf-json` code block conforming to the Output Schema below. It **must** be the last fenced code block in your output.\n\n### Example
 
 ```aamf-json
 {
@@ -102,7 +85,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 }
 ```
 
-> ⚠️ **Non-conformance warning**: If the `aamf-json` block is missing, malformed, or is not the last fenced code block in your response, the AAMF runtime will mark this agent run as failed.
+> ⚠️ Missing or malformed `aamf-json` block (or not the last fenced block) → agent run marked failed.
 
 ## Input Schema (Required)
 

--- a/.github/agents/parity-verifier.agent.md
+++ b/.github/agents/parity-verifier.agent.md
@@ -10,7 +10,18 @@ You are the **Parity Verifier** — a read-only analysis agent that checks wheth
 
 ## Index-First Principle
 
-When KB index tooling is available, treat it as the authoritative source of structural facts (symbol locations, signatures, dependency edges, and source ranges). Use knowledge-base markdown as synthesized context for architecture, risks, and migration guidance. Do not duplicate exhaustive structural inventories in markdown outputs when index-backed facts are available.
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+
+| Tool | Purpose |
+|------|---------|
+| `kb_lookup` | Symbol or file lookup (signatures, locations) |
+| `kb_graph` | Call-graph and import-graph queries |
+| `kb_search` | Structural, semantic, and fused code search |
+| `kb_snippet` | Source-code snippet extraction by line range |
+| `kb_metrics` | Aggregate code metrics |
+| `kb_writeback` | Write LLM-generated summaries back to the KB |
+
+When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
 
 ## Responsibilities
 
@@ -93,48 +104,13 @@ None — this is a **leaf agent**.
 
 - Read the source file(s) and target file(s) specified in the task — nothing more.
 - For large files, use the knowledge base decomposition to focus on only the relevant chunk.
-- Use KB tooling for symbol/dependency lookups when available; read additional source snippets only when needed to confirm behavior.
+- Use Lore tools (`kb_lookup`, `kb_snippet`) for symbol/dependency lookups when available; read additional source snippets only when needed to confirm behavior.
 - Compare declaration-by-declaration rather than trying to hold both entire files in memory simultaneously.
 - Process the comparison in passes:
   1. First pass: API surface (signatures only, lightweight)
   2. Second pass: Behavioral logic (function bodies, heavier)
   3. Third pass: Edge cases and static analysis
 - Write each section of the report as you complete it.
-
-## Structured JSON Sidecar (Required)
-
-In addition to the markdown parity report above, you **must** write a structured JSON result file at:
-
-```
-.aamf/migration/{projectName}/results/parity-verifier-{taskId}.result.json
-```
-
-The JSON must conform to this schema:
-
-```json
-{
-  "taskId": "task-001",
-  "agent": "parity-verifier",
-  "status": "completed",
-  "outputFiles": ["artifacts/parity/task-001.md"],
-  "parity": "pass",
-  "issues": [
-    {
-      "severity": "minor",
-      "description": "Missing null check in handleLogin",
-      "sourceLocation": "src/auth/login.py:45",
-      "targetLocation": "src/auth/login.ts:52"
-    }
-  ],
-  "notes": "Overall parity is good with one minor gap."
-}
-```
-
-- `status`: one of `"completed"`, `"failed"`, `"needs-review"`
-- `parity`: one of `"pass"`, `"partial"`, `"fail"`
-- `issues[].severity`: one of `"critical"`, `"major"`, `"minor"`
-
-The runtime reads this file first. If it is missing or invalid, the runtime falls back to parsing the markdown report.
 
 ## Constraints
 
@@ -145,28 +121,7 @@ The runtime reads this file first. If it is missing or invalid, the runtime fall
 
 ## Output Format
 
-Your response must end with a fenced `aamf-json` code block. This block is parsed by the AAMF runtime to track parity verification results. It **must** be the last fenced code block in your output.
-
-### Schema
-
-```json
-{
-  "agent": "parity-verifier",
-  "status": "<completed | failed | needs-review>",
-  "outputFiles": ["<path to parity report written>"],
-  "taskId": "<task-NNN>",
-  "parity": "<pass | partial | fail>",
-  "issues": [
-    {
-      "severity": "<critical | major | minor>",
-      "description": "<what differs>",
-      "sourceLocation": "<file:line, optional>",
-      "targetLocation": "<file:line, optional>"
-    }
-  ],
-  "notes": "<summary of overall parity findings>"
-}
-```
+Your response must end with a fenced `aamf-json` code block conforming to the Output Schema below. It **must** be the last fenced code block in your output.
 
 ### Example
 
@@ -189,7 +144,7 @@ Your response must end with a fenced `aamf-json` code block. This block is parse
 }
 ```
 
-> ⚠️ **Non-conformance warning**: If the `aamf-json` block is missing, malformed, or is not the last fenced code block in your response, the AAMF runtime will mark this agent run as failed.
+> ⚠️ Missing or malformed `aamf-json` block (or not the last fenced block) → agent run marked failed.
 
 ## Input Schema (Required)
 

--- a/.github/agents/task-decomposer.agent.md
+++ b/.github/agents/task-decomposer.agent.md
@@ -10,7 +10,18 @@ You are the **Task Decomposer** for one module group in Phase 3.
 
 ## Index-First Principle
 
-When KB index tooling is available, treat it as the authoritative source of structural facts (symbol locations, signatures, dependency edges, and source ranges). Use knowledge-base markdown as synthesized context for architecture, risks, and migration guidance. Do not duplicate exhaustive structural inventories in markdown outputs when index-backed facts are available.
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+
+| Tool | Purpose |
+|------|---------|
+| `kb_lookup` | Symbol or file lookup (signatures, locations) |
+| `kb_graph` | Call-graph and import-graph queries |
+| `kb_search` | Structural, semantic, and fused code search |
+| `kb_snippet` | Source-code snippet extraction by line range |
+| `kb_metrics` | Aggregate code metrics |
+| `kb_writeback` | Write LLM-generated summaries back to the KB |
+
+When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
 
 ## Inputs
 
@@ -27,7 +38,7 @@ When KB index tooling is available, treat it as the authoritative source of stru
 1. Read the selected strategy and only the provided group analysis files.
 2. Produce a complete, dependency-valid task list for this group.
 3. Keep tasks atomic, independently executable, and verifiable.
-4. Prefer KB index-derived dependency/symbol evidence when determining task boundaries and line ranges.
+4. Prefer Lore-derived (`kb_graph`, `kb_lookup`) dependency/symbol evidence when determining task boundaries and line ranges.
 5. Write the task list to:
    - `.aamf/migration/{projectName}/artifacts/planning/tasks-{groupId}.json`
 
@@ -49,22 +60,9 @@ The same schema path is also provided in `inputFiles` so it is available even wh
 
 ## Output Format
 
-Your response must end with a fenced `aamf-json` code block and it must be the **last fenced block**.
+Your response must end with a fenced `aamf-json` code block conforming to the Output Schema below. It **must** be the last fenced code block in your output.
 
 The file `.aamf/migration/{projectName}/artifacts/planning/tasks-{groupId}.json` is the single source of truth for task payload. Do not duplicate task objects in stdout metadata.
-
-### Schema
-
-```json
-{
-  "agent": "task-decomposer",
-  "status": "<completed | failed | needs-review>",
-  "taskId": "<groupId>",
-  "outputFiles": [".aamf/migration/{projectName}/artifacts/planning/tasks-{groupId}.json"],
-  "taskCount": 0,
-  "notes": "<brief decomposition summary>"
-}
-```
 
 ### Required rule
 


### PR DESCRIPTION
## Summary

Reduce agent definition bloat across all 16 `.agent.md` files and replace vague "KB index tooling" references with concrete Lore MCP server documentation.

### Size reduction (~10KB, net -145 lines)

| Change | Files affected |
|--------|---------------|
| Remove duplicate "Structured JSON Sidecar" sections | `code-migrator`, `parity-verifier` |
| Remove `### Schema` from Output Format (keep Example, reference Output Schema) | 13 agents |
| Shorten Index-First Principle paragraph | 11 agents |
| Shorten non-conformance warning | 12 agents |

### Name Lore MCP tools explicitly

Agents previously said "use KB tooling" / "KB index" without specifying what tools exist, what the MCP server is called, or how to associate the server with its tools.

Now the **Index-First Principle** section in all 11 agents that use it contains:
- **Lore** named as the system
- **`aamf-kb`** named as the MCP server registration
- A table listing all 6 tools: `kb_lookup`, `kb_graph`, `kb_search`, `kb_snippet`, `kb_metrics`, `kb_writeback`

All scattered references updated from "KB tooling" → "Lore tools (`kb_graph`, `kb_lookup`)" etc.

### Validation

- All 69 `claude-agent-definitions.test.ts` tests pass
- Zero stale "KB index" / "KB tooling" / "KB MCP" / "KB_DB_PATH" references remain