### PR TITLE
chore(deps): upgrade @aamf/lore to 0.2.4, enable debug logging

### DIFF
--- a/runtime/package-lock.json
+++ b/runtime/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aamf-runtime",
       "version": "0.1.0",
       "dependencies": {
-        "@aamf/lore": "npm:@jafreck/lore@^0.2.1",
+        "@aamf/lore": "npm:@jafreck/lore@^0.2.4",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@types/better-sqlite3": "^7.6.13",
         "better-sqlite3": "^12.6.2",
@@ -46,9 +46,9 @@
     },
     "node_modules/@aamf/lore": {
       "name": "@jafreck/lore",
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@jafreck/lore/-/lore-0.2.1.tgz",
-      "integrity": "sha512-YyoOAu7i6BGb+TqfBFqJX7rhLuv/ua8iRp2nuxNgrBBTmyoZrtdhF+Xn6b9x/cY0Bs7dezrB0H7JsycDRL4Gxg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@jafreck/lore/-/lore-0.2.4.tgz",
+      "integrity": "sha512-SIa0NVF5fQMF5sNtxHPnMa9BzyhyNPvvFXTZGMiDgi8QJ3VrXIv1DBpcFvwKU/xCFrZzVzMgZsXuk8WDZ5q5CA==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -15,7 +15,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@aamf/lore": "npm:@jafreck/lore@^0.2.1",
+    "@aamf/lore": "npm:@jafreck/lore@^0.2.4",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@types/better-sqlite3": "^7.6.13",
     "better-sqlite3": "^12.6.2",

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -111,6 +111,13 @@ export const MigrationConfigSchema = z.object({
      */
     kbIndex: z.object({
       enabled: z.boolean().default(false),
+      /**
+       * Log level for the Lore KB server's internal structured logger.
+       * Lore writes NDJSON entries to `logs/runtime/lore.log`.
+       * Set to `'debug'` to monitor every tool call, search, and timing.
+       * Default: `'debug'`.
+       */
+      logLevel: z.enum(['debug', 'info', 'warn', 'error', 'silent']).default('debug'),
       /** Embedding configuration for semantic search in the KB. */
       embeddings: z.object({
         /** Enable vector embeddings during indexing (requires Python + sentence-transformers). */

--- a/runtime/src/core/kb-server-process.ts
+++ b/runtime/src/core/kb-server-process.ts
@@ -11,7 +11,7 @@
 import http from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { createKbMcpServer, openReadOnly, type EmbeddingProvider, type KbServerOptions, type SearchObserver } from '@aamf/lore';
+import { createLoreMcpServer, openReadOnly, type EmbeddingProvider, type LoreServerOptions, type SearchObserver, LoreLogger, type LoreLoggerOptions } from '@aamf/lore';
 import type { McpServerConfig } from '../agents/types.js';
 
 
@@ -35,17 +35,20 @@ export class KbServerProcess {
   private db: import('better-sqlite3').Database | null = null;
   private readonly embedder: EmbeddingProvider | undefined;
   private readonly searchObserver: SearchObserver | undefined;
+  private readonly loreLoggerOpts: LoreLoggerOptions | undefined;
 
   /**
    * @param dbPath          Path to the KB SQLite database.
    * @param embedder        Optional pre-initialised embedding provider for semantic search.
    *                        The caller owns the lifecycle — `stop()` will NOT dispose it.
    * @param searchObserver  Optional callback invoked after every lore_search call.
+   * @param loreLoggerOpts  Optional Lore-internal logger configuration.
    */
-  constructor(dbPath: string, embedder?: EmbeddingProvider, searchObserver?: SearchObserver) {
+  constructor(dbPath: string, embedder?: EmbeddingProvider, searchObserver?: SearchObserver, loreLoggerOpts?: LoreLoggerOptions) {
     this.dbPath = dbPath;
     this.embedder = embedder;
     this.searchObserver = searchObserver;
+    this.loreLoggerOpts = loreLoggerOpts;
   }
 
   /**
@@ -68,10 +71,12 @@ export class KbServerProcess {
 
     this.db = openReadOnly(this.dbPath);
 
-    const serverOptions: KbServerOptions | undefined = this.searchObserver
-      ? { searchObserver: this.searchObserver }
-      : undefined;
-    const mcpServer = createKbMcpServer(this.db, this.dbPath, this.embedder, serverOptions);
+    const loreLogger = this.loreLoggerOpts ? new LoreLogger(this.loreLoggerOpts) : undefined;
+    const serverOptions: LoreServerOptions = {
+      ...(this.searchObserver ? { searchObserver: this.searchObserver } : {}),
+      ...(loreLogger ? { logger: loreLogger } : {}),
+    };
+    const mcpServer = createLoreMcpServer(this.db, this.dbPath, this.embedder, serverOptions);
 
     // Stateless transport: each POST request gets its own temporary session.
     const transport = new StreamableHTTPServerTransport({

--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -74,6 +74,11 @@ function computeSourceFingerprintCompat(
 }
 
 function getKbFingerprintCompat(lore: LoreModule, db: unknown): string | undefined {
+  // Prefer getLoreMeta (>=0.2.4), fall back to getKbFingerprint / getKbMeta.
+  const getLoreMeta = (lore as { getLoreMeta?: (db: unknown, key: string) => string | undefined }).getLoreMeta;
+  if (typeof getLoreMeta === 'function') {
+    return getLoreMeta(db, 'source_fingerprint');
+  }
   const getKbFingerprint = (lore as { getKbFingerprint?: (...args: any[]) => string | undefined }).getKbFingerprint;
   if (typeof getKbFingerprint === 'function') {
     return getKbFingerprint(db);
@@ -747,14 +752,23 @@ export class MigrationOrchestrator {
   /** Start the KB MCP server (HTTP transport). */
   private async startKbServer(): Promise<void> {
     const { KbServerProcess } = await loadKbServerProcess();
+    const lore = await loadLore();
+
+    // Build Lore-internal logger options from config (defaults to debug).
+    const loreLogLevel = this.config.options.kbIndex?.logLevel ?? 'debug';
+    const loreLoggerOpts: import('@aamf/lore').LoreLoggerOptions = {
+      level: lore.LOG_LEVEL_NAMES[loreLogLevel] ?? lore.LogLevel.DEBUG,
+      logFile: this.paths.loreLogFile,
+    };
+
     this.kbServer = new KbServerProcess(this.kbDbPath, this.embedder, (obs) => {
       this.logger.debug(
         `lore_search: query=${JSON.stringify(obs.query)} mode=${obs.requestedMode}→${obs.modeUsed} results=${obs.resultCount} topScore=${obs.topScore} latency=${obs.latencyMs}ms`,
       );
-    });
+    }, loreLoggerOpts);
     try {
       await this.kbServer.start();
-      this.logger.info('KB server started and ready');
+      this.logger.info(`KB server started and ready (lore log: ${this.paths.loreLogFile}, level: ${loreLogLevel})`);
     } catch (err) {
       this.logger.warn(
         `KB server failed to start — agents will run without KB access: ${err instanceof Error ? err.message : String(err)}`,

--- a/runtime/src/core/runtime-paths.ts
+++ b/runtime/src/core/runtime-paths.ts
@@ -33,6 +33,7 @@ export interface RuntimePaths {
   competingStrategiesFile: string;
   finalParityReportFile: string;
   idiomaticReviewReportFile: string;
+  loreLogFile: string;
 }
 
 export function buildRuntimePaths(projectRoot: string, projectName: string): RuntimePaths {
@@ -80,5 +81,6 @@ export function buildRuntimePaths(projectRoot: string, projectName: string): Run
     competingStrategiesFile: join(artifactsPlanningDir, 'competing-strategies.md'),
     finalParityReportFile: join(artifactsParityDir, 'final-parity-report.md'),
     idiomaticReviewReportFile: join(artifactsParityDir, 'idiomatic-review-report.md'),
+    loreLogFile: join(logsRuntimeDir, 'lore.log'),
   };
 }

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import { MigrationRuntime } from './core/runtime.js';
-import { IndexBuilder } from '@aamf/lore';
+import { IndexBuilder, LogLevel, LOG_LEVEL_NAMES } from '@aamf/lore';
 import { KbServerProcess } from './core/kb-server-process.js';
 
 const program = new Command()
@@ -114,8 +114,14 @@ program
   .command('kb-server')
   .description('Start the knowledge-base MCP server')
   .requiredOption('--db <path>', 'Path to the SQLite knowledge-base file')
+  .option('--log-level <level>', 'Lore log level (debug|info|warn|error|silent)', 'debug')
+  .option('--log-file <path>', 'Path to the Lore log file')
   .action(async (opts) => {
-    const srv = new KbServerProcess(opts.db);
+    const loreLoggerOpts = {
+      level: LOG_LEVEL_NAMES[opts.logLevel] ?? LogLevel.DEBUG,
+      ...(opts.logFile ? { logFile: opts.logFile } : {}),
+    };
+    const srv = new KbServerProcess(opts.db, undefined, undefined, loreLoggerOpts);
     try {
       await srv.start();
     } catch (err) {

--- a/runtime/tests/kb-search-handler.test.ts
+++ b/runtime/tests/kb-search-handler.test.ts
@@ -7,7 +7,7 @@ import { join } from 'node:path';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import Database from 'better-sqlite3';
-import { handler, type SearchArgs, type SearchResult } from '@aamf/lore/kb-server/tools/search';
+import { handler, type SearchArgs, type SearchResult } from '@aamf/lore/lore-server/tools/search';
 import type { EmbeddingProvider } from '@aamf/lore';
 
 /**

--- a/runtime/tests/kb-search-tool.test.ts
+++ b/runtime/tests/kb-search-tool.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { handler, type SearchObservation, type SearchObserver } from '@aamf/lore/kb-server/tools/search';
+import { handler, type SearchObservation, type SearchObserver } from '@aamf/lore/lore-server/tools/search';
 
 type Row = {
   symbol_id: number;

--- a/runtime/tests/kb-server.test.ts
+++ b/runtime/tests/kb-server.test.ts
@@ -14,12 +14,12 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { IndexBuilder, openReadOnly } from '@aamf/lore';
 import type { Database } from '@aamf/lore';
-import { handler as lookupHandler } from '@aamf/lore/kb-server/tools/lookup';
-import { handler as graphHandler } from '@aamf/lore/kb-server/tools/graph';
-import { handler as searchHandler } from '@aamf/lore/kb-server/tools/search';
-import { handler as snippetHandler } from '@aamf/lore/kb-server/tools/snippet';
-import { handler as metricsHandler } from '@aamf/lore/kb-server/tools/metrics';
-import { handler as writebackHandler } from '@aamf/lore/kb-server/tools/writeback';
+import { handler as lookupHandler } from '@aamf/lore/lore-server/tools/lookup';
+import { handler as graphHandler } from '@aamf/lore/lore-server/tools/graph';
+import { handler as searchHandler } from '@aamf/lore/lore-server/tools/search';
+import { handler as snippetHandler } from '@aamf/lore/lore-server/tools/snippet';
+import { handler as metricsHandler } from '@aamf/lore/lore-server/tools/metrics';
+import { handler as writebackHandler } from '@aamf/lore/lore-server/tools/writeback';
 
 // ─── Fixture setup ────────────────────────────────────────────────────────────
 
@@ -55,20 +55,20 @@ afterAll(async () => {
 // ─── lore_lookup ────────────────────────────────────────────────────────────────
 
 describe('lookup handler', () => {
-  it('returns an array result for kind="symbol" with a known name', () => {
-    const result = lookupHandler(db, { kind: 'symbol', query: 'Calculator' });
+  it('returns an array result for kind="symbol" with a known name', async () => {
+    const result = await lookupHandler(db, { kind: 'symbol', query: 'Calculator' });
     expect(result).toHaveProperty('results');
     expect(Array.isArray(result.results)).toBe(true);
     expect(result.results.length).toBeGreaterThan(0);
   });
 
-  it('returns an empty array for an unknown symbol', () => {
-    const result = lookupHandler(db, { kind: 'symbol', query: '__nonexistent_xyz__' });
+  it('returns an empty array for an unknown symbol', async () => {
+    const result = await lookupHandler(db, { kind: 'symbol', query: '__nonexistent_xyz__' });
     expect(result.results).toHaveLength(0);
   });
 
-  it('returns file rows for kind="file" with an empty query', () => {
-    const result = lookupHandler(db, { kind: 'file', query: '' });
+  it('returns file rows for kind="file" with an empty query', async () => {
+    const result = await lookupHandler(db, { kind: 'file', query: '' });
     expect(Array.isArray(result.results)).toBe(true);
     // Should have at least one file (the fixture has 5 .py files).
     expect(result.results.length).toBeGreaterThan(0);

--- a/runtime/tests/orchestrator.test.ts
+++ b/runtime/tests/orchestrator.test.ts
@@ -618,7 +618,7 @@ describe('MigrationOrchestrator', () => {
         const dbPath = join(tempDir, '.aamf', 'migration', 'test-project', 'kb.db');
         await mkdir(join(tempDir, '.aamf', 'migration', 'test-project'), { recursive: true });
         const db = dbMod.openDb(dbPath);
-        dbMod.setKbMeta(db, 'source_fingerprint', currentFingerprint);
+        dbMod.setLoreMeta(db, 'source_fingerprint', currentFingerprint);
         db.close();
 
         buildSpy.mockClear();
@@ -658,7 +658,7 @@ describe('MigrationOrchestrator', () => {
         const dbPath = join(tempDir, '.aamf', 'migration', 'test-project', 'kb.db');
         await mkdir(join(tempDir, '.aamf', 'migration', 'test-project'), { recursive: true });
         const db = dbMod.openDb(dbPath);
-        dbMod.setKbMeta(db, 'source_fingerprint', 'old-fp');
+        dbMod.setLoreMeta(db, 'source_fingerprint', 'old-fp');
         db.close();
 
         const { orchestrator, checkpoint } = await setupOrchestrator(tempDir, launcherFn);
@@ -755,7 +755,7 @@ describe('MigrationOrchestrator', () => {
         const dbPath = join(tempDir, '.aamf', 'migration', 'test-project', 'kb.db');
         await mkdir(join(tempDir, '.aamf', 'migration', 'test-project'), { recursive: true });
         const db = dbMod.openDb(dbPath);
-        dbMod.setKbMeta(db, 'source_fingerprint', currentFingerprint);
+        dbMod.setLoreMeta(db, 'source_fingerprint', currentFingerprint);
         db.close();
 
         buildSpy.mockClear();


### PR DESCRIPTION
## Summary

Upgrade `@jafreck/lore` from `^0.2.1` to `^0.2.4` and wire up the new `LoreLogger` so Lore's internal tool calls, searches, and timing metrics are written to `logs/runtime/lore.log` as structured NDJSON for monitoring.

## Changes

### Dependency update
- `@aamf/lore` → `npm:@jafreck/lore@^0.2.4`

### API migration (lore 0.2.4 renames)
- `createKbMcpServer` → `createLoreMcpServer`
- `KbServerOptions` → `LoreServerOptions` (adds `logger` field)
- Import paths: `@aamf/lore/kb-server/tools/*` → `@aamf/lore/lore-server/tools/*`
- `setKbMeta` / `getKbMeta` → `setLoreMeta` / `getLoreMeta`
- `lookupHandler` now returns `Promise<LookupResult>` (tests updated to `await`)

### Debug logging
- Add `options.kbIndex.logLevel` config field (default: `"debug"`)
- Add `loreLogFile` to `RuntimePaths` → `logs/runtime/lore.log`
- Pass `LoreLoggerOptions` through `KbServerProcess` → `LoreServerOptions.logger`
- Add `--log-level` / `--log-file` flags to the `kb-server` CLI subcommand
- Orchestrator logs the lore log path and level at startup

### Test updates
- Fix import paths in `kb-search-handler.test.ts`, `kb-search-tool.test.ts`, `kb-server.test.ts`
- Fix `setKbMeta` → `setLoreMeta` in `orchestrator.test.ts`
- Add `await` to `lookupHandler` calls in `kb-server.test.ts`

## Test results
All 1412 tests pass, 0 failures.