### PR TITLE
refactor(parity): replace sidecar .result.json files with in-memory structured output

### DIFF
--- a/.claude/agents/parity-verifier.md
+++ b/.claude/agents/parity-verifier.md
@@ -85,36 +85,7 @@ The context JSON contains:
 
 ## Output
 
-Write to `.aamf/migration/{projectName}/artifacts/parity/task-{taskId}.md` and also write a structured JSON result file at:
-
-```
-.aamf/migration/{projectName}/results/parity-verifier-{taskId}.result.json
-```
-
-The JSON must conform to this schema:
-
-```json
-{
-  "taskId": "task-001",
-  "agent": "parity-verifier",
-  "status": "completed",
-  "outputFiles": ["artifacts/parity/task-001.md"],
-  "parity": "pass",
-  "issues": [
-    {
-      "severity": "minor",
-      "description": "Missing null check in handleLogin",
-      "sourceLocation": "src/auth/login.py:45",
-      "targetLocation": "src/auth/login.ts:52"
-    }
-  ],
-  "notes": "Overall parity is good with one minor gap."
-}
-```
-
-- `status`: one of `"completed"`, `"failed"`, `"needs-review"`
-- `parity`: one of `"pass"`, `"partial"`, `"fail"`
-- `issues[].severity`: one of `"critical"`, `"major"`, `"minor"`
+Write your parity analysis to `.aamf/migration/{projectName}/artifacts/parity/task-{taskId}.md`.
 
 ## Context Window Management
 

--- a/runtime/src/agents/agent-output-schemas.ts
+++ b/runtime/src/agents/agent-output-schemas.ts
@@ -25,7 +25,9 @@ export const AamfOutputBase = z.object({
 export type AamfOutputBaseType = z.infer<typeof AamfOutputBase>;
 
 /**
- * JSON schema for structured agent task results (sidecar `.result.json`).
+ * JSON schema for structured agent task results.
+ * @deprecated Parity results are now extracted from aamf-json output directly.
+ * Retained for backward compatibility with readTaskResultJson.
  */
 export const TaskResultSchema = z.object({
   taskId: z.string().min(1),

--- a/runtime/src/agents/registry.ts
+++ b/runtime/src/agents/registry.ts
@@ -43,7 +43,16 @@ const TaskDecomposerSchema = AamfOutputBase.extend({
 });
 const AdjudicatorSchema = AamfOutputBase.extend({ agent: z.literal('adjudicator') });
 const CodeMigratorSchema = AamfOutputBase.extend({ agent: z.literal('code-migrator') });
-const ParityVerifierSchema = AamfOutputBase.extend({ agent: z.literal('parity-verifier') });
+const ParityVerifierSchema = AamfOutputBase.extend({
+  agent: z.literal('parity-verifier'),
+  parity: z.enum(['pass', 'partial', 'fail']),
+  issues: z.array(z.object({
+    severity: z.enum(['critical', 'major', 'minor']),
+    description: z.string(),
+    sourceLocation: z.string().optional(),
+    targetLocation: z.string().optional(),
+  })).default([]),
+});
 const TestWriterSchema = AamfOutputBase.extend({ agent: z.literal('test-writer') });
 const FailureAdjudicatorSchema = AamfOutputBase.extend({
   agent: z.enum(['failure-adjudicator', 'failure-recovery']),

--- a/runtime/src/agents/result-parser.ts
+++ b/runtime/src/agents/result-parser.ts
@@ -87,6 +87,11 @@ export class ResultParser {
     return parseMigrationPlanContent(content, log);
   }
 
+  /**
+   * @deprecated Sidecar `.result.json` files are no longer used.
+   * Parity results are extracted from the aamf-json output block.
+   * This method is retained only for backward compatibility.
+   */
   static async readTaskResultJson(
     progressDir: string,
     agent: string,

--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -131,6 +131,17 @@ import { formatDuration } from '../util/format.js';
 
 type Phase4QualityGateMode = 'enforce' | 'advisory' | 'skip';
 
+/** Parity result data extracted from parity-verifier aamf-json output. */
+interface ParityResultData {
+  parity: 'pass' | 'partial' | 'fail';
+  issues: Array<{
+    severity: 'critical' | 'major' | 'minor';
+    description: string;
+    sourceLocation?: string;
+    targetLocation?: string;
+  }>;
+}
+
 interface RetryTargetDetails {
   scope: 'task' | 'parity' | 'command' | 'wave';
   attempt: number;
@@ -247,6 +258,8 @@ export class MigrationOrchestrator {
   private readonly paths: ReturnType<typeof buildRuntimePaths>;
   /** Tracks the maximum concurrency observed across all ParallelExecutor instances. */
   private _peakConcurrency = 0;
+  /** In-memory cache of parity-verifier results parsed from aamf-json output. */
+  private readonly _parityResults = new Map<string, ParityResultData>();
   /** Unique task IDs that have consumed routed-task budget (heavy/critical). */
   private readonly _routedTaskIds = new Set<string>();
   /** Cumulative projected escalation cost (USD) for this run. */
@@ -1978,7 +1991,10 @@ export class MigrationOrchestrator {
         this.buildInvocation('test-writer', testCtx, 4, task.id),
       ]);
       this._peakConcurrency = Math.max(this._peakConcurrency, parallel.peakConcurrency);
-      if (parityResult) this.recordTokens(parityResult, 4);
+      if (parityResult) {
+        this.recordTokens(parityResult, 4);
+        this.storeParityResult(parityResult, task.id);
+      }
       if (testResult) this.recordTokens(testResult, 4);
       if (testResult?.success) {
         await this.commitForAgent('test-writer', 4, task.id, task.name);
@@ -1991,7 +2007,7 @@ export class MigrationOrchestrator {
     // b2. Check parity result and retry if non-minor issues found
     if (gateMode !== 'skip' && !this.hasPhase4Substep(task.id, 'parity-gate')) {
       const maxParityRetries = this.config.options.maxRetriesPerTask;
-      let parityPassed = await this.checkParityResult(task.id);
+      let parityPassed = this.checkParityResult(task.id);
 
       if (!parityPassed && gateMode === 'enforce') {
         const priorAttempts: Array<{ attempt: number; issueCount: number; unresolvedIssues: string[] }> = [];
@@ -2007,8 +2023,8 @@ export class MigrationOrchestrator {
             `${task.id}.md`,
           );
 
-          // Build an enriched failure summary from the actual parity sidecar
-          const issueSummary = await this.getParityIssueSummary(task.id);
+          // Build an enriched failure summary from the actual parity result
+          const issueSummary = this.getParityIssueSummary(task.id);
           const enrichedSummary = issueSummary
             ? `Parity verification failed for ${task.id}: ${issueSummary}`
             : `Parity verification failed for ${task.id}`;
@@ -2096,32 +2112,29 @@ export class MigrationOrchestrator {
           const reParityInv = this.buildInvocation('parity-verifier', reParityCtx, 4, task.id);
           const reParityResult = await this.launchAgentWithEvents(reParityInv);
           this.recordTokens(reParityResult, 4);
+          this.storeParityResult(reParityResult, task.id);
 
-          parityPassed = await this.checkParityResult(task.id);
+          parityPassed = this.checkParityResult(task.id);
           if (parityPassed) {
             this.logger.info(`Parity recovered for ${task.id} on attempt ${attempt}`);
             break;
           }
 
           // Record this attempt's outcome for next iteration's context
-          const attemptResult = await ResultParser.readTaskResultJson(
-            this.progressDir,
-            'parity-verifier',
-            task.id,
-          );
-          const unresolvedIssues = (attemptResult?.issues ?? [])
+          const storedResult = this._parityResults.get(task.id);
+          const unresolvedIssues = (storedResult?.issues ?? [])
             .filter((i) => i.severity !== 'minor')
             .map((i) => i.description);
           priorAttempts.push({
             attempt,
-            issueCount: attemptResult?.issues?.length ?? 0,
+            issueCount: storedResult?.issues?.length ?? 0,
             unresolvedIssues,
           });
         }
 
         // After exhausting retries, check if only minor issues remain
         if (!parityPassed) {
-          const hasBlockingIssues = await this.hasNonMinorParityIssues(task.id);
+          const hasBlockingIssues = this.hasNonMinorParityIssues(task.id);
           if (hasBlockingIssues) {
             await this.raiseTerminalExhaustion({
               reasonCode: 'parity-non-minor-exhausted',
@@ -3185,7 +3198,7 @@ export class MigrationOrchestrator {
       // Identify tasks with non-minor parity issues
       let failingTasks: MigrationTask[] = [];
       for (const task of waveTasks) {
-        const hasNonMinor = await this.hasNonMinorParityIssues(task.id);
+        const hasNonMinor = this.hasNonMinorParityIssues(task.id);
         if (hasNonMinor) failingTasks.push(task);
       }
 
@@ -3207,7 +3220,7 @@ export class MigrationOrchestrator {
             `${task.id}.md`,
           );
 
-          const issueSummary = await this.getParityIssueSummary(task.id);
+          const issueSummary = this.getParityIssueSummary(task.id);
           const enrichedSummary = issueSummary
             ? `Parity verification failed for ${task.id}: ${issueSummary}`
             : `Parity verification failed for ${task.id}`;
@@ -3274,12 +3287,13 @@ export class MigrationOrchestrator {
           const reParityInv = this.buildInvocation('parity-verifier', reParityCtx, 4, task.id);
           const reParityResult = await this.launchAgentWithEvents(reParityInv);
           this.recordTokens(reParityResult, 4);
+          this.storeParityResult(reParityResult, task.id);
         }));
 
         // Re-evaluate: filter to tasks that still have non-minor issues
         const stillFailing: MigrationTask[] = [];
         for (const task of failingTasks) {
-          const hasNonMinor = await this.hasNonMinorParityIssues(task.id);
+          const hasNonMinor = this.hasNonMinorParityIssues(task.id);
           if (hasNonMinor) stillFailing.push(task);
         }
         failingTasks = stillFailing;
@@ -3309,17 +3323,27 @@ export class MigrationOrchestrator {
   // ─── Helpers ─────────────────────────────────────────────────────────
 
   /**
-   * Check if the parity-verifier sidecar result indicates a pass.
-   * Returns `false` (fail-closed) if no sidecar file exists.
+   * Extract parity data from a parity-verifier AgentResult and store it
+   * in the in-memory map. If the aamf-json output was missing or malformed,
+   * nothing is stored and checkParityResult will return false (fail-closed).
    */
-  private async checkParityResult(taskId: string): Promise<boolean> {
-    const result = await ResultParser.readTaskResultJson(
-      this.progressDir,
-      'parity-verifier',
-      taskId,
-    );
+  private storeParityResult(agentResult: AgentResult, taskId: string): void {
+    if (!agentResult.outputParsed || !agentResult.structuredOutput) return;
+    const out = agentResult.structuredOutput as Record<string, unknown>;
+    const parity = out.parity;
+    if (parity !== 'pass' && parity !== 'partial' && parity !== 'fail') return;
+    const issues = Array.isArray(out.issues) ? out.issues as ParityResultData['issues'] : [];
+    this._parityResults.set(taskId, { parity, issues });
+  }
+
+  /**
+   * Check if the parity-verifier result indicates a pass.
+   * Returns `false` (fail-closed) if no result was parsed from the agent output.
+   */
+  private checkParityResult(taskId: string): boolean {
+    const result = this._parityResults.get(taskId);
     if (!result) {
-      this.logger.warn(`Parity sidecar missing for ${taskId} — treating as failed (fail-closed)`);
+      this.logger.warn(`Parity result missing for ${taskId} — treating as failed (fail-closed)`);
       return false;
     }
     if (result.parity === 'pass') return true;
@@ -3331,32 +3355,24 @@ export class MigrationOrchestrator {
   }
 
   /**
-   * Check if the parity sidecar has any non-minor (critical/major) issues.
-   * Returns `true` (fail-closed) if no sidecar exists, assuming blocking issues.
+   * Check if the parity result has any non-minor (critical/major) issues.
+   * Returns `true` (fail-closed) if no result exists, assuming blocking issues.
    */
-  private async hasNonMinorParityIssues(taskId: string): Promise<boolean> {
-    const result = await ResultParser.readTaskResultJson(
-      this.progressDir,
-      'parity-verifier',
-      taskId,
-    );
+  private hasNonMinorParityIssues(taskId: string): boolean {
+    const result = this._parityResults.get(taskId);
     if (!result) {
-      this.logger.warn(`Parity sidecar missing for ${taskId} — assuming blocking issues (fail-closed)`);
+      this.logger.warn(`Parity result missing for ${taskId} — assuming blocking issues (fail-closed)`);
       return true;
     }
     return result.issues.some((i) => i.severity !== 'minor');
   }
 
   /**
-   * Build a concise human-readable summary of parity issues from the sidecar.
-   * Returns `undefined` if no sidecar or no issues exist.
+   * Build a concise human-readable summary of parity issues.
+   * Returns `undefined` if no result or no issues exist.
    */
-  private async getParityIssueSummary(taskId: string): Promise<string | undefined> {
-    const result = await ResultParser.readTaskResultJson(
-      this.progressDir,
-      'parity-verifier',
-      taskId,
-    );
+  private getParityIssueSummary(taskId: string): string | undefined {
+    const result = this._parityResults.get(taskId);
     if (!result || result.issues.length === 0) return undefined;
 
     const bySeverity = { critical: 0, major: 0, minor: 0 };

--- a/runtime/tests/aamf-output-schema.test.ts
+++ b/runtime/tests/aamf-output-schema.test.ts
@@ -100,12 +100,12 @@ describe('Per-agent output schemas', () => {
   describe('ParityVerifierOutput', () => {
     it('accepts valid output', () => {
       expect(() =>
-        ParityVerifierOutput.parse({ status: VALID_STATUS, agent: 'parity-verifier' }),
+        ParityVerifierOutput.parse({ status: VALID_STATUS, agent: 'parity-verifier', parity: 'pass' }),
       ).not.toThrow();
     });
     it('rejects wrong agent literal', () => {
       expect(() =>
-        ParityVerifierOutput.parse({ status: VALID_STATUS, agent: 'code-migrator' }),
+        ParityVerifierOutput.parse({ status: VALID_STATUS, agent: 'code-migrator', parity: 'pass' }),
       ).toThrow();
     });
   });

--- a/runtime/tests/orchestrator.test.ts
+++ b/runtime/tests/orchestrator.test.ts
@@ -157,30 +157,63 @@ async function writeParityReport(
 }
 
 /**
- * Wrap a launcher function so parity-verifier invocations auto-write a
- * pass sidecar when none exists, matching the fail-closed default (#118).
+ * Wrap a launcher function so parity-verifier invocations auto-include
+ * valid parity data in structuredOutput, matching the fail-closed default (#118).
  */
-function withParityPassSidecar(
+function withParityPassOutput(
   fn: (inv: AgentInvocation) => Promise<AgentResult>,
 ): (inv: AgentInvocation) => Promise<AgentResult> {
   return async (inv: AgentInvocation): Promise<AgentResult> => {
     const result = await fn(inv);
-    if (inv.agent === 'parity-verifier' && inv.taskId && inv.progressDir) {
-      const resultsDir = join(inv.progressDir, 'artifacts', 'results');
-      const sidecarPath = join(resultsDir, `parity-verifier-${inv.taskId}.result.json`);
-      if (!(await fileExists(sidecarPath))) {
-        await mkdir(resultsDir, { recursive: true });
-        await writeFile(
-          sidecarPath,
-          JSON.stringify({
-            taskId: inv.taskId,
-            agent: 'parity-verifier',
-            status: 'completed',
-            outputFiles: [],
-            parity: 'pass',
-            issues: [],
-          }),
-        );
+    if (inv.agent === 'parity-verifier' && inv.taskId) {
+      if (!result.structuredOutput || !(result.structuredOutput as any).parity) {
+        result.structuredOutput = {
+          ...(result.structuredOutput ?? {}),
+          agent: 'parity-verifier',
+          status: 'completed',
+          taskId: inv.taskId,
+          parity: 'pass',
+          issues: [],
+        };
+        result.outputParsed = true;
+      }
+    }
+    return result;
+  };
+}
+
+/**
+ * Wrap a launcher function so parity-verifier invocations return custom
+ * structuredOutput per task. Used to simulate specific parity outcomes.
+ */
+function withParityOutput(
+  fn: (inv: AgentInvocation) => Promise<AgentResult>,
+  overrides: Record<string, { parity: string; issues: Array<{ severity: string; description: string; sourceLocation?: string; targetLocation?: string }> }>,
+): (inv: AgentInvocation) => Promise<AgentResult> {
+  return async (inv: AgentInvocation): Promise<AgentResult> => {
+    const result = await fn(inv);
+    if (inv.agent === 'parity-verifier' && inv.taskId) {
+      const override = overrides[inv.taskId];
+      if (override) {
+        result.structuredOutput = {
+          ...(result.structuredOutput ?? {}),
+          agent: 'parity-verifier',
+          status: 'completed',
+          taskId: inv.taskId,
+          parity: override.parity,
+          issues: override.issues,
+        };
+        result.outputParsed = true;
+      } else if (!result.structuredOutput || !(result.structuredOutput as any).parity) {
+        result.structuredOutput = {
+          ...(result.structuredOutput ?? {}),
+          agent: 'parity-verifier',
+          status: 'completed',
+          taskId: inv.taskId,
+          parity: 'pass',
+          issues: [],
+        };
+        result.outputParsed = true;
       }
     }
     return result;
@@ -232,7 +265,7 @@ async function setupOrchestrator(
   const progress = new ProgressWriter(progressFile);
   await progress.initialize(config);
 
-  const mockLauncher = new MockAgentLauncher(withParityPassSidecar(launcherFn));
+  const mockLauncher = new MockAgentLauncher(withParityPassOutput(launcherFn));
 
   const orchestrator = new MigrationOrchestrator(
     config,
@@ -782,7 +815,7 @@ describe('MigrationOrchestrator', () => {
       const progress = new ProgressWriter(progressFile);
       await progress.initialize(config);
 
-      const mockLauncher = new MockAgentLauncher(withParityPassSidecar(launcherFn));
+      const mockLauncher = new MockAgentLauncher(withParityPassOutput(launcherFn));
 
       const orchestrator = new MigrationOrchestrator(
         config,
@@ -859,7 +892,7 @@ describe('MigrationOrchestrator', () => {
       const progress = new ProgressWriter(progressFile);
       await progress.initialize(config);
 
-      const mockLauncher = new MockAgentLauncher(withParityPassSidecar(launcherFn));
+      const mockLauncher = new MockAgentLauncher(withParityPassOutput(launcherFn));
       const orchestrator = new MigrationOrchestrator(
         config,
         checkpoint,
@@ -1039,7 +1072,7 @@ describe('MigrationOrchestrator', () => {
       const progress = new ProgressWriter(progressFile);
       await progress.initialize(config);
 
-      const mockLauncher = new MockAgentLauncher(withParityPassSidecar(launcherFn));
+      const mockLauncher = new MockAgentLauncher(withParityPassOutput(launcherFn));
       const orchestrator = new MigrationOrchestrator(
         config,
         checkpoint,
@@ -1888,368 +1921,13 @@ describe('MigrationOrchestrator', () => {
       const launcherFn = createMockLauncher((inv) => {
         if (inv.agent === 'parity-verifier') {
           parityCallCount++;
-        }
-        return {};
-      });
-
-      const { orchestrator, progressDir, mockLauncher } = await setupOrchestrator(
-        tempDir,
-        launcherFn,
-        {
-          options: {
-            maxParallelAgents: 3,
-            maxRetriesPerTask: 2,
-            maxLinesPerTask: 500,
-            dryRun: false,
-            resume: false,
-            invocationDelayMs: 0,
-            buildConcurrency: 1,
-            continueOnBlocked: true,
-            maxBlockedTasks: 0,
-            maxInfraRetries: 3,
-          },
-        },
-      );
-
-      const singleTaskPlan = `# Migration Plan
-
-## Task: task-001 - Auth Module
-
-**Description:** Migrate auth
-**Complexity:** simple
-**Knowledge Base Reference:** kb/auth.md
-
-**Source Files:**
-- src/auth.py
-
-**Target Files:**
-- src/auth.ts
-
-**Dependencies:** none
-
-**Acceptance Criteria:**
-- works
-
-**Parity Checks:**
-- matches
-`;
-      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
-      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
-      await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
-
-      // Write a parity sidecar with critical issues (will be read after parity-verifier runs)
-      await ensureDir(join(progressDir, 'artifacts', 'results'));
-      await writeFile(
-        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-        JSON.stringify({
-          taskId: 'task-001',
-          agent: 'parity-verifier',
-          status: 'completed',
-          outputFiles: ['parity-reports/task-001.md'],
-          parity: 'fail',
-          issues: [
-            {
-              severity: 'critical',
-              description: 'Missing error handling in auth flow',
-              sourceLocation: 'src/auth.py:45',
-              targetLocation: 'src/auth.ts:52',
-            },
-          ],
-        }),
-      );
-
-      await orchestrator.run();
-
-      const recoveryInvocations = mockLauncher.invocations.filter(
-        (i) => i.agent === 'failure-adjudicator' && i.phase === 4,
-      );
-      expect(recoveryInvocations.length).toBeGreaterThan(0);
-
-      const parityRecovery = recoveryInvocations[0]!;
-      const recoveryContext = JSON.parse(await readFile(parityRecovery.contextFile, 'utf-8'));
-      expect(recoveryContext.payload?.remediationContext?.failureKind).toBe('parity');
-      expect(recoveryContext.payload?.remediationContext?.failureTarget?.taskId).toBe('task-001');
-
-      const remigrateCandidates = mockLauncher.invocations.filter(
-        (i) => i.agent === 'code-migrator' && i.phase === 4,
-      );
-      let foundParityRemediation = false;
-      for (const inv of remigrateCandidates) {
-        const ctx = JSON.parse(await readFile(inv.contextFile, 'utf-8'));
-        if (ctx.payload?.remediationContext?.failureKind === 'parity') {
-          foundParityRemediation = true;
-          break;
-        }
-      }
-      expect(foundParityRemediation).toBe(true);
-    });
-
-    it('should pass enriched context to code-migrator during parity recovery', async () => {
-      const launcherFn = createMockLauncher();
-      const { orchestrator, progressDir, mockLauncher } = await setupOrchestrator(
-        tempDir,
-        launcherFn,
-        {
-          options: {
-            maxParallelAgents: 3,
-            maxRetriesPerTask: 1,
-            maxLinesPerTask: 500,
-            dryRun: false,
-            resume: false,
-            invocationDelayMs: 0,
-            buildConcurrency: 1,
-            continueOnBlocked: true,
-            maxBlockedTasks: 0,
-            maxInfraRetries: 3,
-          },
-        },
-      );
-
-      const singleTaskPlan = `# Migration Plan
-
-## Task: task-001 - Auth Module
-
-**Description:** Migrate auth
-**Complexity:** simple
-**Knowledge Base Reference:** kb/auth.md
-
-**Source Files:**
-- src/auth.py
-
-**Target Files:**
-- src/auth.ts
-
-**Dependencies:** none
-
-**Acceptance Criteria:**
-- works
-
-**Parity Checks:**
-- matches
-`;
-      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
-      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
-      await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
-
-      await ensureDir(join(progressDir, 'artifacts', 'results'));
-      await writeFile(
-        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-        JSON.stringify({
-          taskId: 'task-001',
-          agent: 'parity-verifier',
-          status: 'completed',
-          outputFiles: ['parity-reports/task-001.md'],
-          parity: 'fail',
-          issues: [
-            {
-              severity: 'major',
-              description: 'HashMap shim instead of direct struct access',
-              sourceLocation: 'src/wrapper.c:178',
-              targetLocation: 'src/lib.rs:120',
-            },
-            {
-              severity: 'critical',
-              description: 'Missing z_deflate wrapper functions',
-              sourceLocation: 'src/wrapper.c:263',
-              targetLocation: 'src/lib.rs',
-            },
-          ],
-        }),
-      );
-
-      await orchestrator.run();
-
-      // Find the code-migrator invocation that has a parity remediationContext
-      const reMigrateCandidates = mockLauncher.invocations.filter(
-        (i) => i.agent === 'code-migrator' && i.phase === 4,
-      );
-      let reMigrateCtx: Record<string, unknown> | undefined;
-      for (const inv of reMigrateCandidates) {
-        const ctx = JSON.parse(await readFile(inv.contextFile, 'utf-8'));
-        if (ctx.payload?.remediationContext?.failureKind === 'parity') {
-          reMigrateCtx = ctx;
-          break;
-        }
-      }
-      expect(reMigrateCtx).toBeDefined();
-
-      // Enriched failureSummary should contain the specific issue descriptions
-      const remediation = reMigrateCtx!.payload?.remediationContext as Record<string, unknown>;
-      const summary = remediation?.failureSummary as string;
-      expect(summary).toContain('major');
-      expect(summary).toContain('critical');
-      expect(summary).toContain('HashMap shim');
-
-      // Parity report .md should be in inputFiles
-      const inputFiles = reMigrateCtx!.inputFiles as string[];
-      const hasParityMd = inputFiles.some((f: string) => f.endsWith('.md') && f.includes('parity'));
-      expect(hasParityMd).toBe(true);
-
-      // Adjudication report path should be in inputFiles
-      const hasAdjudicationMd = inputFiles.some((f: string) => f.includes('adjudication'));
-      expect(hasAdjudicationMd).toBe(true);
-
-      // adjudicationReportPath should be set in remediationContext
-      expect(remediation?.adjudicationReportPath).toBeDefined();
-      expect(typeof remediation?.adjudicationReportPath).toBe('string');
-    });
-
-    it('should not trigger recovery when parity has only minor issues', async () => {
-      const launcherFn = createMockLauncher();
-      const { orchestrator, progressDir, mockLauncher } = await setupOrchestrator(
-        tempDir,
-        launcherFn,
-      );
-
-      const singleTaskPlan = `# Migration Plan
-
-## Task: task-001 - Auth Module
-
-**Description:** Migrate auth
-**Complexity:** simple
-**Knowledge Base Reference:** kb/auth.md
-
-**Source Files:**
-- src/auth.py
-
-**Target Files:**
-- src/auth.ts
-
-**Dependencies:** none
-
-**Acceptance Criteria:**
-- works
-
-**Parity Checks:**
-- matches
-`;
-      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
-      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
-      await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
-
-      // Write a parity sidecar with only minor issues
-      await ensureDir(join(progressDir, 'artifacts', 'results'));
-      await writeFile(
-        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-        JSON.stringify({
-          taskId: 'task-001',
-          agent: 'parity-verifier',
-          status: 'completed',
-          outputFiles: ['parity-reports/task-001.md'],
-          parity: 'partial',
-          issues: [
-            {
-              severity: 'minor',
-              description: 'Slightly different API surface',
-            },
-          ],
-        }),
-      );
-
-      const result = await orchestrator.run();
-
-      // No failure-adjudicator should be invoked for parity
-      const recoveryForParity = mockLauncher.invocations.filter(
-        (i) => i.agent === 'failure-adjudicator' && i.phase === 4,
-      );
-      expect(recoveryForParity).toHaveLength(0);
-      expect(result.success).toBe(true);
-    });
-
-    it('should fail fast when parity retains non-minor issues after retries', async () => {
-      let migratorAttempt = 0;
-      const launcherFn = createMockLauncher((inv) => {
-        if (inv.agent === 'code-migrator') {
-          migratorAttempt++;
-        }
-        return {};
-      });
-
-      const { orchestrator, progressDir } = await setupOrchestrator(
-        tempDir,
-        launcherFn,
-        {
-          options: {
-            maxParallelAgents: 3,
-            maxRetriesPerTask: 1,
-            maxLinesPerTask: 500,
-            dryRun: false,
-            resume: false,
-            invocationDelayMs: 0,
-            buildConcurrency: 1,
-            continueOnBlocked: true,
-            maxBlockedTasks: 0,
-            maxInfraRetries: 3,
-          },
-        },
-      );
-
-      const singleTaskPlan = `# Migration Plan
-
-## Task: task-001 - Auth Module
-
-**Description:** Migrate auth
-**Complexity:** simple
-**Knowledge Base Reference:** kb/auth.md
-
-**Source Files:**
-- src/auth.py
-
-**Target Files:**
-- src/auth.ts
-
-**Dependencies:** none
-
-**Acceptance Criteria:**
-- works
-
-**Parity Checks:**
-- matches
-`;
-      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
-      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
-      await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
-
-      // Write a parity sidecar with major issues that downgrade to minor after retry
-      // but since the file persists, we simulate "only minor remaining"
-      await ensureDir(join(progressDir, 'artifacts', 'results'));
-      await writeFile(
-        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-        JSON.stringify({
-          taskId: 'task-001',
-          agent: 'parity-verifier',
-          status: 'completed',
-          outputFiles: ['parity-reports/task-001.md'],
-          parity: 'partial',
-          issues: [
-            {
-              severity: 'major',
-              description: 'Missing validation logic',
-            },
-            {
-              severity: 'minor',
-              description: 'Slightly different API surface',
-            },
-          ],
-        }),
-      );
-
-      const result = await orchestrator.run();
-      const phase4 = result.phases.find((p) => p.phase === 4);
-
-      expect(result.success).toBe(false);
-      expect(phase4?.error).toContain('parity-non-minor-exhausted');
-      expect(result.blockedTasks).not.toContain('task-001');
-    });
-
-    it('should terminally exhaust when failure-adjudicator emits no aamf-json during parity recovery', async () => {
-      const launcherFn = createMockLauncher((inv) => {
-        if (inv.agent === 'failure-adjudicator') {
           return {
-            exitCode: 1,
-            success: false,
-            error: 'aamf-json parse failed: missing aamf-json block',
-            parseError: 'missing aamf-json block',
+            outputParsed: true,
+            structuredOutput: {
+              agent: 'parity-verifier', status: 'completed', taskId: inv.taskId,
+              parity: 'fail',
+              issues: [{ severity: 'critical', description: 'Missing error handling in auth flow', sourceLocation: 'src/auth.py:45', targetLocation: 'src/auth.ts:52' }],
+            },
           };
         }
         return {};
@@ -2300,24 +1978,326 @@ describe('MigrationOrchestrator', () => {
       await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
       await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
 
-      await ensureDir(join(progressDir, 'artifacts', 'results'));
-      await writeFile(
-        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-        JSON.stringify({
-          taskId: 'task-001',
-          agent: 'parity-verifier',
-          status: 'completed',
-          outputFiles: ['parity-reports/task-001.md'],
-          parity: 'fail',
-          issues: [
-            {
-              severity: 'major',
-              description: 'Behavior diverges in auth checks',
+      await orchestrator.run();
+
+      const recoveryInvocations = mockLauncher.invocations.filter(
+        (i) => i.agent === 'failure-adjudicator' && i.phase === 4,
+      );
+      expect(recoveryInvocations.length).toBeGreaterThan(0);
+
+      const parityRecovery = recoveryInvocations[0]!;
+      const recoveryContext = JSON.parse(await readFile(parityRecovery.contextFile, 'utf-8'));
+      expect(recoveryContext.payload?.remediationContext?.failureKind).toBe('parity');
+      expect(recoveryContext.payload?.remediationContext?.failureTarget?.taskId).toBe('task-001');
+
+      const remigrateCandidates = mockLauncher.invocations.filter(
+        (i) => i.agent === 'code-migrator' && i.phase === 4,
+      );
+      let foundParityRemediation = false;
+      for (const inv of remigrateCandidates) {
+        const ctx = JSON.parse(await readFile(inv.contextFile, 'utf-8'));
+        if (ctx.payload?.remediationContext?.failureKind === 'parity') {
+          foundParityRemediation = true;
+          break;
+        }
+      }
+      expect(foundParityRemediation).toBe(true);
+    });
+
+    it('should pass enriched context to code-migrator during parity recovery', async () => {
+      const launcherFn = createMockLauncher((inv) => {
+        if (inv.agent === 'parity-verifier') {
+          return {
+            outputParsed: true,
+            structuredOutput: {
+              agent: 'parity-verifier', status: 'completed', taskId: inv.taskId,
+              parity: 'fail',
+              issues: [
+                { severity: 'major', description: 'HashMap shim instead of direct struct access', sourceLocation: 'src/wrapper.c:178', targetLocation: 'src/lib.rs:120' },
+                { severity: 'critical', description: 'Missing z_deflate wrapper functions', sourceLocation: 'src/wrapper.c:263', targetLocation: 'src/lib.rs' },
+              ],
             },
-          ],
-        }),
+          };
+        }
+        return {};
+      });
+      const { orchestrator, progressDir, mockLauncher } = await setupOrchestrator(
+        tempDir,
+        launcherFn,
+        {
+          options: {
+            maxParallelAgents: 3,
+            maxRetriesPerTask: 1,
+            maxLinesPerTask: 500,
+            dryRun: false,
+            resume: false,
+            invocationDelayMs: 0,
+            buildConcurrency: 1,
+            continueOnBlocked: true,
+            maxBlockedTasks: 0,
+            maxInfraRetries: 3,
+          },
+        },
       );
 
+      const singleTaskPlan = `# Migration Plan
+
+## Task: task-001 - Auth Module
+
+**Description:** Migrate auth
+**Complexity:** simple
+**Knowledge Base Reference:** kb/auth.md
+
+**Source Files:**
+- src/auth.py
+
+**Target Files:**
+- src/auth.ts
+
+**Dependencies:** none
+
+**Acceptance Criteria:**
+- works
+
+**Parity Checks:**
+- matches
+`;
+      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
+      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
+      await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
+
+      await orchestrator.run();
+
+      // Find the code-migrator invocation that has a parity remediationContext
+      const reMigrateCandidates = mockLauncher.invocations.filter(
+        (i) => i.agent === 'code-migrator' && i.phase === 4,
+      );
+      let reMigrateCtx: Record<string, unknown> | undefined;
+      for (const inv of reMigrateCandidates) {
+        const ctx = JSON.parse(await readFile(inv.contextFile, 'utf-8'));
+        if (ctx.payload?.remediationContext?.failureKind === 'parity') {
+          reMigrateCtx = ctx;
+          break;
+        }
+      }
+      expect(reMigrateCtx).toBeDefined();
+
+      // Enriched failureSummary should contain the specific issue descriptions
+      const remediation = reMigrateCtx!.payload?.remediationContext as Record<string, unknown>;
+      const summary = remediation?.failureSummary as string;
+      expect(summary).toContain('major');
+      expect(summary).toContain('critical');
+      expect(summary).toContain('HashMap shim');
+
+      // Parity report .md should be in inputFiles
+      const inputFiles = reMigrateCtx!.inputFiles as string[];
+      const hasParityMd = inputFiles.some((f: string) => f.endsWith('.md') && f.includes('parity'));
+      expect(hasParityMd).toBe(true);
+
+      // Adjudication report path should be in inputFiles
+      const hasAdjudicationMd = inputFiles.some((f: string) => f.includes('adjudication'));
+      expect(hasAdjudicationMd).toBe(true);
+
+      // adjudicationReportPath should be set in remediationContext
+      expect(remediation?.adjudicationReportPath).toBeDefined();
+      expect(typeof remediation?.adjudicationReportPath).toBe('string');
+    });
+
+    it('should not trigger recovery when parity has only minor issues', async () => {
+      const launcherFn = createMockLauncher((inv) => {
+        if (inv.agent === 'parity-verifier') {
+          return {
+            outputParsed: true,
+            structuredOutput: {
+              agent: 'parity-verifier', status: 'completed', taskId: inv.taskId,
+              parity: 'partial',
+              issues: [{ severity: 'minor', description: 'Slightly different API surface', sourceLocation: 'src/auth.py:10', targetLocation: 'src/auth.ts:12' }],
+            },
+          };
+        }
+        return {};
+      });
+      const { orchestrator, progressDir, mockLauncher } = await setupOrchestrator(
+        tempDir,
+        launcherFn,
+      );
+
+      const singleTaskPlan = `# Migration Plan
+
+## Task: task-001 - Auth Module
+
+**Description:** Migrate auth
+**Complexity:** simple
+**Knowledge Base Reference:** kb/auth.md
+
+**Source Files:**
+- src/auth.py
+
+**Target Files:**
+- src/auth.ts
+
+**Dependencies:** none
+
+**Acceptance Criteria:**
+- works
+
+**Parity Checks:**
+- matches
+`;
+      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
+      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
+      await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
+
+      const result = await orchestrator.run();
+
+      // No failure-adjudicator should be invoked for parity
+      const recoveryForParity = mockLauncher.invocations.filter(
+        (i) => i.agent === 'failure-adjudicator' && i.phase === 4,
+      );
+      expect(recoveryForParity).toHaveLength(0);
+      expect(result.success).toBe(true);
+    });
+
+    it('should fail fast when parity retains non-minor issues after retries', async () => {
+      let migratorAttempt = 0;
+      const launcherFn = createMockLauncher((inv) => {
+        if (inv.agent === 'code-migrator') {
+          migratorAttempt++;
+        }
+        if (inv.agent === 'parity-verifier') {
+          return {
+            outputParsed: true,
+            structuredOutput: {
+              agent: 'parity-verifier', status: 'completed', taskId: inv.taskId,
+              parity: 'partial',
+              issues: [{ severity: 'major', description: 'Missing validation logic' }],
+            },
+          };
+        }
+        return {};
+      });
+
+      const { orchestrator, progressDir } = await setupOrchestrator(
+        tempDir,
+        launcherFn,
+        {
+          options: {
+            maxParallelAgents: 3,
+            maxRetriesPerTask: 1,
+            maxLinesPerTask: 500,
+            dryRun: false,
+            resume: false,
+            invocationDelayMs: 0,
+            buildConcurrency: 1,
+            continueOnBlocked: true,
+            maxBlockedTasks: 0,
+            maxInfraRetries: 3,
+          },
+        },
+      );
+
+      const singleTaskPlan = `# Migration Plan
+
+## Task: task-001 - Auth Module
+
+**Description:** Migrate auth
+**Complexity:** simple
+**Knowledge Base Reference:** kb/auth.md
+
+**Source Files:**
+- src/auth.py
+
+**Target Files:**
+- src/auth.ts
+
+**Dependencies:** none
+
+**Acceptance Criteria:**
+- works
+
+**Parity Checks:**
+- matches
+`;
+      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
+      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
+      await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
+
+      // but since the file persists, we simulate "only minor remaining"
+      const result = await orchestrator.run();
+      const phase4 = result.phases.find((p) => p.phase === 4);
+
+      expect(result.success).toBe(false);
+      expect(phase4?.error).toContain('parity-non-minor-exhausted');
+      expect(result.blockedTasks).not.toContain('task-001');
+    });
+
+    it('should terminally exhaust when failure-adjudicator emits no aamf-json during parity recovery', async () => {
+      const launcherFn = createMockLauncher((inv) => {
+        if (inv.agent === 'failure-adjudicator') {
+          return {
+            exitCode: 1,
+            success: false,
+            error: 'aamf-json parse failed: missing aamf-json block',
+            parseError: 'missing aamf-json block',
+          };
+        }
+        if (inv.agent === 'parity-verifier') {
+          return {
+            outputParsed: true,
+            structuredOutput: {
+              agent: 'parity-verifier', status: 'completed', taskId: inv.taskId,
+              parity: 'fail',
+              issues: [{ severity: 'major', description: 'Behavior diverges in auth checks' }],
+            },
+          };
+        }
+        return {};
+      });
+
+      const { orchestrator, progressDir, mockLauncher } = await setupOrchestrator(
+        tempDir,
+        launcherFn,
+        {
+          options: {
+            maxParallelAgents: 3,
+            maxRetriesPerTask: 2,
+            maxLinesPerTask: 500,
+            dryRun: false,
+            resume: false,
+            invocationDelayMs: 0,
+            buildConcurrency: 1,
+            continueOnBlocked: true,
+            maxBlockedTasks: 0,
+            maxInfraRetries: 3,
+          },
+        },
+      );
+
+      const singleTaskPlan = `# Migration Plan
+
+## Task: task-001 - Auth Module
+
+**Description:** Migrate auth
+**Complexity:** simple
+**Knowledge Base Reference:** kb/auth.md
+
+**Source Files:**
+- src/auth.py
+
+**Target Files:**
+- src/auth.ts
+
+**Dependencies:** none
+
+**Acceptance Criteria:**
+- works
+
+**Parity Checks:**
+- matches
+`;
+      await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
+      await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
+      await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
       const result = await orchestrator.run();
       const phase4 = result.phases.find((p) => p.phase === 4);
 
@@ -2485,7 +2465,19 @@ describe('MigrationOrchestrator', () => {
       });
 
       it('should pass wave-end parity gate in deferred-strict when all tasks have only minor issues', async () => {
-        const launcherFn = createMockLauncher();
+        const launcherFn = createMockLauncher((inv) => {
+          if (inv.agent === 'parity-verifier') {
+            return {
+              outputParsed: true,
+              structuredOutput: {
+                agent: 'parity-verifier', status: 'completed', taskId: inv.taskId,
+                parity: 'partial',
+                issues: [{ severity: 'minor', description: 'Style nit' }],
+              },
+            };
+          }
+          return {};
+        });
         const { orchestrator, progressDir, mockLauncher } = await setupOrchestrator(tempDir, launcherFn, {
           target: {
             outputPath: join(tempDir, 'deferred-parity-pass-output'),
@@ -2519,20 +2511,6 @@ describe('MigrationOrchestrator', () => {
         await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
         await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
 
-        // Write a parity sidecar with only minor issues
-        await ensureDir(join(progressDir, 'artifacts', 'results'));
-        await writeFile(
-          join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-          JSON.stringify({
-            taskId: 'task-001',
-            agent: 'parity-verifier',
-            status: 'completed',
-            outputFiles: [],
-            parity: 'partial',
-            issues: [{ severity: 'minor', description: 'Slightly different API surface' }],
-          }),
-        );
-
         const result = await orchestrator.run();
 
         expect(result.success).toBe(true);
@@ -2544,9 +2522,29 @@ describe('MigrationOrchestrator', () => {
       });
 
       it('should trigger batched remediation at wave-end in deferred-strict for non-minor parity issues', async () => {
+        let parityCallCount = 0;
         const launcherFn = createMockLauncher((inv) => {
-          // After remediation, parity-verifier writes a passing sidecar
-          // (the withParityPassSidecar wrapper handles this automatically)
+          if (inv.agent === 'parity-verifier') {
+            parityCallCount++;
+            if (parityCallCount === 1) {
+              return {
+                outputParsed: true,
+                structuredOutput: {
+                  agent: 'parity-verifier', status: 'completed', taskId: inv.taskId,
+                  parity: 'fail',
+                  issues: [{ severity: 'major', description: 'Divergence in task' }],
+                },
+              };
+            }
+            // After remediation, pass
+            return {
+              outputParsed: true,
+              structuredOutput: {
+                agent: 'parity-verifier', status: 'completed', taskId: inv.taskId,
+                parity: 'pass', issues: [],
+              },
+            };
+          }
           return {};
         });
         const { orchestrator, progressDir, mockLauncher } = await setupOrchestrator(tempDir, launcherFn, {
@@ -2582,20 +2580,6 @@ describe('MigrationOrchestrator', () => {
         await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
         await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
 
-        // Write a parity sidecar with major issues
-        await ensureDir(join(progressDir, 'artifacts', 'results'));
-        await writeFile(
-          join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-          JSON.stringify({
-            taskId: 'task-001',
-            agent: 'parity-verifier',
-            status: 'completed',
-            outputFiles: ['parity-reports/task-001.md'],
-            parity: 'fail',
-            issues: [{ severity: 'major', description: 'Missing validation logic' }],
-          }),
-        );
-
         const result = await orchestrator.run();
 
         // Remediation should have been triggered at wave-end
@@ -2611,8 +2595,20 @@ describe('MigrationOrchestrator', () => {
       });
 
       it('should raise terminal exhaustion at wave-end in deferred-strict when remediation does not converge', async () => {
-        // Launcher always returns success, but the parity sidecar persists with major issues
-        const launcherFn = createMockLauncher();
+        // Parity-verifier always reports fail with major issues — remediation cannot converge
+        const launcherFn = createMockLauncher((inv) => {
+          if (inv.agent === 'parity-verifier') {
+            return {
+              outputParsed: true,
+              structuredOutput: {
+                agent: 'parity-verifier', status: 'completed', taskId: inv.taskId,
+                parity: 'fail',
+                issues: [{ severity: 'major', description: 'Persistent divergence' }],
+              },
+            };
+          }
+          return {};
+        });
         const { orchestrator, progressDir } = await setupOrchestrator(tempDir, launcherFn, {
           target: {
             outputPath: join(tempDir, 'deferred-exhaustion-output'),
@@ -2645,20 +2641,6 @@ describe('MigrationOrchestrator', () => {
         await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
         await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
         await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
-
-        // Write a parity sidecar with major issues that won't be resolved
-        await ensureDir(join(progressDir, 'artifacts', 'results'));
-        await writeFile(
-          join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-          JSON.stringify({
-            taskId: 'task-001',
-            agent: 'parity-verifier',
-            status: 'completed',
-            outputFiles: ['parity-reports/task-001.md'],
-            parity: 'fail',
-            issues: [{ severity: 'major', description: 'Critical behavior divergence' }],
-          }),
-        );
 
         const result = await orchestrator.run();
         const phase4 = result.phases.find((p) => p.phase === 4);
@@ -2732,20 +2714,6 @@ describe('MigrationOrchestrator', () => {
         await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
         await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
 
-        // Write a parity sidecar with parity: 'pass' and no issues
-        await ensureDir(join(progressDir, 'artifacts', 'results'));
-        await writeFile(
-          join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-          JSON.stringify({
-            taskId: 'task-001',
-            agent: 'parity-verifier',
-            status: 'completed',
-            outputFiles: [],
-            parity: 'pass',
-            issues: [],
-          }),
-        );
-
         const result = await orchestrator.run();
 
         expect(result.success).toBe(true);
@@ -2790,12 +2758,9 @@ describe('MigrationOrchestrator', () => {
         await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
         await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
 
-        // Intentionally do NOT write a parity sidecar — the initial pass sidecar
-        // written by withParityPassSidecar during Phase 4 migration will be present,
-        // so we must delete it after phase 4 migration runs. Instead, we spy on
-        // hasNonMinorParityIssues to simulate missing sidecar at wave-end.
+        // Simulate missing parity result at wave-end by mocking hasNonMinorParityIssues
         const hasNonMinorSpy = vi.spyOn(orchestrator as any, 'hasNonMinorParityIssues')
-          .mockResolvedValue(true);
+          .mockReturnValue(true);
 
         const result = await orchestrator.run();
 
@@ -2810,7 +2775,19 @@ describe('MigrationOrchestrator', () => {
       });
 
       it('should trigger remediation for critical severity parity issues in deferred-strict', async () => {
-        const launcherFn = createMockLauncher();
+        const launcherFn = createMockLauncher((inv) => {
+          if (inv.agent === 'parity-verifier') {
+            return {
+              outputParsed: true,
+              structuredOutput: {
+                agent: 'parity-verifier', status: 'completed', taskId: inv.taskId,
+                parity: 'fail',
+                issues: [{ severity: 'critical', description: 'Missing export' }],
+              },
+            };
+          }
+          return {};
+        });
         const { orchestrator, progressDir, mockLauncher } = await setupOrchestrator(tempDir, launcherFn, {
           target: {
             outputPath: join(tempDir, 'deferred-critical-output'),
@@ -2843,20 +2820,6 @@ describe('MigrationOrchestrator', () => {
         await mkdir(join(progressDir, 'artifacts', 'planning'), { recursive: true });
         await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
         await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
-
-        // Write a parity sidecar with critical severity issues
-        await ensureDir(join(progressDir, 'artifacts', 'results'));
-        await writeFile(
-          join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-          JSON.stringify({
-            taskId: 'task-001',
-            agent: 'parity-verifier',
-            status: 'completed',
-            outputFiles: ['parity-reports/task-001.md'],
-            parity: 'fail',
-            issues: [{ severity: 'critical', description: 'Security check missing entirely' }],
-          }),
-        );
 
         const result = await orchestrator.run();
 
@@ -2905,20 +2868,6 @@ describe('MigrationOrchestrator', () => {
         await writeFile(join(progressDir, 'artifacts', 'planning', 'migration-plan.md'), singleTaskPlan);
         await writePhase3PlanningArtifacts(progressDir, [SINGLE_AUTH_TASK]);
 
-        // Write a parity sidecar with major issues — but build gate should fail first
-        await ensureDir(join(progressDir, 'artifacts', 'results'));
-        await writeFile(
-          join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-          JSON.stringify({
-            taskId: 'task-001',
-            agent: 'parity-verifier',
-            status: 'completed',
-            outputFiles: [],
-            parity: 'fail',
-            issues: [{ severity: 'major', description: 'Major divergence' }],
-          }),
-        );
-
         const result = await orchestrator.run();
         const phase4 = result.phases.find((p) => p.phase === 4);
 
@@ -2934,6 +2883,16 @@ describe('MigrationOrchestrator', () => {
         const invocationOrder: string[] = [];
         const launcherFn = createMockLauncher((inv) => {
           invocationOrder.push(`${inv.agent}:${inv.taskId}`);
+          if (inv.agent === 'parity-verifier') {
+            return {
+              outputParsed: true,
+              structuredOutput: {
+                agent: 'parity-verifier', status: 'completed', taskId: inv.taskId,
+                parity: 'fail',
+                issues: [{ severity: 'major', description: `Divergence in ${inv.taskId}` }],
+              },
+            };
+          }
           return {};
         });
         const { orchestrator, progressDir, mockLauncher } = await setupOrchestrator(tempDir, launcherFn, {
@@ -2943,31 +2902,6 @@ describe('MigrationOrchestrator', () => {
           options: { qualityPolicy: 'deferred-strict', maxRetriesPerTask: 1 },
         });
         await writeMigrationPlan(progressDir);
-
-        // Write parity sidecars with major issues for both tasks
-        await ensureDir(join(progressDir, 'artifacts', 'results'));
-        await writeFile(
-          join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-          JSON.stringify({
-            taskId: 'task-001',
-            agent: 'parity-verifier',
-            status: 'completed',
-            outputFiles: [],
-            parity: 'fail',
-            issues: [{ severity: 'major', description: 'Divergence in task-001' }],
-          }),
-        );
-        await writeFile(
-          join(progressDir, 'artifacts', 'results', 'parity-verifier-task-002.result.json'),
-          JSON.stringify({
-            taskId: 'task-002',
-            agent: 'parity-verifier',
-            status: 'completed',
-            outputFiles: [],
-            parity: 'fail',
-            issues: [{ severity: 'major', description: 'Divergence in task-002' }],
-          }),
-        );
 
         const result = await orchestrator.run();
 
@@ -3003,7 +2937,7 @@ describe('MigrationOrchestrator', () => {
         await checkpoint.load(config.projectName);
         const progress = new ProgressWriter(join(progressDir2, 'progress.md'));
         await progress.initialize(config);
-        const mockLauncher = new MockAgentLauncher(withParityPassSidecar(launcherFn));
+        const mockLauncher = new MockAgentLauncher(withParityPassOutput(launcherFn));
         const orchestrator = new MigrationOrchestrator(config, checkpoint, mockLauncher as any, progress, logger, join(tempDir, 'sub1'), 'test-run-id');
         await writeMigrationPlan(progressDir2);
         await orchestrator.run();
@@ -3025,7 +2959,7 @@ describe('MigrationOrchestrator', () => {
         await checkpoint.load(config.projectName);
         const progress = new ProgressWriter(join(progressDir3, 'progress.md'));
         await progress.initialize(config);
-        const mockLauncher = new MockAgentLauncher(withParityPassSidecar(launcherFn));
+        const mockLauncher = new MockAgentLauncher(withParityPassOutput(launcherFn));
         const orchestrator = new MigrationOrchestrator(config, checkpoint, mockLauncher as any, progress, logger, join(tempDir, 'sub2'), 'test-run-id');
         await writeMigrationPlan(progressDir3);
         await orchestrator.run();
@@ -3251,231 +3185,176 @@ describe('MigrationOrchestrator', () => {
     });
   });
 
-  // ─── Parity Sidecar Fail-Closed ────────────────────────────────────
+  // ─── Parity Result Fail-Closed ──────────────────────────────────────
 
-  describe('Parity sidecar fail-closed defaults', () => {
-    it('checkParityResult returns false when no sidecar file exists', async () => {
+  describe('Parity result fail-closed defaults', () => {
+    it('checkParityResult returns false when no result is stored', async () => {
       const launcherFn = createMockLauncher();
-      const { orchestrator, progressDir, logger } = await setupOrchestrator(tempDir, launcherFn);
-      // Ensure the results directory exists but no sidecar is written
-      await mkdir(join(progressDir, 'artifacts', 'results'), { recursive: true });
+      const { orchestrator, logger } = await setupOrchestrator(tempDir, launcherFn);
 
       const warnSpy = vi.spyOn(logger, 'warn');
-      const result = await (orchestrator as any).checkParityResult('task-001');
+      const result = (orchestrator as any).checkParityResult('task-001');
 
       expect(result).toBe(false);
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Parity sidecar missing for task-001'),
+        expect.stringContaining('Parity result missing for task-001'),
       );
     });
 
-    it('hasNonMinorParityIssues returns true when no sidecar file exists', async () => {
+    it('hasNonMinorParityIssues returns true when no result is stored', async () => {
       const launcherFn = createMockLauncher();
-      const { orchestrator, progressDir, logger } = await setupOrchestrator(tempDir, launcherFn);
-      await mkdir(join(progressDir, 'artifacts', 'results'), { recursive: true });
+      const { orchestrator, logger } = await setupOrchestrator(tempDir, launcherFn);
 
       const warnSpy = vi.spyOn(logger, 'warn');
-      const result = await (orchestrator as any).hasNonMinorParityIssues('task-001');
+      const result = (orchestrator as any).hasNonMinorParityIssues('task-001');
 
       expect(result).toBe(true);
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Parity sidecar missing for task-001'),
+        expect.stringContaining('Parity result missing for task-001'),
       );
     });
 
-    it('checkParityResult returns true when sidecar has parity pass', async () => {
+    it('checkParityResult returns true when parity is pass', async () => {
       const launcherFn = createMockLauncher();
-      const { orchestrator, progressDir } = await setupOrchestrator(tempDir, launcherFn);
-      await mkdir(join(progressDir, 'artifacts', 'results'), { recursive: true });
-      await writeFile(
-        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-        JSON.stringify({
-          taskId: 'task-001',
-          agent: 'parity-verifier',
-          status: 'completed',
-          outputFiles: [],
-          parity: 'pass',
-          issues: [],
-        }),
-      );
+      const { orchestrator } = await setupOrchestrator(tempDir, launcherFn);
+      (orchestrator as any)._parityResults.set('task-001', { parity: 'pass', issues: [] });
 
-      const result = await (orchestrator as any).checkParityResult('task-001');
+      const result = (orchestrator as any).checkParityResult('task-001');
       expect(result).toBe(true);
     });
 
-    it('hasNonMinorParityIssues returns false when sidecar has only minor issues', async () => {
+    it('hasNonMinorParityIssues returns false when only minor issues', async () => {
       const launcherFn = createMockLauncher();
-      const { orchestrator, progressDir } = await setupOrchestrator(tempDir, launcherFn);
-      await mkdir(join(progressDir, 'artifacts', 'results'), { recursive: true });
-      await writeFile(
-        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-        JSON.stringify({
-          taskId: 'task-001',
-          agent: 'parity-verifier',
-          status: 'completed',
-          outputFiles: [],
-          parity: 'partial',
-          issues: [{ severity: 'minor', description: 'style nit', sourceLocation: 'a.py:1', targetLocation: 'a.ts:1' }],
-        }),
-      );
+      const { orchestrator } = await setupOrchestrator(tempDir, launcherFn);
+      (orchestrator as any)._parityResults.set('task-001', {
+        parity: 'partial',
+        issues: [{ severity: 'minor', description: 'style nit', sourceLocation: 'a.py:1', targetLocation: 'a.ts:1' }],
+      });
 
-      const result = await (orchestrator as any).hasNonMinorParityIssues('task-001');
+      const result = (orchestrator as any).hasNonMinorParityIssues('task-001');
       expect(result).toBe(false);
     });
 
     it('checkParityResult returns false when parity is fail', async () => {
       const launcherFn = createMockLauncher();
-      const { orchestrator, progressDir } = await setupOrchestrator(tempDir, launcherFn);
-      await mkdir(join(progressDir, 'artifacts', 'results'), { recursive: true });
-      await writeFile(
-        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-        JSON.stringify({
-          taskId: 'task-001',
-          agent: 'parity-verifier',
-          status: 'completed',
-          outputFiles: [],
-          parity: 'fail',
-          issues: [{ severity: 'critical', description: 'missing function', sourceLocation: 'a.py:10', targetLocation: 'a.ts:10' }],
-        }),
-      );
+      const { orchestrator } = await setupOrchestrator(tempDir, launcherFn);
+      (orchestrator as any)._parityResults.set('task-001', {
+        parity: 'fail',
+        issues: [{ severity: 'critical', description: 'missing function', sourceLocation: 'a.py:10', targetLocation: 'a.ts:10' }],
+      });
 
-      const result = await (orchestrator as any).checkParityResult('task-001');
+      const result = (orchestrator as any).checkParityResult('task-001');
       expect(result).toBe(false);
     });
 
     it('checkParityResult returns true when parity is partial with all minor issues', async () => {
       const launcherFn = createMockLauncher();
-      const { orchestrator, progressDir } = await setupOrchestrator(tempDir, launcherFn);
-      await mkdir(join(progressDir, 'artifacts', 'results'), { recursive: true });
-      await writeFile(
-        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-        JSON.stringify({
-          taskId: 'task-001',
-          agent: 'parity-verifier',
-          status: 'completed',
-          outputFiles: [],
-          parity: 'partial',
-          issues: [
-            { severity: 'minor', description: 'style nit', sourceLocation: 'a.py:1', targetLocation: 'a.ts:1' },
-            { severity: 'minor', description: 'whitespace diff', sourceLocation: 'a.py:5', targetLocation: 'a.ts:5' },
-          ],
-        }),
-      );
+      const { orchestrator } = await setupOrchestrator(tempDir, launcherFn);
+      (orchestrator as any)._parityResults.set('task-001', {
+        parity: 'partial',
+        issues: [
+          { severity: 'minor', description: 'style nit', sourceLocation: 'a.py:1', targetLocation: 'a.ts:1' },
+          { severity: 'minor', description: 'whitespace diff', sourceLocation: 'a.py:5', targetLocation: 'a.ts:5' },
+        ],
+      });
 
-      const result = await (orchestrator as any).checkParityResult('task-001');
+      const result = (orchestrator as any).checkParityResult('task-001');
       expect(result).toBe(true);
     });
 
     it('checkParityResult returns false when parity is partial with a major issue', async () => {
       const launcherFn = createMockLauncher();
-      const { orchestrator, progressDir } = await setupOrchestrator(tempDir, launcherFn);
-      await mkdir(join(progressDir, 'artifacts', 'results'), { recursive: true });
-      await writeFile(
-        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-        JSON.stringify({
-          taskId: 'task-001',
-          agent: 'parity-verifier',
-          status: 'completed',
-          outputFiles: [],
-          parity: 'partial',
-          issues: [
-            { severity: 'minor', description: 'style nit', sourceLocation: 'a.py:1', targetLocation: 'a.ts:1' },
-            { severity: 'major', description: 'logic mismatch', sourceLocation: 'a.py:10', targetLocation: 'a.ts:10' },
-          ],
-        }),
-      );
+      const { orchestrator } = await setupOrchestrator(tempDir, launcherFn);
+      (orchestrator as any)._parityResults.set('task-001', {
+        parity: 'partial',
+        issues: [
+          { severity: 'minor', description: 'style nit', sourceLocation: 'a.py:1', targetLocation: 'a.ts:1' },
+          { severity: 'major', description: 'logic mismatch', sourceLocation: 'a.py:10', targetLocation: 'a.ts:10' },
+        ],
+      });
 
-      const result = await (orchestrator as any).checkParityResult('task-001');
+      const result = (orchestrator as any).checkParityResult('task-001');
       expect(result).toBe(false);
     });
 
-    it('hasNonMinorParityIssues returns true when sidecar has a critical issue', async () => {
+    it('hasNonMinorParityIssues returns true when a critical issue exists', async () => {
       const launcherFn = createMockLauncher();
-      const { orchestrator, progressDir } = await setupOrchestrator(tempDir, launcherFn);
-      await mkdir(join(progressDir, 'artifacts', 'results'), { recursive: true });
-      await writeFile(
-        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-        JSON.stringify({
-          taskId: 'task-001',
-          agent: 'parity-verifier',
-          status: 'completed',
-          outputFiles: [],
-          parity: 'fail',
-          issues: [
-            { severity: 'minor', description: 'style nit', sourceLocation: 'a.py:1', targetLocation: 'a.ts:1' },
-            { severity: 'critical', description: 'missing export', sourceLocation: 'a.py:20', targetLocation: 'a.ts:20' },
-          ],
-        }),
-      );
+      const { orchestrator } = await setupOrchestrator(tempDir, launcherFn);
+      (orchestrator as any)._parityResults.set('task-001', {
+        parity: 'fail',
+        issues: [
+          { severity: 'minor', description: 'style nit', sourceLocation: 'a.py:1', targetLocation: 'a.ts:1' },
+          { severity: 'critical', description: 'missing export', sourceLocation: 'a.py:20', targetLocation: 'a.ts:20' },
+        ],
+      });
 
-      const result = await (orchestrator as any).hasNonMinorParityIssues('task-001');
+      const result = (orchestrator as any).hasNonMinorParityIssues('task-001');
       expect(result).toBe(true);
     });
 
     it('hasNonMinorParityIssues returns false when issues array is empty', async () => {
       const launcherFn = createMockLauncher();
-      const { orchestrator, progressDir } = await setupOrchestrator(tempDir, launcherFn);
-      await mkdir(join(progressDir, 'artifacts', 'results'), { recursive: true });
-      await writeFile(
-        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-        JSON.stringify({
-          taskId: 'task-001',
-          agent: 'parity-verifier',
-          status: 'completed',
-          outputFiles: [],
-          parity: 'pass',
-          issues: [],
-        }),
-      );
+      const { orchestrator } = await setupOrchestrator(tempDir, launcherFn);
+      (orchestrator as any)._parityResults.set('task-001', { parity: 'pass', issues: [] });
 
-      const result = await (orchestrator as any).hasNonMinorParityIssues('task-001');
+      const result = (orchestrator as any).hasNonMinorParityIssues('task-001');
       expect(result).toBe(false);
     });
 
-    it('checkParityResult does not log warning when sidecar exists', async () => {
+    it('checkParityResult does not log warning when result is stored', async () => {
       const launcherFn = createMockLauncher();
-      const { orchestrator, progressDir, logger } = await setupOrchestrator(tempDir, launcherFn);
-      await mkdir(join(progressDir, 'artifacts', 'results'), { recursive: true });
-      await writeFile(
-        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-        JSON.stringify({
-          taskId: 'task-001',
-          agent: 'parity-verifier',
-          status: 'completed',
-          outputFiles: [],
-          parity: 'pass',
-          issues: [],
-        }),
-      );
+      const { orchestrator, logger } = await setupOrchestrator(tempDir, launcherFn);
+      (orchestrator as any)._parityResults.set('task-001', { parity: 'pass', issues: [] });
 
       const warnSpy = vi.spyOn(logger, 'warn');
-      await (orchestrator as any).checkParityResult('task-001');
+      (orchestrator as any).checkParityResult('task-001');
       expect(warnSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining('Parity sidecar missing'),
+        expect.stringContaining('Parity result missing'),
       );
     });
 
-    it('hasNonMinorParityIssues does not log warning when sidecar exists', async () => {
+    it('hasNonMinorParityIssues does not log warning when result is stored', async () => {
       const launcherFn = createMockLauncher();
-      const { orchestrator, progressDir, logger } = await setupOrchestrator(tempDir, launcherFn);
-      await mkdir(join(progressDir, 'artifacts', 'results'), { recursive: true });
-      await writeFile(
-        join(progressDir, 'artifacts', 'results', 'parity-verifier-task-001.result.json'),
-        JSON.stringify({
-          taskId: 'task-001',
-          agent: 'parity-verifier',
-          status: 'completed',
-          outputFiles: [],
-          parity: 'pass',
-          issues: [],
-        }),
-      );
+      const { orchestrator, logger } = await setupOrchestrator(tempDir, launcherFn);
+      (orchestrator as any)._parityResults.set('task-001', { parity: 'pass', issues: [] });
 
       const warnSpy = vi.spyOn(logger, 'warn');
-      await (orchestrator as any).hasNonMinorParityIssues('task-001');
+      (orchestrator as any).hasNonMinorParityIssues('task-001');
       expect(warnSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining('Parity sidecar missing'),
+        expect.stringContaining('Parity result missing'),
       );
+    });
+
+    it('storeParityResult populates map from structuredOutput', async () => {
+      const launcherFn = createMockLauncher();
+      const { orchestrator } = await setupOrchestrator(tempDir, launcherFn);
+      const agentResult: Partial<AgentResult> = {
+        outputParsed: true,
+        structuredOutput: {
+          agent: 'parity-verifier',
+          status: 'completed',
+          parity: 'partial',
+          issues: [{ severity: 'major', description: 'divergence' }],
+        },
+      };
+      (orchestrator as any).storeParityResult(agentResult, 'task-001');
+
+      const stored = (orchestrator as any)._parityResults.get('task-001');
+      expect(stored).toBeDefined();
+      expect(stored.parity).toBe('partial');
+      expect(stored.issues).toHaveLength(1);
+    });
+
+    it('storeParityResult ignores result when outputParsed is false', async () => {
+      const launcherFn = createMockLauncher();
+      const { orchestrator } = await setupOrchestrator(tempDir, launcherFn);
+      const agentResult: Partial<AgentResult> = {
+        outputParsed: false,
+        structuredOutput: undefined,
+      };
+      (orchestrator as any).storeParityResult(agentResult, 'task-001');
+
+      expect((orchestrator as any)._parityResults.has('task-001')).toBe(false);
     });
   });
 
@@ -3674,7 +3553,7 @@ describe('MigrationOrchestrator', () => {
       await checkpoint2.load(config2.projectName);
       const progress2 = new ProgressWriter(join(progressDir, 'progress.md'));
       await progress2.initialize(config2);
-      const mockLauncher2 = new MockAgentLauncher(withParityPassSidecar(createMockLauncher()));
+      const mockLauncher2 = new MockAgentLauncher(withParityPassOutput(createMockLauncher()));
       const orch2 = new MigrationOrchestrator(
         config2,
         checkpoint2,
@@ -3884,7 +3763,7 @@ describe('MigrationOrchestrator', () => {
       await checkpoint1.load(config.projectName);
       const progress1 = new ProgressWriter(join(progressDir, 'progress.md'));
       await progress1.initialize(config);
-      const orch1 = new MigrationOrchestrator(config, checkpoint1, new MockAgentLauncher(withParityPassSidecar(launcherFn)) as any, progress1, logger, tempDir, 'test-run-id');
+      const orch1 = new MigrationOrchestrator(config, checkpoint1, new MockAgentLauncher(withParityPassOutput(launcherFn)) as any, progress1, logger, tempDir, 'test-run-id');
       const result1 = await orch1.run();
 
       expect(result1.cumulativeDuration).toBe(result1.totalDuration);
@@ -3904,7 +3783,7 @@ describe('MigrationOrchestrator', () => {
 
       const progress2 = new ProgressWriter(join(progressDir, 'progress.md'));
       await progress2.initialize(config2);
-      const orch2 = new MigrationOrchestrator(config2, checkpoint2, new MockAgentLauncher(withParityPassSidecar(launcherFn)) as any, progress2, logger, tempDir, 'test-run-id');
+      const orch2 = new MigrationOrchestrator(config2, checkpoint2, new MockAgentLauncher(withParityPassOutput(launcherFn)) as any, progress2, logger, tempDir, 'test-run-id');
       const result2 = await orch2.run();
 
       expect(result2.cumulativeDuration).toBe(afterFirst + result2.totalDuration);

--- a/runtime/tests/result-parser.test.ts
+++ b/runtime/tests/result-parser.test.ts
@@ -434,7 +434,7 @@ Here are the tasks:
     });
 
     it('should validate ParityVerifierOutput', () => {
-      expect(() => ParityVerifierOutput.parse({ status: 'completed', agent: 'parity-verifier' })).not.toThrow();
+      expect(() => ParityVerifierOutput.parse({ status: 'completed', agent: 'parity-verifier', parity: 'pass' })).not.toThrow();
     });
 
     it('should validate TestWriterOutput', () => {


### PR DESCRIPTION
## Summary

Eliminates the parity-verifier sidecar `.result.json` file mechanism and replaces it with in-memory structured output parsing from the `aamf-json` block.

The parity-verifier agent was expected to write both a `.result.json` sidecar file **and** emit an `aamf-json` block—a duplicated requirement where the agent never actually wrote the sidecar file. This PR makes the `aamf-json` structured output the single source of truth.

## Changes

### Schema (`registry.ts`, `agent-output-schemas.ts`)
- Extended `ParityVerifierSchema` with required `parity` enum (`pass | partial | fail`) and `issues` array (severity, description, location)
- Deprecated `TaskResultSchema` JSDoc

### Orchestrator (`orchestrator.ts`)
- Added `ParityResultData` interface and `_parityResults` Map for in-memory storage
- Added `storeParityResult()` helper to extract parity data from `AgentResult.structuredOutput`
- Rewrote `checkParityResult()`, `hasNonMinorParityIssues()`, `getParityIssueSummary()` as **synchronous** map lookups (previously async disk reads)
- Updated all parity-verifier launch call sites to store results after each launch

### Agent prompt (`parity-verifier.md`)
- Removed sidecar JSON file writing instructions from the agent prompt

### Result parser (`result-parser.ts`)
- Deprecated `readTaskResultJson` (body retained for backward compatibility)

### Tests
- Renamed `withParityPassSidecar` → `withParityPassOutput` (sets `structuredOutput` instead of writing files)
- Added `withParityOutput` helper for custom per-task parity data
- Rewrote "Parity sidecar fail-closed defaults" test block to use `_parityResults` map
- Updated 13+ integration tests to return parity data via launcher callbacks
- Fixed `mockResolvedValue` → `mockReturnValue` for now-synchronous methods

## Validation

Full test suite: **1137 passed**, 185 skipped, 0 failed.

**8 files changed, 372 insertions, 490 deletions** — net reduction of ~120 lines.