### PR TITLE
feat(config): add user-provided migration guidance field

### DIFF
--- a/.github/agents/code-migrator.agent.md
+++ b/.github/agents/code-migrator.agent.md
@@ -29,6 +29,7 @@ When these tools are available, prefer them for structural facts over exhaustive
    - Read your assigned task from the migration plan
    - Read the relevant knowledge base document(s) referenced by the task
    - Understand the source file(s) structure, behavior, and dependencies
+   - **Check your context JSON for a `guidance` array.** If present, these are user-provided migration directives that you MUST follow. They take precedence over default heuristics (e.g. if guidance says "do not use wrapper crates", you must write native code rather than importing an existing binding).
 
 2. **Read Source Code**
    - Read only the source file(s) specified in the task — nothing else

--- a/.github/agents/migration-planner.agent.md
+++ b/.github/agents/migration-planner.agent.md
@@ -39,6 +39,7 @@ When these tools are available, prefer them for structural facts over exhaustive
    - Read the knowledge base index (`.aamf/migration/{projectName}/knowledge-base/index.md`)
    - Understand module dependencies, complexity ratings, and risk factors
   - Use Lore tools (`kb_lookup`, `kb_graph`) for authoritative dependency/symbol detail when available
+  - **Check your context JSON for a `guidance` array.** If present, these are user-provided migration directives that MUST be incorporated into every strategy you produce and propagated into `strategy.md` so that downstream agents (task-decomposer, code-migrator) honour them.
 
 2. **Generate Strategy Candidates**
   - Produce **at least 2 competing migration strategies** (e.g., bottom-up vs top-down, by-module vs by-layer, risk-first vs dependency-first).

--- a/.github/agents/task-decomposer.agent.md
+++ b/.github/agents/task-decomposer.agent.md
@@ -32,6 +32,7 @@ When these tools are available, prefer them for structural facts over exhaustive
   - `groupName`
   - `taskSchemaPath` (absolute path to canonical JSON Schema)
   - `maxLinesPerTask` (hard per-task source line budget)
+- **`guidance`** (optional string array) — user-provided migration directives from the config. If present, embed relevant guidance items into each task's `description` or `acceptanceCriteria` so that `code-migrator` agents see them at task level.
 
 ## Responsibilities
 

--- a/runtime/src/agents/context-builder.ts
+++ b/runtime/src/agents/context-builder.ts
@@ -118,6 +118,8 @@ export class ContextBuilder {
           outputPath: this.config.target.outputPath,
         },
       },
+      // Thread user-provided guidance into every agent context.
+      ...(this.config.guidance?.length ? { guidance: this.config.guidance } : {}),
     };
 
     const { inputFiles, outputPath, agentPayload } = this.getAgentFiles(agent, taskId, payload);

--- a/runtime/src/agents/types.ts
+++ b/runtime/src/agents/types.ts
@@ -182,6 +182,13 @@ export interface AgentContext {
   /** Directory or file path where the agent should write its output. */
   outputPath: string;
 
+  /**
+   * User-provided migration guidance directives from the config file.
+   * Every agent receives the same array so it can respect project-specific
+   * constraints (e.g. "do not use wrapper crates").
+   */
+  guidance?: string[];
+
   /** Arbitrary extra data specific to the invoking phase or agent. */
   payload?: Record<string, unknown>;
 }

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -2,6 +2,19 @@ import { z } from 'zod';
 
 export const MigrationConfigSchema = z.object({
   projectName: z.string().min(1).regex(/^[a-z0-9-]+$/),
+  /**
+   * Optional user-provided migration guidance directives.
+   *
+   * Each entry is a freeform instruction that is injected into every
+   * agent's context JSON so that planners, code-migrators, and reviewers
+   * can honour project-specific constraints.
+   *
+   * Examples:
+   *   - "Do NOT use any existing crates/packages that wrap the C implementation."
+   *   - "Write a pure native Rust port — no FFI or bindgen."
+   *   - "Preserve the original directory layout in the target output."
+   */
+  guidance: z.array(z.string().min(1)).optional(),
   source: z.object({
     path: z.string(),
     language: z.string(),

--- a/runtime/tests/config-schema.test.ts
+++ b/runtime/tests/config-schema.test.ts
@@ -531,4 +531,43 @@ describe('MigrationConfigSchema', () => {
       });
     });
   });
+
+  describe('Guidance', () => {
+    it('should accept guidance as an array of strings', () => {
+      const result = MigrationConfigSchema.parse({
+        ...validConfig,
+        guidance: ['Do not use wrapper crates', 'Write native Rust code'],
+      });
+      expect(result.guidance).toEqual(['Do not use wrapper crates', 'Write native Rust code']);
+    });
+
+    it('should default guidance to undefined when omitted', () => {
+      const result = MigrationConfigSchema.parse(validConfig);
+      expect(result.guidance).toBeUndefined();
+    });
+
+    it('should reject guidance with empty strings', () => {
+      const result = MigrationConfigSchema.safeParse({
+        ...validConfig,
+        guidance: ['valid', ''],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should accept an empty guidance array', () => {
+      const result = MigrationConfigSchema.parse({
+        ...validConfig,
+        guidance: [],
+      });
+      expect(result.guidance).toEqual([]);
+    });
+
+    it('should reject guidance when not an array', () => {
+      const result = MigrationConfigSchema.safeParse({
+        ...validConfig,
+        guidance: 'single string',
+      });
+      expect(result.success).toBe(false);
+    });
+  });
 });

--- a/runtime/tests/context-builder.test.ts
+++ b/runtime/tests/context-builder.test.ts
@@ -694,4 +694,50 @@ describe('ContextBuilder', () => {
       expect(context.outputPath).toBe(progressDir);
     });
   });
+
+  // ─── Guidance Propagation ──────────────────────────────────────────
+
+  describe('Guidance Propagation', () => {
+    it('should include guidance in context when config has guidance', async () => {
+      const config = createMockConfig({
+        guidance: ['Do not use wrapper crates', 'Write native Rust port'],
+      });
+      const guidanceBuilder = new ContextBuilder(config, progressDir, paths);
+
+      const contextPath = await guidanceBuilder.buildContext('code-migrator', 4, 'task-001');
+      const context = await readJson<AgentContext>(contextPath);
+
+      expect(context.guidance).toEqual(['Do not use wrapper crates', 'Write native Rust port']);
+    });
+
+    it('should omit guidance from context when config has no guidance', async () => {
+      const contextPath = await builder.buildContext('code-migrator', 4, 'task-001');
+      const context = await readJson<AgentContext>(contextPath);
+
+      expect(context.guidance).toBeUndefined();
+    });
+
+    it('should omit guidance from context when config guidance is empty array', async () => {
+      const config = createMockConfig({ guidance: [] });
+      const emptyGuidanceBuilder = new ContextBuilder(config, progressDir, paths);
+
+      const contextPath = await emptyGuidanceBuilder.buildContext('migration-planner', 3);
+      const context = await readJson<AgentContext>(contextPath);
+
+      expect(context.guidance).toBeUndefined();
+    });
+
+    it('should propagate guidance to all agent types', async () => {
+      const config = createMockConfig({
+        guidance: ['No FFI bindings allowed'],
+      });
+      const guidanceBuilder = new ContextBuilder(config, progressDir, paths);
+
+      for (const agent of ['impact-assessor', 'migration-planner', 'code-migrator', 'parity-verifier'] as const) {
+        const contextPath = await guidanceBuilder.buildContext(agent, 1, 'task-001');
+        const context = await readJson<AgentContext>(contextPath);
+        expect(context.guidance).toEqual(['No FFI bindings allowed']);
+      }
+    });
+  });
 });

--- a/runtime/tests/fixtures/zstd-c-project/migration.config.json
+++ b/runtime/tests/fixtures/zstd-c-project/migration.config.json
@@ -1,5 +1,10 @@
 {
   "projectName": "zstd-to-rust",
+  "guidance": [
+    "Do NOT use any existing Rust crates that wrap the C implementation (e.g. zstd, zstd-safe, zstd-sys, lz4-sys). Write a pure native Rust port of the C source code.",
+    "Do NOT use FFI, bindgen, or any C interop. All code must be idiomatic safe Rust.",
+    "Preserve the original algorithmic structure so that the Rust port is auditable against the C reference."
+  ],
   "source": {
     "path": "./zstd-src/zstd-1.5.7",
     "language": "c",

--- a/runtime/tests/helpers/mocks.ts
+++ b/runtime/tests/helpers/mocks.ts
@@ -79,6 +79,7 @@ export class MockAgentLauncher {
 export function createMockConfig(overrides?: any): MigrationConfig {
   const raw = {
     projectName: overrides?.projectName ?? 'test-project',
+    ...(overrides?.guidance !== undefined ? { guidance: overrides.guidance } : {}),
     source: {
       path: '/tmp/source',
       language: 'python',


### PR DESCRIPTION
## Summary

Adds an optional top-level `guidance` string array to the migration config, allowing users to provide project-specific directives that every agent honours.

Closes #136

## Motivation

When migrating a C library to Rust (e.g. zstd), agents may default to pulling in existing wrapper crates (`zstd`, `zstd-safe`) instead of writing a native port. There was no way for users to communicate constraints like "do not use wrapper crates" or "write a pure native Rust port."

## Changes

| File | Change |
|------|--------|
| `runtime/src/config/schema.ts` | Add `guidance: z.array(z.string().min(1)).optional()` at the top level |
| `runtime/src/agents/types.ts` | Add `guidance?: string[]` to `AgentContext` interface |
| `runtime/src/agents/context-builder.ts` | Spread guidance into base context when non-empty |
| `.github/agents/migration-planner.agent.md` | Reference `guidance` in Responsibilities §1 |
| `.github/agents/task-decomposer.agent.md` | Reference `guidance` in Inputs section |
| `.github/agents/code-migrator.agent.md` | Reference `guidance` in Responsibilities §1 |
| `runtime/tests/config-schema.test.ts` | 5 new tests for schema validation |
| `runtime/tests/context-builder.test.ts` | 4 new tests for guidance propagation |
| `runtime/tests/helpers/mocks.ts` | Thread `guidance` override into mock config |
| zstd fixture config | Example guidance for the zstd C→Rust migration |

## Example usage

```json
{
  "projectName": "zstd-to-rust",
  "guidance": [
    "Do NOT use existing Rust crates that wrap the C implementation (e.g. zstd, zstd-safe, zstd-sys).",
    "Write a pure native Rust port — no FFI or bindgen.",
    "Preserve the original algorithmic structure for auditability."
  ],
  "source": { ... }
}
```

## Design decisions

- **Top-level field** (not nested under `options`) — guidance is conceptually separate from runtime tuning knobs
- **Threaded to all agents** — every agent sees the same guidance; the planner, task-decomposer, and code-migrator have explicit documentation telling them to honour it
- **Omitted when empty** — no noise in context JSON for configs that don't use it
- **String array** — each directive is a separate item for clarity; validated as non-empty strings