### PR TITLE
fix(runtime): replace require('node:fs') with static import in ESM module

### DIFF
--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -1,5 +1,6 @@
 import { join, resolve } from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
+import { readdirSync, readFileSync } from 'node:fs';
 import { readdir, readFile, unlink } from 'node:fs/promises';
 import pLimit from 'p-limit';
 import { PHASES, PhaseDefinition } from './phase-registry.js';
@@ -3487,7 +3488,6 @@ export class MigrationOrchestrator {
       const taskLogDir = join(this.paths.logsAgentsDir, 'parity-verifier', taskId);
       // Synchronous check: readdirSync is acceptable here because this is
       // a cold-path fallback that only fires once per task on resume.
-      const { readdirSync, readFileSync } = require('node:fs') as typeof import('node:fs');
       let entries: string[];
       try {
         entries = readdirSync(taskLogDir);


### PR DESCRIPTION
`rehydrateParityFromLog` used `require('node:fs')` to get `readdirSync` and `readFileSync`, but the runtime is an ESM package (`"type": "module"` in package.json). `require()` throws `ReferenceError` in ESM, so parity rehydration **always failed** on resume with `"require is not defined"`.

This caused the fail-closed path to treat every task's parity result as missing, unnecessarily restarting the full recovery loop (failure-adjudicator → code-migrator → parity-verifier × 3 retries) on every `--resume` — even for tasks that had already passed parity in a prior run.

**Fix:** Replace the dynamic `require('node:fs')` with a static `import { readdirSync, readFileSync } from 'node:fs'` at the top of the file, alongside the existing `node:fs/promises` import.

**Impact:** On the zstd-to-rust migration, this was causing task-15, task-20, and task-26 to burn ~10 min + 3 agent calls of wasted retry each resume.