### PR TITLE
feat(observability): stream agent stdout/stderr live during execution

### DIFF
--- a/runtime/src/core/agent-launcher.ts
+++ b/runtime/src/core/agent-launcher.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import { readFile, readdir, stat } from 'node:fs/promises';
+import { readFile, readdir, stat, appendFile } from 'node:fs/promises';
 import { AgentInvocation, AgentName, AgentResult } from '../agents/types.js';
 import { MigrationConfig } from '../config/schema.js';
 import { spawnWithTimeout, resolveLoginPath } from '../util/process.js';
@@ -91,6 +91,95 @@ async function writeAgentLog(logDir: string, agent: string, taskId: string, stdo
   const filename = invocationId ? `${invocationId}-${timestamp}.log` : `${timestamp}.log`;
   const content = `=== STDOUT ===\n${stdout}\n\n=== STDERR ===\n${stderr}\n`;
   await atomicWrite(join(targetDir, filename), content);
+}
+
+// ─── Live output streaming ────────────────────────────────────────────────────
+
+/**
+ * Create a pair of callbacks that stream agent stdout/stderr line-by-line to:
+ *  1. A live log file (`.live.log`) in the agent log directory
+ *  2. The runtime logger as `agent-output-line` events (debug level)
+ *
+ * Chunks from the child process may not be line-aligned, so each callback
+ * maintains a residual buffer and flushes complete lines only.
+ *
+ * Returns `{ onStdoutData, onStderrData, flush }`. Call `flush()` after the
+ * process exits to write any remaining partial line.
+ */
+function createLiveOutputCallbacks(
+  logDir: string,
+  agent: string,
+  taskId: string,
+  invocationId: string,
+  logger: Logger,
+): {
+  onStdoutData: (chunk: Buffer) => void;
+  onStderrData: (chunk: Buffer) => void;
+  flush: () => Promise<void>;
+} {
+  const targetDir = join(logDir, agent, taskId);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const liveLogPath = join(targetDir, `${invocationId}-${timestamp}.live.log`);
+
+  // Serialise writes so they never interleave
+  let writeChain: Promise<void> = ensureDir(targetDir);
+
+  const enqueueWrite = (text: string): void => {
+    writeChain = writeChain
+      .then(() => appendFile(liveLogPath, text, 'utf-8'))
+      .catch(() => {/* best-effort */});
+  };
+
+  // Per-stream residual buffers for incomplete lines
+  let stdoutResidue = '';
+  let stderrResidue = '';
+
+  const processChunk = (
+    chunk: Buffer,
+    residue: string,
+    stream: 'stdout' | 'stderr',
+  ): string => {
+    const text = residue + chunk.toString('utf-8');
+    const lines = text.split('\n');
+    // Last element is either empty (if text ended with \n) or an incomplete line
+    const remaining = lines.pop()!;
+
+    for (const line of lines) {
+      const prefixed = `[${stream}] ${line}\n`;
+      enqueueWrite(prefixed);
+      logger.event({
+        type: 'agent-output-line',
+        agent,
+        taskId,
+        invocationId,
+        stream,
+        line,
+      });
+    }
+
+    return remaining;
+  };
+
+  return {
+    onStdoutData: (chunk: Buffer) => {
+      stdoutResidue = processChunk(chunk, stdoutResidue, 'stdout');
+    },
+    onStderrData: (chunk: Buffer) => {
+      stderrResidue = processChunk(chunk, stderrResidue, 'stderr');
+    },
+    flush: async () => {
+      // Flush any remaining partial lines
+      if (stdoutResidue) {
+        enqueueWrite(`[stdout] ${stdoutResidue}\n`);
+        stdoutResidue = '';
+      }
+      if (stderrResidue) {
+        enqueueWrite(`[stderr] ${stderrResidue}\n`);
+        stderrResidue = '';
+      }
+      await writeChain;
+    },
+  };
 }
 
 /** Shared helper: detect output files created by the agent in the progress directory. */
@@ -341,14 +430,24 @@ export class CopilotRunner implements AgentRunner {
     };
     // ────────────────────────────────────────────────────────────────
 
+    // ── Live output streaming ────────────────────────────────────────
+    const liveTaskId = invocation.taskId ?? 'main';
+    const liveCallbacks = createLiveOutputCallbacks(
+      this.logDir, invocation.agent, liveTaskId, invocationId, invLogger,
+    );
+    // ────────────────────────────────────────────────────────────────
+
     try {
       const result = await spawnWithTimeout(cliCommand, args, {
         cwd: this.projectRoot,
         env,
         timeout,
+        onStdoutData: liveCallbacks.onStdoutData,
+        onStderrData: liveCallbacks.onStderrData,
       });
 
       stopTimers();
+      await liveCallbacks.flush();
       const duration = Date.now() - startTime;
 
       const taskId = invocation.taskId ?? 'main';
@@ -379,6 +478,7 @@ export class CopilotRunner implements AgentRunner {
       return finaliseResult(agentResult, result.stdout, prompt, invLogger);
     } catch (err) {
       stopTimers();
+      await liveCallbacks.flush().catch(() => {});
       const duration = Date.now() - startTime;
       const estimatedTotal = TokenTracker.estimateTokens(prompt);
       invLogger.warn(
@@ -538,14 +638,24 @@ export class ClaudeCodeRunner implements AgentRunner {
     };
     // ────────────────────────────────────────────────────────────────
 
+    // ── Live output streaming ────────────────────────────────────────
+    const liveTaskId = invocation.taskId ?? 'main';
+    const liveCallbacks = createLiveOutputCallbacks(
+      this.logDir, invocation.agent, liveTaskId, invocationId, invLogger,
+    );
+    // ────────────────────────────────────────────────────────────────
+
     try {
       const result = await spawnWithTimeout(cliCommand, args, {
         cwd: this.projectRoot,
         env,
         timeout,
+        onStdoutData: liveCallbacks.onStdoutData,
+        onStderrData: liveCallbacks.onStderrData,
       });
 
       stopTimers();
+      await liveCallbacks.flush();
       const duration = Date.now() - startTime;
 
       const taskId = invocation.taskId ?? 'main';
@@ -577,6 +687,7 @@ export class ClaudeCodeRunner implements AgentRunner {
       return finaliseResult(agentResult, result.stdout, prompt, invLogger);
     } catch (err) {
       stopTimers();
+      await liveCallbacks.flush().catch(() => {});
       const duration = Date.now() - startTime;
       const estimatedTotal = TokenTracker.estimateTokens(prompt);
       invLogger.warn(

--- a/runtime/src/logging/events.ts
+++ b/runtime/src/logging/events.ts
@@ -29,6 +29,7 @@ export type RuntimeEvent =
   | { type: 'agent-heartbeat'; agent: string; taskId?: string; runId?: string; invocationId?: string; elapsedSeconds: number }
   | { type: 'agent-output-file-detected'; agent: string; taskId?: string; runId?: string; invocationId?: string; file: string }
   | { type: 'agent-timed-out'; agent: string; taskId?: string; runId?: string; invocationId?: string; timeout: number }
+  | { type: 'agent-output-line'; agent: string; taskId?: string; runId?: string; invocationId?: string; stream: 'stdout' | 'stderr'; line: string }
   | { type: 'task-started'; taskId: string; name: string }
   | { type: 'task-completed'; taskId: string; name: string; duration: number }
   | { type: 'task-failed'; taskId: string; name: string; error: string; attempt: number }

--- a/runtime/src/util/process.ts
+++ b/runtime/src/util/process.ts
@@ -16,6 +16,10 @@ export interface SpawnWithTimeoutOptions extends SpawnOptions {
   timeout?: number;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
+  /** Called with each chunk of stdout data as it arrives (streaming). */
+  onStdoutData?: (chunk: Buffer) => void;
+  /** Called with each chunk of stderr data as it arrives (streaming). */
+  onStderrData?: (chunk: Buffer) => void;
 }
 
 /**
@@ -27,7 +31,7 @@ export async function spawnWithTimeout(
   args: string[],
   options: SpawnWithTimeoutOptions = {},
 ): Promise<SpawnResult> {
-  const { timeout, ...spawnOpts } = options;
+  const { timeout, onStdoutData, onStderrData, ...spawnOpts } = options;
   const start = performance.now();
 
   return new Promise<SpawnResult>((resolve, reject) => {
@@ -67,8 +71,14 @@ export async function spawnWithTimeout(
       });
     };
 
-    child.stdout!.on('data', (chunk: Buffer) => stdoutChunks.push(chunk));
-    child.stderr!.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
+    child.stdout!.on('data', (chunk: Buffer) => {
+      stdoutChunks.push(chunk);
+      if (onStdoutData) onStdoutData(chunk);
+    });
+    child.stderr!.on('data', (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+      if (onStderrData) onStderrData(chunk);
+    });
 
     if (timeout !== undefined && timeout > 0) {
       timer = setTimeout(() => {

--- a/runtime/tests/agent-launcher.test.ts
+++ b/runtime/tests/agent-launcher.test.ts
@@ -1015,4 +1015,113 @@ describe('AgentLauncher', () => {
       setTimeoutSpy.mockRestore();
     });
   });
+
+  describe('live output streaming', () => {
+    it('should create a .live.log file with streamed stdout lines', async () => {
+      const script = await createScript('live-stdout.sh', [
+        'echo "line one"',
+        'echo "line two"',
+        'echo "line three"',
+        'exit 0',
+      ].join('\n'));
+      const launcher = makeLauncher(script);
+      const { contextFile, progressDir } = await prepareInvocation('live-stdout-001');
+
+      const result = await launcher.launchAgent({
+        agent: 'code-migrator',
+        contextFile,
+        progressDir,
+        phase: 4,
+        taskId: 'live-stdout-001',
+      });
+
+      expect(result.success).toBe(true);
+
+      // Find the .live.log file
+      const agentLogDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs', 'agents', 'code-migrator', 'live-stdout-001');
+      const logFiles = await readdir(agentLogDir);
+      const liveLogFile = logFiles.find(f => f.endsWith('.live.log'));
+      expect(liveLogFile).toBeDefined();
+
+      const liveContent = await readFile(join(agentLogDir, liveLogFile!), 'utf-8');
+      expect(liveContent).toContain('[stdout] line one');
+      expect(liveContent).toContain('[stdout] line two');
+      expect(liveContent).toContain('[stdout] line three');
+    });
+
+    it('should include stderr lines prefixed with [stderr] in the live log', async () => {
+      const script = await createScript('live-stderr.sh', [
+        'echo "stdout stuff"',
+        'echo "error stuff" >&2',
+        'exit 0',
+      ].join('\n'));
+      const launcher = makeLauncher(script);
+      const { contextFile, progressDir } = await prepareInvocation('live-stderr-001');
+
+      const result = await launcher.launchAgent({
+        agent: 'code-migrator',
+        contextFile,
+        progressDir,
+        phase: 4,
+        taskId: 'live-stderr-001',
+      });
+
+      expect(result.success).toBe(true);
+
+      const agentLogDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs', 'agents', 'code-migrator', 'live-stderr-001');
+      const logFiles = await readdir(agentLogDir);
+      const liveLogFile = logFiles.find(f => f.endsWith('.live.log'));
+      expect(liveLogFile).toBeDefined();
+
+      const liveContent = await readFile(join(agentLogDir, liveLogFile!), 'utf-8');
+      expect(liveContent).toContain('[stdout] stdout stuff');
+      expect(liveContent).toContain('[stderr] error stuff');
+    });
+
+    it('should still create the final agent log alongside the live log', async () => {
+      const script = await createScript('live-both.sh', 'echo "output"\nexit 0');
+      const launcher = makeLauncher(script);
+      const { contextFile, progressDir } = await prepareInvocation('live-both-001');
+
+      await launcher.launchAgent({
+        agent: 'code-migrator',
+        contextFile,
+        progressDir,
+        phase: 4,
+        taskId: 'live-both-001',
+      });
+
+      const agentLogDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs', 'agents', 'code-migrator', 'live-both-001');
+      const logFiles = await readdir(agentLogDir);
+      const liveLogFile = logFiles.find(f => f.endsWith('.live.log'));
+      const finalLogFile = logFiles.find(f => f.endsWith('.log') && !f.endsWith('.live.log'));
+      expect(liveLogFile).toBeDefined();
+      expect(finalLogFile).toBeDefined();
+    });
+
+    it('should create live log even when agent fails', async () => {
+      const script = await createScript('live-fail.sh', 'echo "before fail"\necho "fail reason" >&2\nexit 1');
+      const launcher = makeLauncher(script);
+      const { contextFile, progressDir } = await prepareInvocation('live-fail-001');
+
+      const result = await launcher.launchAgent({
+        agent: 'code-migrator',
+        contextFile,
+        progressDir,
+        phase: 4,
+        taskId: 'live-fail-001',
+      });
+
+      expect(result.success).toBe(false);
+
+      const agentLogDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs', 'agents', 'code-migrator', 'live-fail-001');
+      const logFiles = await readdir(agentLogDir);
+      const liveLogFile = logFiles.find(f => f.endsWith('.live.log'));
+      expect(liveLogFile).toBeDefined();
+
+      const liveContent = await readFile(join(agentLogDir, liveLogFile!), 'utf-8');
+      expect(liveContent).toContain('[stdout] before fail');
+      expect(liveContent).toContain('[stderr] fail reason');
+    });
+  });
 });

--- a/runtime/tests/process-util.test.ts
+++ b/runtime/tests/process-util.test.ts
@@ -87,4 +87,42 @@ describe('spawnWithTimeout', () => {
   it('killProcessTree should not throw for a non-existent pid', async () => {
     await expect(killProcessTree(999_999)).resolves.toBeUndefined();
   });
+
+  describe('streaming callbacks', () => {
+    it('should invoke onStdoutData for each stdout chunk', async () => {
+      const chunks: string[] = [];
+      const result = await spawnWithTimeout('echo', ['hello streaming'], {
+        onStdoutData: (chunk) => chunks.push(chunk.toString()),
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('hello streaming');
+      // The callback should have received at least one chunk containing the output
+      const combined = chunks.join('');
+      expect(combined).toContain('hello streaming');
+    });
+
+    it('should invoke onStderrData for each stderr chunk', async () => {
+      const chunks: string[] = [];
+      const result = await spawnWithTimeout('node', ['-e', "console.error('err-stream')"], {
+        onStderrData: (chunk) => chunks.push(chunk.toString()),
+      });
+      expect(result.stderr.trim()).toBe('err-stream');
+      const combined = chunks.join('');
+      expect(combined).toContain('err-stream');
+    });
+
+    it('should still produce full stdout/stderr when callbacks are provided', async () => {
+      const stdoutChunks: string[] = [];
+      const stderrChunks: string[] = [];
+      const result = await spawnWithTimeout('node', [
+        '-e', "console.log('out1'); console.log('out2'); console.error('err1');",
+      ], {
+        onStdoutData: (chunk) => stdoutChunks.push(chunk.toString()),
+        onStderrData: (chunk) => stderrChunks.push(chunk.toString()),
+      });
+      expect(result.stdout).toContain('out1');
+      expect(result.stdout).toContain('out2');
+      expect(result.stderr).toContain('err1');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Agent output (stdout/stderr) was previously only available after the process finished. This adds real-time streaming so output is observable while the agent is still running.

## Changes

### `runtime/src/util/process.ts`
- Add optional `onStdoutData` / `onStderrData` callbacks to `SpawnWithTimeoutOptions`
- Callbacks fire on each chunk while still buffering for the final `SpawnResult` (no breaking change)

### `runtime/src/core/agent-launcher.ts`
- Add `createLiveOutputCallbacks()` helper that:
  - Line-buffers raw chunks (handles partial lines correctly)
  - Writes each complete line to a **`.live.log`** file with `[stdout]`/`[stderr]` prefixes
  - Emits `agent-output-line` events through the logger
  - Uses a serialised write chain to prevent interleaving
- Wired into both `CopilotRunner` and `ClaudeCodeRunner` (success + error paths)

### `runtime/src/logging/events.ts`
- New `agent-output-line` `RuntimeEvent` type

### Usage
```bash
# Tail live agent output during a migration
tail -f .aamf/migration/<project>/logs/agents/<agent>/<taskId>/*.live.log
```

## Tests
- `process-util.test.ts`: 3 new tests for streaming callbacks
- `agent-launcher.test.ts`: 4 new tests for live log file creation/content
- Full suite: 1035 passed, 0 failures