### PR TITLE
fix(runtime): fix task queue dependency handling and runtime config selection

### DIFF
--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -263,6 +263,27 @@ export class MigrationOrchestrator {
    */
   private _deferGitCommits = false;
 
+  private getConfiguredRuntimeModel(): string {
+    if (this.config.agentRuntime === 'claude-code') {
+      return this.config.claudeCode?.model ?? 'unknown';
+    }
+    return this.config.copilot.model ?? 'claude-sonnet-4';
+  }
+
+  private getRuntimeTimeout(): number {
+    if (this.config.agentRuntime === 'claude-code') {
+      return this.config.claudeCode?.timeout ?? this.config.copilot.timeout;
+    }
+    return this.config.copilot.timeout;
+  }
+
+  private getPhaseTimeout(phase: number): number {
+    const phaseTimeouts = this.config.agentRuntime === 'claude-code'
+      ? this.config.claudeCode?.phaseTimeouts
+      : this.config.copilot.phaseTimeouts;
+    return phaseTimeouts?.[phase] ?? this.getRuntimeTimeout();
+  }
+
   constructor(
     private readonly config: MigrationConfig,
     private readonly checkpoint: CheckpointManager,
@@ -1153,9 +1174,8 @@ export class MigrationOrchestrator {
     const agentMultiplier = this.config.target.testCommand ? 3 : 2; // migrator + parity (+ test-writer if testCommand set)
     const retryMultiplier = this.config.options.retryOverheadMultiplier;
     const estimatedTotalTokens = taskCount * this.config.options.avgTokensPerTask * agentMultiplier * retryMultiplier;
-    const model = this.config.copilot.model ?? 'claude-sonnet-4';
-    const estimator = new CostEstimator(this.config.copilot.costOverrides);
-    const projected = estimator.estimateFromTotal(model, estimatedTotalTokens);
+    const model = this.getConfiguredRuntimeModel();
+    const projected = this.costEstimatorInstance.estimateFromTotal(model, estimatedTotalTokens);
 
     this.logger.info(
       `Phase 4: ${taskCount} tasks, estimated ~${estimatedTotalTokens.toLocaleString()} tokens, ` +
@@ -2919,7 +2939,7 @@ export class MigrationOrchestrator {
       if (label === 'test') this.phase4Snapshot.testCommandRuns++;
     }
     return this.buildLimiter(async () => {
-      const timeout = this.config.copilot.timeout;
+      const timeout = this.getRuntimeTimeout();
       this.logger.info(`Running ${label} command for task ${taskId}: ${command}`);
 
       try {
@@ -3486,7 +3506,7 @@ export class MigrationOrchestrator {
       const resolvedPath = this.launcher.getResolvedPath();
       const result = await spawnWithTimeout('git', args, {
         cwd: this.config.target.outputPath,
-        timeout: this.config.copilot.timeout,
+        timeout: this.getRuntimeTimeout(),
         env: {
           ...process.env,
           ...(resolvedPath ? { PATH: resolvedPath } : {}),
@@ -3629,8 +3649,7 @@ export class MigrationOrchestrator {
     taskId?: string,
     task?: MigrationTask,
   ): AgentInvocation {
-    const phaseTimeouts = this.config.copilot.phaseTimeouts;
-    const timeout = phaseTimeouts?.[phase] ?? this.config.copilot.timeout;
+    const timeout = this.getPhaseTimeout(phase);
 
     // Agents that benefit from KB access when the KB server is running.
     // Essentially every agent that analyses or transforms source code.

--- a/runtime/src/core/runtime.ts
+++ b/runtime/src/core/runtime.ts
@@ -76,6 +76,32 @@ export class MigrationRuntime {
   private phase?: number;
   private runId!: string;
 
+  private getActiveRuntimeSettings(): {
+    agentDir: string;
+    model?: string;
+    costOverrides?: MigrationConfig['copilot']['costOverrides'];
+    agentFileSuffix: '.agent.md' | '.md';
+    validateSchemaContract: boolean;
+  } {
+    if (this.config.agentRuntime === 'claude-code') {
+      return {
+        agentDir: this.config.claudeCode.agentDir,
+        model: this.config.claudeCode.model,
+        costOverrides: this.config.claudeCode.costOverrides,
+        agentFileSuffix: '.md',
+        validateSchemaContract: false,
+      };
+    }
+
+    return {
+      agentDir: this.config.copilot.agentDir,
+      model: this.config.copilot.model,
+      costOverrides: this.config.copilot.costOverrides,
+      agentFileSuffix: '.agent.md',
+      validateSchemaContract: true,
+    };
+  }
+
   async initialize(options: RuntimeOptions): Promise<void> {
     // 1. Load config
     const rawConfig = await loadConfig(options.configPath);
@@ -231,8 +257,9 @@ export class MigrationRuntime {
     }
     console.log(`Token Usage: ${result.tokenUsage.total.toLocaleString()}`);
     
-    const model = this.config.copilot.model ?? 'claude-sonnet-4';
-    const estimator = new CostEstimator(this.config.copilot.costOverrides);
+    const runtimeSettings = this.getActiveRuntimeSettings();
+    const model = runtimeSettings.model ?? 'claude-sonnet-4';
+    const estimator = new CostEstimator(runtimeSettings.costOverrides);
     const cost = estimator.estimateFromTotal(model, result.tokenUsage.total);
     console.log(`Estimated Cost: ${CostEstimator.formatCost(cost.total)}`);
 
@@ -261,13 +288,14 @@ export class MigrationRuntime {
   }
 
   private async validateAgentFiles(): Promise<void> {
-    const agentDir = this.config.copilot.agentDir;
+    const runtimeSettings = this.getActiveRuntimeSettings();
+    const { agentDir, agentFileSuffix, validateSchemaContract } = runtimeSettings;
     const allAgents = [...new Set(PHASES.flatMap(p => p.agents))];
     const missing: string[] = [];
     const invalid: string[] = [];
 
     for (const agent of allAgents) {
-      const agentPath = join(agentDir, `${agent}.agent.md`);
+      const agentPath = join(agentDir, `${agent}${agentFileSuffix}`);
       if (!(await fileExists(agentPath))) {
         missing.push(agentPath);
       }
@@ -279,22 +307,24 @@ export class MigrationRuntime {
       );
     }
 
-    const entries = await readdir(agentDir, { withFileTypes: true });
-    const agentFiles = entries
-      .filter(e => e.isFile() && e.name.endsWith('.agent.md'))
-      .map(e => join(agentDir, e.name));
+    if (validateSchemaContract) {
+      const entries = await readdir(agentDir, { withFileTypes: true });
+      const agentFiles = entries
+        .filter(e => e.isFile() && e.name.endsWith(agentFileSuffix))
+        .map(e => join(agentDir, e.name));
 
-    for (const agentPath of agentFiles) {
-      const content = await readFile(agentPath, 'utf-8');
-      const contractError = this.validateSchemaContract(content);
-      if (contractError) {
-        invalid.push(`${agentPath}: ${contractError}`);
+      for (const agentPath of agentFiles) {
+        const content = await readFile(agentPath, 'utf-8');
+        const contractError = this.validateSchemaContract(content);
+        if (contractError) {
+          invalid.push(`${agentPath}: ${contractError}`);
+        }
       }
     }
 
     if (invalid.length > 0) {
       throw new Error(
-        `Invalid agent schema contract(s) — each .agent.md must define required input/output schemas:\n${invalid.map(p => `  - ${p}`).join('\n')}`,
+        `Invalid agent schema contract(s) — each ${agentFileSuffix} file must define required input/output schemas:\n${invalid.map(p => `  - ${p}`).join('\n')}`,
       );
     }
   }

--- a/runtime/src/execution/task-queue.ts
+++ b/runtime/src/execution/task-queue.ts
@@ -56,7 +56,7 @@ export class TaskQueue {
     const ready: MigrationTask[] = [];
     for (const [id, task] of this.tasks) {
       if (this.completed.has(id) || this.blocked.has(id)) continue;
-      const depsOk = task.dependencies.every(dep => this.completed.has(dep) || this.blocked.has(dep));
+      const depsOk = task.dependencies.every(dep => this.completed.has(dep));
       if (depsOk) ready.push(task);
     }
     return ready;

--- a/runtime/src/logging/logger.ts
+++ b/runtime/src/logging/logger.ts
@@ -24,6 +24,10 @@ export interface LoggerOptions {
   console: boolean;
 }
 
+interface LoggerWriteState {
+  chain: Promise<void>;
+}
+
 export class Logger {
   private readonly logDir: string;
   private readonly minLevel: number;
@@ -41,7 +45,7 @@ export class Logger {
    * Write queue — serializes appendFile calls so they never interleave
    * and tracks pending writes so they can be awaited on shutdown.
    */
-  private writeChain: Promise<void> = Promise.resolve();
+  private readonly writeState: LoggerWriteState;
 
   constructor(opts: LoggerOptions);
   constructor(parent: Logger, source: string);
@@ -59,12 +63,13 @@ export class Logger {
       this.attempt = optsOrParent.attempt;
       this.phase = optsOrParent.phase;
       this.taskId = optsOrParent.taskId;
-      // Share the write chain with parent so all children serialize through one queue
-      this.writeChain = optsOrParent.writeChain;
+      // Share the write state with parent so all children serialize through one queue.
+      this.writeState = optsOrParent.writeState;
     } else {
       this.logDir = optsOrParent.logDir;
       this.minLevel = LEVEL_PRIORITY[optsOrParent.level];
       this.consoleEnabled = optsOrParent.console;
+      this.writeState = { chain: Promise.resolve() };
     }
   }
 
@@ -177,14 +182,14 @@ export class Logger {
     }
 
     // Queue the write — serialized through writeChain to prevent interleaving
-    this.writeChain = this.writeChain
+    this.writeState.chain = this.writeState.chain
       .then(() => this.appendEntry(entry))
       .catch(() => {/* best-effort: swallow write errors to keep the chain alive */});
   }
 
   /** Await all pending log writes. Call during graceful shutdown. */
   async flush(): Promise<void> {
-    await this.writeChain;
+    await this.writeState.chain;
   }
 
   private async appendEntry(entry: LogEntry): Promise<void> {

--- a/runtime/tests/logger.test.ts
+++ b/runtime/tests/logger.test.ts
@@ -262,6 +262,13 @@ describe('Logger', () => {
     expect(entry.taskId).toBe('task-007');
   });
 
+  it('should share a single write queue between parent and child loggers', () => {
+    const logger = new Logger({ logDir, level: 'info', console: false }) as any;
+    const child = logger.child('child-source') as any;
+
+    expect(child.writeState).toBe(logger.writeState);
+  });
+
   // ─── Console correlation tags ──────────────────────────────────────────────
 
   it('should include correlation tags in console output when fields are set', async () => {

--- a/runtime/tests/orchestrator.test.ts
+++ b/runtime/tests/orchestrator.test.ts
@@ -4203,6 +4203,26 @@ describe('MigrationOrchestrator', () => {
       expect(phase1Invocation).toBeDefined();
       expect(phase1Invocation!.timeout).toBe(300_000);
     });
+
+    it('should use claudeCode phaseTimeouts and timeout when agentRuntime is claude-code', async () => {
+      const launcherFn = createMockLauncher();
+      const { orchestrator, mockLauncher } = await setupOrchestrator(tempDir, launcherFn, {
+        agentRuntime: 'claude-code',
+        claudeCode: {
+          cliCommand: 'claude',
+          agentDir: '.claude/agents',
+          timeout: 120_000,
+          phaseTimeouts: { 1: 45_000 },
+        },
+      });
+
+      await orchestrator.run();
+
+      const phase1Invocation = mockLauncher.invocations.find((i) => i.agent === 'impact-assessor');
+      expect(phase1Invocation).toBeDefined();
+      expect(phase1Invocation!.timeout).toBe(45_000);
+      expect((orchestrator as any).getRuntimeTimeout()).toBe(120_000);
+    });
   });
 
   // ─── Phase 8: Idiomatic Refactor ──────────────────────────────────

--- a/runtime/tests/runtime.test.ts
+++ b/runtime/tests/runtime.test.ts
@@ -129,7 +129,9 @@ describe('MigrationRuntime', () => {
       // Inject a minimal config so formatDuration and CostEstimator work
       (runtime as any).config = {
         projectName: 'test-project',
+        agentRuntime: 'copilot',
         copilot: { model: 'claude-sonnet-4', costOverrides: undefined },
+        claudeCode: { model: undefined, costOverrides: undefined },
       };
       consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     });
@@ -189,6 +191,25 @@ describe('MigrationRuntime', () => {
       const output = consoleSpy.mock.calls.flat().join('\n');
       expect(output).toContain('Failed Tasks: task-a');
       expect(output).toContain('Blocked Tasks: task-b');
+    });
+
+    it('should use claudeCode model and cost overrides when runtime is claude-code', () => {
+      (runtime as any).config = {
+        projectName: 'test-project',
+        agentRuntime: 'claude-code',
+        copilot: { model: 'claude-opus-4.6', costOverrides: undefined },
+        claudeCode: {
+          model: 'claude-test-model',
+          costOverrides: {
+            'claude-test-model': { input: 10, output: 10 },
+          },
+        },
+      };
+
+      (runtime as any).printSummary(makeResult({ totalDuration: 5_000, tokenUsage: { total: 1_000_000, byPhase: {}, byAgent: {} } }));
+
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('Estimated Cost: $10.0000');
     });
   });
 
@@ -415,7 +436,7 @@ describe('MigrationRuntime', () => {
     it('validateAgentFiles succeeds when all phase agents exist', async () => {
       const root = await mkdtemp(join(tmpdir(), 'aamf-agent-files-'));
       const runtime = new MigrationRuntime() as any;
-      runtime.config = { copilot: { agentDir: root } };
+      runtime.config = { agentRuntime: 'copilot', copilot: { agentDir: root } };
 
       const allAgents = [...new Set(PHASES.flatMap(p => p.agents))];
       await Promise.all(
@@ -429,7 +450,7 @@ describe('MigrationRuntime', () => {
       it('validateAgentFiles throws when schema sections are missing', async () => {
         const root = await mkdtemp(join(tmpdir(), 'aamf-agent-files-invalid-'));
         const runtime = new MigrationRuntime() as any;
-        runtime.config = { copilot: { agentDir: root } };
+        runtime.config = { agentRuntime: 'copilot', copilot: { agentDir: root } };
 
         const allAgents = [...new Set(PHASES.flatMap(p => p.agents))];
         await Promise.all(
@@ -470,9 +491,27 @@ describe('MigrationRuntime', () => {
     it('validateAgentFiles throws with missing file list', async () => {
       const root = await mkdtemp(join(tmpdir(), 'aamf-agent-files-missing-'));
       const runtime = new MigrationRuntime() as any;
-      runtime.config = { copilot: { agentDir: root } };
+      runtime.config = { agentRuntime: 'copilot', copilot: { agentDir: root } };
 
       await expect(runtime.validateAgentFiles()).rejects.toThrow('Missing agent file(s)');
+      await rm(root, { recursive: true, force: true });
+    });
+
+    it('validateAgentFiles succeeds for claude-code runtime using .md agent files', async () => {
+      const root = await mkdtemp(join(tmpdir(), 'aamf-claude-agent-files-'));
+      const runtime = new MigrationRuntime() as any;
+      runtime.config = {
+        agentRuntime: 'claude-code',
+        copilot: { agentDir: '/unused' },
+        claudeCode: { agentDir: root },
+      };
+
+      const allAgents = [...new Set(PHASES.flatMap(p => p.agents))];
+      await Promise.all(
+        allAgents.map(agent => writeFile(join(root, `${agent}.md`), '# Claude agent\n', 'utf-8')),
+      );
+
+      await expect(runtime.validateAgentFiles()).resolves.toBeUndefined();
       await rm(root, { recursive: true, force: true });
     });
 

--- a/runtime/tests/task-queue.test.ts
+++ b/runtime/tests/task-queue.test.ts
@@ -42,13 +42,12 @@ describe('TaskQueue', () => {
     expect(queue.isComplete()).toBe(true);
   });
 
-  it('should handle blocked tasks', () => {
+  it('should not release dependent tasks when an upstream dependency is blocked', () => {
     const queue = new TaskQueue([makeTask('a'), makeTask('b', ['a'])]);
     queue.markBlocked('a');
-    
-    // b should become ready since blocked deps count as resolved
+
     const ready = queue.getReady();
-    expect(ready.map(t => t.id)).toEqual(['b']);
+    expect(ready).toEqual([]);
   });
 
   it('should report correct progress', () => {


### PR DESCRIPTION
## Summary
- stop releasing dependent tasks when an upstream dependency is blocked
- respect the active agent runtime for model, cost, timeout, and agent-file selection
- share a single write queue across parent/child loggers
- add regression coverage for task queue, runtime, orchestrator, and logger behavior

## Testing
- `npx vitest run tests/task-queue.test.ts tests/logger.test.ts tests/runtime.test.ts tests/orchestrator.test.ts`