### PR TITLE
feat(agents): inject execution strategy into planner context

### DIFF
--- a/runtime/src/agents/context-builder.ts
+++ b/runtime/src/agents/context-builder.ts
@@ -170,6 +170,9 @@ export class ContextBuilder {
         return {
           inputFiles: [join(kbDir, 'index.md'), impactAssessment],
           outputPath: join(this.progressDir, 'artifacts', 'planning'),
+          agentPayload: {
+            executionStrategy: this.buildExecutionStrategy(),
+          },
         };
 
       case 'task-decomposer': {
@@ -185,6 +188,7 @@ export class ContextBuilder {
             groupName: payload?.groupName,
             taskSchemaPath: TASK_DECOMPOSER_SCHEMA_PATH,
             maxLinesPerTask: this.config.options.maxLinesPerTask,
+            executionStrategy: this.buildExecutionStrategy(),
           },
         };
       }
@@ -320,5 +324,27 @@ export class ContextBuilder {
           outputPath: this.progressDir,
         };
     }
+  }
+
+  /**
+   * Build the execution-strategy descriptor from the current config.
+   * Injected into the planning agents' payload so they can reason about
+   * how Phase 4 will execute their task graph.
+   */
+  private buildExecutionStrategy(): import('./types.js').ExecutionStrategy {
+    const opts = this.config.options;
+    const waveControl = opts.waveControl ?? { waveSize: 3, maxConvergenceIterations: 3 };
+    return {
+      executionMode: opts.executionMode ?? 'per-task',
+      maxParallelAgents: opts.maxParallelAgents,
+      waveControl: {
+        waveSize: waveControl.waveSize,
+        maxConvergenceIterations: waveControl.maxConvergenceIterations,
+      },
+      maxRetriesPerTask: opts.maxRetriesPerTask,
+      buildCommand: this.config.target.buildCommand,
+      testCommand: this.config.target.testCommand,
+      requiresNonOverlappingTargets: true,
+    };
   }
 }

--- a/runtime/src/agents/types.ts
+++ b/runtime/src/agents/types.ts
@@ -186,6 +186,49 @@ export interface AgentContext {
   payload?: Record<string, unknown>;
 }
 
+// ─── Execution Strategy ──────────────────────────────────────────────────────
+
+/**
+ * Execution-topology context passed to planning agents (`migration-planner`,
+ * `task-decomposer`) so they can tailor task granularity, grouping, and
+ * dependency design to the actual Phase 4 execution mode.
+ *
+ * Agents that receive this in their `payload.executionStrategy` can, for
+ * example, co-locate related files into the same wave-friendly grouping,
+ * avoid target-directory overlap that would shrink wave batch size, or
+ * calibrate task complexity against the available recovery budget.
+ */
+export interface ExecutionStrategy {
+  /** Phase 4 execution mode: `'per-task'` (serial) or `'wave-barrier'` (concurrent waves). */
+  executionMode: 'per-task' | 'wave-barrier';
+
+  /** Maximum number of agent subprocesses running in parallel. */
+  maxParallelAgents: number;
+
+  /** Wave-barrier settings (only meaningful when `executionMode === 'wave-barrier'`). */
+  waveControl: {
+    /** Number of tasks that run concurrently within a single wave. */
+    waveSize: number;
+    /** Maximum build/test convergence iterations per wave before giving up. */
+    maxConvergenceIterations: number;
+  };
+
+  /** Maximum retry attempts per task before failure-adjudication. */
+  maxRetriesPerTask: number;
+
+  /** Shell command used to build the target project (empty when not configured). */
+  buildCommand?: string;
+
+  /** Shell command used to test the target project (empty when not configured). */
+  testCommand?: string;
+
+  /**
+   * Whether wave members must have non-overlapping target files/directories.
+   * Always `true` — exposed so the planner can reason about the constraint.
+   */
+  requiresNonOverlappingTargets: true;
+}
+
 // ─── Recovery Remediation Contracts ───────────────────────────────────────────
 
 /**

--- a/runtime/tests/context-builder.test.ts
+++ b/runtime/tests/context-builder.test.ts
@@ -137,6 +137,63 @@ describe('ContextBuilder', () => {
       expect(context.outputPath).toContain('planning');
     });
 
+    it('should include executionStrategy in migration-planner payload with default config', async () => {
+      const contextPath = await builder.buildContext('migration-planner', 3);
+      const context = await readJson<AgentContext>(contextPath);
+      const strategy = context.payload?.executionStrategy as Record<string, unknown>;
+
+      expect(strategy).toBeDefined();
+      expect(strategy.executionMode).toBe('per-task');
+      expect(strategy.maxParallelAgents).toBe(3);
+      expect(strategy.maxRetriesPerTask).toBe(3);
+      expect(strategy.requiresNonOverlappingTargets).toBe(true);
+      expect(strategy.waveControl).toEqual({ waveSize: 3, maxConvergenceIterations: 3 });
+      expect(strategy.buildCommand).toBeUndefined();
+      expect(strategy.testCommand).toBeUndefined();
+    });
+
+    it('should reflect wave-barrier mode and build/test commands in migration-planner executionStrategy', async () => {
+      const config = createMockConfig({
+        target: {
+          language: 'rust',
+          outputPath: '/tmp/target',
+          buildCommand: 'cargo build',
+          testCommand: 'cargo test',
+        },
+        options: {
+          maxParallelAgents: 5,
+          maxRetriesPerTask: 2,
+          maxLinesPerTask: 500,
+          dryRun: false,
+          resume: false,
+          invocationDelayMs: 0,
+          buildConcurrency: 1,
+          continueOnBlocked: true,
+          maxBlockedTasks: 0,
+          maxInfraRetries: 3,
+          avgTokensPerTask: 5000,
+          contextWindowStrategy: 'per-invocation' as const,
+          keepArtifacts: false,
+          qualityPolicy: 'strict' as const,
+          executionMode: 'wave-barrier' as const,
+          waveControl: { waveSize: 4, maxConvergenceIterations: 5 },
+          git: { enabled: false, autoInit: true, commitByAgent: true, commitPerTask: true, authorName: 'AAMF Migration Bot', authorEmail: 'aamf@local.invalid' },
+        },
+      });
+      const b = new ContextBuilder(config, progressDir, paths);
+      const contextPath = await b.buildContext('migration-planner', 3);
+      const context = await readJson<AgentContext>(contextPath);
+      const strategy = context.payload?.executionStrategy as Record<string, unknown>;
+
+      expect(strategy.executionMode).toBe('wave-barrier');
+      expect(strategy.maxParallelAgents).toBe(5);
+      expect(strategy.maxRetriesPerTask).toBe(2);
+      expect(strategy.waveControl).toEqual({ waveSize: 4, maxConvergenceIterations: 5 });
+      expect(strategy.buildCommand).toBe('cargo build');
+      expect(strategy.testCommand).toBe('cargo test');
+      expect(strategy.requiresNonOverlappingTargets).toBe(true);
+    });
+
     it('should route adjudicator to competing strategies file', async () => {
       const contextPath = await builder.buildContext('adjudicator', 3, undefined, {
         competingStrategiesFile: '/tmp/strategies.md',
@@ -174,6 +231,22 @@ describe('ContextBuilder', () => {
       expect(context.payload?.maxLinesPerTask).toBe(500);
       expect(context.inputFiles).toContain('/tmp/strategy.md');
       expect(context.inputFiles).toContain('/tmp/kb-core.md');
+    });
+
+    it('should include executionStrategy in task-decomposer payload', async () => {
+      const contextPath = await builder.buildContext('task-decomposer', 3, 'core', {
+        strategyFile: '/tmp/strategy.md',
+        analysisFiles: ['/tmp/kb-core.md'],
+        groupId: 'core',
+        groupName: 'Core',
+      });
+      const context = await readJson<AgentContext>(contextPath);
+      const strategy = context.payload?.executionStrategy as Record<string, unknown>;
+
+      expect(strategy).toBeDefined();
+      expect(strategy.executionMode).toBe('per-task');
+      expect(strategy.maxParallelAgents).toBe(3);
+      expect(strategy.requiresNonOverlappingTargets).toBe(true);
     });
 
     it('should route code-migrator with task-specific source/target files', async () => {


### PR DESCRIPTION
## Summary

Give the `migration-planner` and `task-decomposer` agents visibility into the Phase 4 execution topology via a new `executionStrategy` payload field.

Previously the planner ran blind — it could not reason about wave size, concurrency, build/test commands, retry budgets, or the non-overlapping-target constraint that governs wave batch formation.

## Changes

- **`ExecutionStrategy` interface** (`agents/types.ts`) — describes the execution mode, wave control, parallelism, retry budget, build/test commands, and the non-overlapping-targets constraint.
- **`buildExecutionStrategy()`** (`agents/context-builder.ts`) — private method that assembles the descriptor from the current `MigrationConfig`.
- **`migration-planner`** now receives `executionStrategy` in its `agentPayload` so it can tailor task grouping and dependency design to the actual execution mode.
- **`task-decomposer`** now receives `executionStrategy` alongside the existing `maxLinesPerTask`/`groupId`/etc. so it can calibrate task granularity and target-file layout.

## What the planner can now reason about

| Field | Why it matters |
|---|---|
| `executionMode` | Decomposition strategy should differ between `per-task` and `wave-barrier` |
| `waveControl.waveSize` | Can optimize task clusters to match wave capacity |
| `maxParallelAgents` | Can structure independent task groups to maximize throughput |
| `maxRetriesPerTask` | Can calibrate task complexity against available recovery budget |
| `buildCommand` / `testCommand` | Can factor build-system coupling into dependency design |
| `requiresNonOverlappingTargets` | Can produce tasks that are naturally non-overlapping, avoiding batch-size reduction |

## Tests

3 new tests covering:
- Default config values flow through to planner payload
- Wave-barrier mode with custom wave size and build/test commands
- Task-decomposer also receives the strategy

All 1019 tests pass.