### PR TITLE
refactor(agents): replace hardcoded Lore tool tables with MCP discovery

### DIFF
--- a/.claude/agents/code-migrator.md
+++ b/.claude/agents/code-migrator.md
@@ -116,14 +116,11 @@ The JSON must conform to this schema:
 - `parity`: one of `"pass"`, `"partial"`, `"fail"`
 - `issues[].severity`: one of `"critical"`, `"major"`, `"minor"`
 
-## KB MCP Tools
+## Lore MCP Tools
 
-If the KB index is available (indicated by `KB_DB_PATH` in your environment), prefer the following MCP tools over reading source files directly:
+If the `aamf-kb` MCP server is available (indicated by `KB_DB_PATH` in your environment), prefer Lore tools over reading source files directly. Lore provides symbol lookup, snippet extraction, code search, and more — discover the right tool for each query via MCP.
 
-- **`kb_lookup`** — retrieve a specific symbol's full definition (signature, docstring, body location) by name. Use this to fetch a function or class implementation instead of reading the entire source file.
-- **`kb_snippet`** — retrieve a precise line-range excerpt from an indexed source file. Use this when you need a specific code snippet without loading the whole file.
-
-Fall back to Bash / Read / Grep tools only when the KB index is unavailable or a query cannot be satisfied by the MCP tools.
+Fall back to Bash / Read / Grep tools only when the MCP server is unavailable or a query cannot be satisfied by Lore.
 
 ## Context Window Management
 

--- a/.claude/agents/impact-assessor.md
+++ b/.claude/agents/impact-assessor.md
@@ -105,14 +105,11 @@ Write the full assessment to `.aamf/migration/{projectName}/artifacts/impact-ass
 
 None — this is a **leaf agent**.
 
-## KB MCP Tools
+## Lore MCP Tools
 
-If the KB index is available (indicated by `KB_DB_PATH` in your environment), prefer the following MCP tools over direct file reads:
+If the `aamf-kb` MCP server is available (indicated by `KB_DB_PATH` in your environment), prefer Lore tools over direct file reads. Lore provides code search, symbol lookup, dependency graphs, and more — discover the right tool for each query via MCP.
 
-- **`kb_search`** — full-text and semantic search across the indexed codebase. Use this to locate symbols, files, or patterns instead of running `grep` or `find`.
-- **`kb_lookup`** — retrieve a specific symbol's definition, type, docstring, and location by name. Use this instead of reading a whole file to find a function or class.
-
-Fall back to Bash / Read / Grep tools only when the KB index is unavailable or a query cannot be satisfied by the MCP tools.
+Fall back to Bash / Read / Grep tools only when the MCP server is unavailable or a query cannot be satisfied by Lore.
 
 ## Context Window Management
 

--- a/.claude/agents/knowledge-builder.md
+++ b/.claude/agents/knowledge-builder.md
@@ -110,14 +110,11 @@ knowledge-base/
 {special considerations for migration}
 ```
 
-## KB MCP Tools
+## Lore MCP Tools
 
-If the KB index is available (indicated by `KB_DB_PATH` in your environment), prefer the following MCP tools over direct file reads:
+If the `aamf-kb` MCP server is available (indicated by `KB_DB_PATH` in your environment), prefer Lore tools over direct file reads. Lore provides dependency graph queries, symbol lookup, code search, and more — discover the right tool for each query via MCP.
 
-- **`kb_graph`** — query the import/dependency graph. Use this to discover what a module imports and what imports it, instead of grepping for `import` statements across files.
-- **`kb_lookup`** — retrieve a specific symbol's definition, signature, docstring, and source location by name. Use this to enumerate a module's public API without reading the entire file.
-
-Fall back to Bash / Read / Grep tools only when the KB index is unavailable or a query cannot be satisfied by the MCP tools.
+Fall back to Bash / Read / Grep tools only when the MCP server is unavailable or a query cannot be satisfied by Lore.
 
 ## Context Window Management
 

--- a/.claude/agents/migration-planner.md
+++ b/.claude/agents/migration-planner.md
@@ -127,13 +127,11 @@ Example `strategy.md`:
 
 Do not launch sub-agents directly from this prompt.
 
-## KB MCP Tools
+## Lore MCP Tools
 
-If the KB index is available (indicated by `KB_DB_PATH` in your environment), prefer the following MCP tool over direct file reads:
+If the `aamf-kb` MCP server is available (indicated by `KB_DB_PATH` in your environment), prefer Lore tools over direct file reads. Lore provides dependency graph queries, symbol lookup, code search, and more — discover the right tool for each query via MCP.
 
-- **`kb_graph`** — query the import/dependency graph to determine topological ordering of modules and to identify tightly coupled components that must be migrated together.
-
-Fall back to Bash / Read / Grep tools only when the KB index is unavailable or a query cannot be satisfied by the MCP tools.
+Fall back to Bash / Read / Grep tools only when the MCP server is unavailable or a query cannot be satisfied by Lore.
 
 ## Context Window Management
 

--- a/.github/agents/code-migrator.agent.md
+++ b/.github/agents/code-migrator.agent.md
@@ -10,18 +10,11 @@ You are the **Code Migrator** — responsible for executing a single migration t
 
 ## Index-First Principle
 
-The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that provides code-intelligence tools for symbol lookup, dependency/call-graph queries, code search, snippet extraction, metrics, and write-back. Lore exposes its full tool list via MCP — discover and use the right tool for each query.
 
-| Tool | Purpose |
-|------|---------|
-| `kb_lookup` | Symbol or file lookup (signatures, locations) |
-| `kb_graph` | Call-graph and import-graph queries |
-| `kb_search` | Structural, semantic, and fused code search |
-| `kb_snippet` | Source-code snippet extraction by line range |
-| `kb_metrics` | Aggregate code metrics |
-| `kb_writeback` | Write LLM-generated summaries back to the KB |
+When available, **prefer Lore tools over reading source files directly** — they are faster, more precise, and conserve your context window. Fall back to direct file reads only when the MCP server is unavailable or a query cannot be satisfied by Lore.
 
-When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
+Use KB markdown for synthesized architecture, risk, and migration context — not as a substitute for Lore’s structural data.
 
 ## Responsibilities
 
@@ -113,7 +106,7 @@ Update `.aamf/migration/{projectName}/reports/progress.md` with task result:
 
 - **Only read the files specified in your task** — never browse the broader codebase.
 - Read the knowledge base document for your module FIRST (this is a compact summary). Only then read the actual source file(s).
-- Use Lore tools (`kb_lookup`, `kb_graph`, `kb_snippet`) for fast symbol/dependency lookup when available instead of expanding context with broad markdown inventories.
+- Use Lore tools for fast symbol/dependency lookup when available instead of expanding context with broad markdown inventories.
 - For large file chunks, read ONLY the specified line range, plus ~20 lines before/after for context.
 - If the task involves multiple source files, process them one at a time: read source → write target → move to next.
 - After writing each target file, release the source file from your working memory (don't re-read it).

--- a/.github/agents/documentation-writer.agent.md
+++ b/.github/agents/documentation-writer.agent.md
@@ -10,18 +10,11 @@ You are the **Documentation Writer** — responsible for producing comprehensive
 
 ## Index-First Principle
 
-The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that provides code-intelligence tools for symbol lookup, dependency/call-graph queries, code search, snippet extraction, metrics, and write-back. Lore exposes its full tool list via MCP — discover and use the right tool for each query.
 
-| Tool | Purpose |
-|------|---------|
-| `kb_lookup` | Symbol or file lookup (signatures, locations) |
-| `kb_graph` | Call-graph and import-graph queries |
-| `kb_search` | Structural, semantic, and fused code search |
-| `kb_snippet` | Source-code snippet extraction by line range |
-| `kb_metrics` | Aggregate code metrics |
-| `kb_writeback` | Write LLM-generated summaries back to the KB |
+When available, **prefer Lore tools over reading source files directly** — they are faster, more precise, and conserve your context window. Fall back to direct file reads only when the MCP server is unavailable or a query cannot be satisfied by Lore.
 
-When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
+Use KB markdown for synthesized architecture, risk, and migration context — not as a substitute for Lore’s structural data.
 
 ## Responsibilities
 
@@ -91,7 +84,7 @@ None — this is a **leaf agent**.
 - Read the migration plan and parity reports for migration-specific context.
 - When adding inline docs to migrated files, process one file at a time: read → add docs → save → move to next.
 - Write each documentation file completely before starting the next.
-- For API reference generation, prefer Lore tools (`kb_lookup`, `kb_graph`) for exhaustive signatures/dependencies; keep markdown/api docs concise and reader-oriented.
+- For API reference generation, prefer Lore tools for exhaustive signatures/dependencies; keep markdown/api docs concise and reader-oriented.
 - Do NOT re-read source (pre-migration) files — only the migrated target files and knowledge base.
 
 ## Constraints

--- a/.github/agents/e2e-test-crafter.agent.md
+++ b/.github/agents/e2e-test-crafter.agent.md
@@ -10,18 +10,11 @@ You are the **E2E Test Crafter** — a coordinating agent that plans comprehensi
 
 ## Index-First Principle
 
-The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that provides code-intelligence tools for symbol lookup, dependency/call-graph queries, code search, snippet extraction, metrics, and write-back. Lore exposes its full tool list via MCP — discover and use the right tool for each query.
 
-| Tool | Purpose |
-|------|---------|
-| `kb_lookup` | Symbol or file lookup (signatures, locations) |
-| `kb_graph` | Call-graph and import-graph queries |
-| `kb_search` | Structural, semantic, and fused code search |
-| `kb_snippet` | Source-code snippet extraction by line range |
-| `kb_metrics` | Aggregate code metrics |
-| `kb_writeback` | Write LLM-generated summaries back to the KB |
+When available, **prefer Lore tools over reading source files directly** — they are faster, more precise, and conserve your context window. Fall back to direct file reads only when the MCP server is unavailable or a query cannot be satisfied by Lore.
 
-When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
+Use KB markdown for synthesized architecture, risk, and migration context — not as a substitute for Lore’s structural data.
 
 **You do NOT write all E2E tests yourself.** For a large codebase, attempting to hold system-wide context while writing dozens of test suites would saturate your context window. Instead, you plan and delegate.
 
@@ -32,7 +25,7 @@ When these tools are available, prefer them for structural facts over exhaustive
 - Read the knowledge base integration points document
 - Identify the most critical user-facing workflows and system behaviors
 - Prioritize scenarios by business importance and risk
-- Use Lore tools (`kb_lookup`, `kb_graph`) to validate entry points/dependency paths when available
+- Use Lore tools to validate entry points/dependency paths when available
 
 ### 2. Design the Test Plan
 - Group scenarios into logical, isolated test suites (by feature, by workflow, by integration)

--- a/.github/agents/final-parity-checker.agent.md
+++ b/.github/agents/final-parity-checker.agent.md
@@ -10,18 +10,11 @@ You are the **Final Parity Checker** — a secondary, comprehensive verification
 
 ## Index-First Principle
 
-The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that provides code-intelligence tools for symbol lookup, dependency/call-graph queries, code search, snippet extraction, metrics, and write-back. Lore exposes its full tool list via MCP — discover and use the right tool for each query.
 
-| Tool | Purpose |
-|------|---------|
-| `kb_lookup` | Symbol or file lookup (signatures, locations) |
-| `kb_graph` | Call-graph and import-graph queries |
-| `kb_search` | Structural, semantic, and fused code search |
-| `kb_snippet` | Source-code snippet extraction by line range |
-| `kb_metrics` | Aggregate code metrics |
-| `kb_writeback` | Write LLM-generated summaries back to the KB |
+When available, **prefer Lore tools over reading source files directly** — they are faster, more precise, and conserve your context window. Fall back to direct file reads only when the MCP server is unavailable or a query cannot be satisfied by Lore.
 
-When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
+Use KB markdown for synthesized architecture, risk, and migration context — not as a substitute for Lore’s structural data.
 
 ## Why a Separate Final Check?
 
@@ -121,7 +114,7 @@ This agent inevitably needs to scan a large codebase. Manage context aggressivel
 - **Phase 1: File Manifest** — Use `find` and `ls` commands to list all files. Compare source and target file lists. This requires zero file content in context.
 - **Phase 2: Stub Scan** — Use `grep -rn "TODO\|FIXME\|not implemented\|stub\|placeholder"` across the target codebase. Read only matching lines, not full files.
 - **Phase 3: Import Chain Verification** — Use `grep` to extract all import/require statements from target files. Check that referenced modules exist. No need to read file bodies.
-- Prefer Lore tools (`kb_graph`, `kb_lookup`) for cross-module dependency verification when available; use grep/find scans as a fast consistency cross-check.
+- Prefer Lore tools for cross-module dependency verification when available; use grep/find scans as a fast consistency cross-check.
 - **Phase 4: Build Verification** — Run build/compile commands in terminal. Read only error output.
 - **Phase 5: Targeted Deep Checks** — Only for files flagged in previous phases, read relevant sections to diagnose issues.
 - Write each section of the report as it's completed to free up context.

--- a/.github/agents/idiomatic-refactorer.agent.md
+++ b/.github/agents/idiomatic-refactorer.agent.md
@@ -10,18 +10,11 @@ You are the **Idiomatic Refactorer** — an agent that applies a single idiomati
 
 ## Index-First Principle
 
-The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that provides code-intelligence tools for symbol lookup, dependency/call-graph queries, code search, snippet extraction, metrics, and write-back. Lore exposes its full tool list via MCP — discover and use the right tool for each query.
 
-| Tool | Purpose |
-|------|---------|
-| `kb_lookup` | Symbol or file lookup (signatures, locations) |
-| `kb_graph` | Call-graph and import-graph queries |
-| `kb_search` | Structural, semantic, and fused code search |
-| `kb_snippet` | Source-code snippet extraction by line range |
-| `kb_metrics` | Aggregate code metrics |
-| `kb_writeback` | Write LLM-generated summaries back to the KB |
+When available, **prefer Lore tools over reading source files directly** — they are faster, more precise, and conserve your context window. Fall back to direct file reads only when the MCP server is unavailable or a query cannot be satisfied by Lore.
 
-When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
+Use KB markdown for synthesized architecture, risk, and migration context — not as a substitute for Lore’s structural data.
 
 ## Responsibilities
 

--- a/.github/agents/idiomatic-reviewer.agent.md
+++ b/.github/agents/idiomatic-reviewer.agent.md
@@ -10,18 +10,11 @@ You are the **Idiomatic Reviewer** — an agent that reviews the migrated codeba
 
 ## Index-First Principle
 
-The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that provides code-intelligence tools for symbol lookup, dependency/call-graph queries, code search, snippet extraction, metrics, and write-back. Lore exposes its full tool list via MCP — discover and use the right tool for each query.
 
-| Tool | Purpose |
-|------|---------|
-| `kb_lookup` | Symbol or file lookup (signatures, locations) |
-| `kb_graph` | Call-graph and import-graph queries |
-| `kb_search` | Structural, semantic, and fused code search |
-| `kb_snippet` | Source-code snippet extraction by line range |
-| `kb_metrics` | Aggregate code metrics |
-| `kb_writeback` | Write LLM-generated summaries back to the KB |
+When available, **prefer Lore tools over reading source files directly** — they are faster, more precise, and conserve your context window. Fall back to direct file reads only when the MCP server is unavailable or a query cannot be satisfied by Lore.
 
-When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
+Use KB markdown for synthesized architecture, risk, and migration context — not as a substitute for Lore’s structural data.
 
 ## Responsibilities
 

--- a/.github/agents/impact-assessor.agent.md
+++ b/.github/agents/impact-assessor.agent.md
@@ -10,18 +10,11 @@ You are the **Impact Assessor** — a read-only analysis agent that evaluates a 
 
 ## Index-First Principle
 
-The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that provides code-intelligence tools for symbol lookup, dependency/call-graph queries, code search, snippet extraction, metrics, and write-back. Lore exposes its full tool list via MCP — discover and use the right tool for each query.
 
-| Tool | Purpose |
-|------|---------|
-| `kb_lookup` | Symbol or file lookup (signatures, locations) |
-| `kb_graph` | Call-graph and import-graph queries |
-| `kb_search` | Structural, semantic, and fused code search |
-| `kb_snippet` | Source-code snippet extraction by line range |
-| `kb_metrics` | Aggregate code metrics |
-| `kb_writeback` | Write LLM-generated summaries back to the KB |
+When available, **prefer Lore tools over reading source files directly** — they are faster, more precise, and conserve your context window. Fall back to direct file reads only when the MCP server is unavailable or a query cannot be satisfied by Lore.
 
-When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
+Use KB markdown for synthesized architecture, risk, and migration context — not as a substitute for Lore’s structural data.
 
 ## Responsibilities
 
@@ -102,7 +95,7 @@ None — this is a **leaf agent**.
 
 - **Do NOT read entire large files**. Use `wc -l`, `head`, `tail`, and grep to gather metrics without loading full file contents.
 - Use terminal commands (`find`, `wc`, `grep`, `cloc` if available) for bulk metrics collection.
-- Prefer Lore tools (`kb_graph`, `kb_lookup`) for dependency/symbol topology when available; use source-file scanning to validate risk and effort context.
+- Prefer Lore tools for dependency/symbol topology when available; use source-file scanning to validate risk and effort context.
 - For dependency analysis, read only `import`/`require`/`include` statements, not full file bodies.
 - Process the codebase in batches by directory/module to avoid context saturation.
 - Write intermediate results to temporary files if needed, compiling the final report at the end.

--- a/.github/agents/knowledge-builder.agent.md
+++ b/.github/agents/knowledge-builder.agent.md
@@ -14,18 +14,11 @@ The knowledge base must serve as a **context-efficient substitute for reading so
 
 ## Index-First Principle
 
-The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that provides code-intelligence tools for symbol lookup, dependency/call-graph queries, code search, snippet extraction, metrics, and write-back. Lore exposes its full tool list via MCP — discover and use the right tool for each query.
 
-| Tool | Purpose |
-|------|---------|
-| `kb_lookup` | Symbol or file lookup (signatures, locations) |
-| `kb_graph` | Call-graph and import-graph queries |
-| `kb_search` | Structural, semantic, and fused code search |
-| `kb_snippet` | Source-code snippet extraction by line range |
-| `kb_metrics` | Aggregate code metrics |
-| `kb_writeback` | Write LLM-generated summaries back to the KB |
+When available, **prefer Lore tools over reading source files directly** — they are faster, more precise, and conserve your context window. Fall back to direct file reads only when the MCP server is unavailable or a query cannot be satisfied by Lore.
 
-When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
+Use KB markdown for synthesized architecture, risk, and migration context — not as a substitute for Lore’s structural data.
 
 ## Responsibilities
 
@@ -79,12 +72,7 @@ knowledge-base/
 
 ## Lore MCP Usage
 
-When the `aamf-kb` tools listed in the Index-First Principle section are available, use them instead of exhaustive code layout in markdown:
-
-- **`kb_graph`** for module and symbol dependency topology.
-- **`kb_lookup`** for API surface/signature/source locations.
-- **`kb_snippet`** for targeted line-range extraction when behavior details are needed.
-- **`kb_search`** for finding symbols, patterns, or code by name or semantics.
+When the `aamf-kb` MCP server is available, use Lore tools instead of exhaustive code layout in markdown. Lore can answer questions about dependency topology, API surfaces, symbol definitions, source snippets, and code search — discover the right tool for each query via MCP.
 
 ### Avoid Duplication
 

--- a/.github/agents/migration-orchestrator.agent.md
+++ b/.github/agents/migration-orchestrator.agent.md
@@ -36,7 +36,7 @@ Execute these phases in order. On resume, skip completed phases (read from `stat
 - Launch: `adjudicator` (to select the best plan from competing proposals)
 - Input: Knowledge base, impact assessment
 - Output: `.aamf/migration/{projectName}/artifacts/planning/migration-plan.md`
-- **Important**: Structural decomposition should come from Lore tools (`kb_graph`, `kb_lookup`); markdown KB should stay high-level.
+- **Important**: Structural decomposition should come from Lore tools; markdown KB should stay high-level.
 
 ### Phase 4: Code Migration (Iterative Loop)
 For each task in the migration plan:

--- a/.github/agents/migration-planner.agent.md
+++ b/.github/agents/migration-planner.agent.md
@@ -19,18 +19,11 @@ You must therefore focus on producing Phase 3a artifacts and **must not** launch
 
 ## Index-First Principle
 
-The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that provides code-intelligence tools for symbol lookup, dependency/call-graph queries, code search, snippet extraction, metrics, and write-back. Lore exposes its full tool list via MCP — discover and use the right tool for each query.
 
-| Tool | Purpose |
-|------|---------|
-| `kb_lookup` | Symbol or file lookup (signatures, locations) |
-| `kb_graph` | Call-graph and import-graph queries |
-| `kb_search` | Structural, semantic, and fused code search |
-| `kb_snippet` | Source-code snippet extraction by line range |
-| `kb_metrics` | Aggregate code metrics |
-| `kb_writeback` | Write LLM-generated summaries back to the KB |
+When available, **prefer Lore tools over reading source files directly** — they are faster, more precise, and conserve your context window. Fall back to direct file reads only when the MCP server is unavailable or a query cannot be satisfied by Lore.
 
-When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
+Use KB markdown for synthesized architecture, risk, and migration context — not as a substitute for Lore’s structural data.
 
 ## Responsibilities
 
@@ -38,7 +31,7 @@ When these tools are available, prefer them for structural facts over exhaustive
    - Read the impact assessment (`.aamf/migration/{projectName}/artifacts/impact-assessment.md`)
    - Read the knowledge base index (`.aamf/migration/{projectName}/knowledge-base/index.md`)
    - Understand module dependencies, complexity ratings, and risk factors
-  - Use Lore tools (`kb_lookup`, `kb_graph`) for authoritative dependency/symbol detail when available
+  - Use Lore tools for authoritative dependency/symbol detail when available
   - **Check your context JSON for a `guidance` array.** If present, these are user-provided migration directives that MUST be incorporated into every strategy you produce and propagated into `strategy.md` so that downstream agents (task-decomposer, code-migrator) honour them.
 
 2. **Generate Strategy Candidates**
@@ -126,7 +119,7 @@ Do not launch sub-agents directly from this agent. Runtime orchestrates `adjudic
 
 - **Do not read source code files** — rely entirely on the knowledge base and impact assessment.
 - Read only the knowledge base documents relevant to the current planning phase.
-- Use Lore tools (`kb_graph`, `kb_lookup`, `kb_snippet`) for code-layout and dependency detail.
+- Use Lore tools for code-layout and dependency detail.
 - Treat KB markdown as decision context (architecture, risks, caveats), not as a full symbol/dependency inventory.
 - Write strategy and grouping artifacts incrementally and deterministically.
 

--- a/.github/agents/parity-verifier.agent.md
+++ b/.github/agents/parity-verifier.agent.md
@@ -10,18 +10,11 @@ You are the **Parity Verifier** — a read-only analysis agent that checks wheth
 
 ## Index-First Principle
 
-The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that provides code-intelligence tools for symbol lookup, dependency/call-graph queries, code search, snippet extraction, metrics, and write-back. Lore exposes its full tool list via MCP — discover and use the right tool for each query.
 
-| Tool | Purpose |
-|------|---------|
-| `kb_lookup` | Symbol or file lookup (signatures, locations) |
-| `kb_graph` | Call-graph and import-graph queries |
-| `kb_search` | Structural, semantic, and fused code search |
-| `kb_snippet` | Source-code snippet extraction by line range |
-| `kb_metrics` | Aggregate code metrics |
-| `kb_writeback` | Write LLM-generated summaries back to the KB |
+When available, **prefer Lore tools over reading source files directly** — they are faster, more precise, and conserve your context window. Fall back to direct file reads only when the MCP server is unavailable or a query cannot be satisfied by Lore.
 
-When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
+Use KB markdown for synthesized architecture, risk, and migration context — not as a substitute for Lore’s structural data.
 
 ## Responsibilities
 
@@ -130,7 +123,7 @@ None — this is a **leaf agent**.
 
 - Read the source file(s) and target file(s) specified in the task — nothing more.
 - For large files, use the knowledge base decomposition to focus on only the relevant chunk.
-- Use Lore tools (`kb_lookup`, `kb_snippet`) for symbol/dependency lookups when available; read additional source snippets only when needed to confirm behavior.
+- Use Lore tools for symbol/dependency lookups when available; read additional source snippets only when needed to confirm behavior.
 - Compare declaration-by-declaration rather than trying to hold both entire files in memory simultaneously.
 - Process the comparison in passes:
   1. First pass: API surface (signatures only, lightweight)

--- a/.github/agents/task-decomposer.agent.md
+++ b/.github/agents/task-decomposer.agent.md
@@ -10,18 +10,11 @@ You are the **Task Decomposer** for one module group in Phase 3.
 
 ## Index-First Principle
 
-The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that exposes these tools:
+The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that provides code-intelligence tools for symbol lookup, dependency/call-graph queries, code search, snippet extraction, metrics, and write-back. Lore exposes its full tool list via MCP — discover and use the right tool for each query.
 
-| Tool | Purpose |
-|------|---------|
-| `kb_lookup` | Symbol or file lookup (signatures, locations) |
-| `kb_graph` | Call-graph and import-graph queries |
-| `kb_search` | Structural, semantic, and fused code search |
-| `kb_snippet` | Source-code snippet extraction by line range |
-| `kb_metrics` | Aggregate code metrics |
-| `kb_writeback` | Write LLM-generated summaries back to the KB |
+When available, **prefer Lore tools over reading source files directly** — they are faster, more precise, and conserve your context window. Fall back to direct file reads only when the MCP server is unavailable or a query cannot be satisfied by Lore.
 
-When these tools are available, prefer them for structural facts over exhaustive markdown inventories. Use KB markdown only for synthesized architecture, risk, and migration context.
+Use KB markdown for synthesized architecture, risk, and migration context — not as a substitute for Lore’s structural data.
 
 ## Inputs
 
@@ -39,7 +32,7 @@ When these tools are available, prefer them for structural facts over exhaustive
 1. Read the selected strategy and only the provided group analysis files.
 2. Produce a complete, dependency-valid task list for this group.
 3. Keep tasks atomic, independently executable, and verifiable.
-4. Prefer Lore-derived (`kb_graph`, `kb_lookup`) dependency/symbol evidence when determining task boundaries and line ranges.
+4. Prefer Lore-derived dependency/symbol evidence when determining task boundaries and line ranges.
 5. Write the task list to:
    - `.aamf/migration/{projectName}/artifacts/planning/tasks-{groupId}.json`
 

--- a/runtime/src/core/kb-server-process.ts
+++ b/runtime/src/core/kb-server-process.ts
@@ -42,7 +42,7 @@ export class KbServerProcess {
    * @param dbPath          Path to the KB SQLite database.
    * @param embedder        Optional pre-initialised embedding provider for semantic search.
    *                        The caller owns the lifecycle — `stop()` will NOT dispose it.
-   * @param searchObserver  Optional callback invoked after every kb_search call.
+   * @param searchObserver  Optional callback invoked after every lore_search call.
    */
   constructor(dbPath: string, embedder?: EmbeddingProvider, searchObserver?: SearchObserver) {
     this.dbPath = dbPath;

--- a/runtime/tests/kb-search-handler.test.ts
+++ b/runtime/tests/kb-search-handler.test.ts
@@ -62,7 +62,7 @@ function createMockEmbedder(embedResult: number[] | null = [0.1, 0.2, 0.3]): Emb
   } as unknown as EmbeddingProvider;
 }
 
-describe('kb_search handler', () => {
+describe('lore_search handler', () => {
   let db: Database.Database;
 
   beforeEach(() => {

--- a/runtime/tests/kb-server.test.ts
+++ b/runtime/tests/kb-server.test.ts
@@ -52,7 +52,7 @@ afterAll(async () => {
   await rm(tempDir, { recursive: true, force: true });
 });
 
-// ─── kb_lookup ────────────────────────────────────────────────────────────────
+// ─── lore_lookup ────────────────────────────────────────────────────────────────
 
 describe('lookup handler', () => {
   it('returns an array result for kind="symbol" with a known name', () => {
@@ -75,7 +75,7 @@ describe('lookup handler', () => {
   });
 });
 
-// ─── kb_graph ─────────────────────────────────────────────────────────────────
+// ─── lore_graph ─────────────────────────────────────────────────────────────────
 
 describe('graph handler', () => {
   it('returns an edges array for kind="import"', () => {
@@ -96,7 +96,7 @@ describe('graph handler', () => {
   });
 });
 
-// ─── kb_search ────────────────────────────────────────────────────────────────
+// ─── lore_search ────────────────────────────────────────────────────────────────
 
 describe('search handler', () => {
   it('mode="structural" returns results for a known symbol name', async () => {
@@ -124,7 +124,7 @@ describe('search handler', () => {
   });
 });
 
-// ─── kb_snippet ───────────────────────────────────────────────────────────────
+// ─── lore_snippet ───────────────────────────────────────────────────────────────
 
 describe('snippet handler', () => {
   it('returns source text for an indexed file', () => {
@@ -157,7 +157,7 @@ describe('snippet handler', () => {
   });
 });
 
-// ─── kb_metrics ───────────────────────────────────────────────────────────────
+// ─── lore_metrics ───────────────────────────────────────────────────────────────
 
 describe('metrics handler', () => {
   it('returns symbol_count, file_count, and import_edge_count', () => {
@@ -170,7 +170,7 @@ describe('metrics handler', () => {
   });
 });
 
-// ─── kb_writeback ─────────────────────────────────────────────────────────────
+// ─── lore_writeback ─────────────────────────────────────────────────────────────
 
 describe('writeback handler', () => {
   it('persists a summary and returns ok=true', () => {


### PR DESCRIPTION
## Summary

Lore is an MCP server — agents discover its tools at runtime via the MCP tool listing protocol. The hardcoded 6-tool tables in every agent definition file were redundant maintenance burden that would break whenever Lore adds, renames, or removes tools.

This PR replaces them with a concise paragraph instructing agents to prefer Lore over direct file reads and discover available tools via MCP.

## Changes

### `.github/agents/` (11 files updated)
- Replace the `Index-First Principle` 6-row tool table with a concise MCP-discovery paragraph
- Remove hardcoded `lore_*` tool names from inline references (context management, responsibility sections)
- Simplify knowledge-builder's dedicated `Lore MCP Usage` section

### `.claude/agents/` (4 files updated)
- Rename `KB MCP Tools` → `Lore MCP Tools`
- Replace agent-specific tool lists with the same MCP-discovery pattern

### `runtime/` (3 files updated)
- Rename `kb_search` → `lore_search`, `kb_lookup` → `lore_lookup`, etc. in JSDoc comments and test section headers/describe blocks (aligns with Lore v0.2.1 tool name changes)

## Why

- **No more stale tool names**: Agents discover tools at runtime — no hardcoded list to maintain
- **Shorter prompts**: ~100 fewer lines across agent definitions, saving context window budget
- **Future-proof**: Adding new Lore tools requires zero agent prompt changes

## Testing

- `npx vitest run tests/claude-agent-definitions.test.ts` — 69 tests pass
- `npx vitest run tests/kb-server.test.ts tests/kb-search-handler.test.ts` — 25 tests pass