### PR TITLE
refactor(agents): rename failure-adjudicator to parity-failure-resolver and simplify parity loop

### DIFF
--- a/runtime/agents/templates/code-migrator.md
+++ b/runtime/agents/templates/code-migrator.md
@@ -82,7 +82,7 @@ If you encounter something you cannot migrate correctly:
    - Why it's difficult to migrate
    - Your best-effort attempt
    - What needs human review or a different approach
-4. The orchestrator will route this to `failure-adjudicator` if needed
+4. The orchestrator will route this to `parity-failure-resolver` if needed
 
 ## Sub-Agents (launched via CLI)
 
@@ -90,12 +90,12 @@ If you encounter something you cannot migrate correctly:
 |-------|---------|
 | `parity-verifier` | Verify behavioral parity after writing code |
 | `test-writer` | Write tests for the migrated code |
-| `failure-adjudicator` | Handle migration difficulties or failures |
+| `parity-failure-resolver` | Handle migration difficulties or failures |
 
 After writing migrated code:
 1. Launch `parity-verifier` to verify behavioral equivalence
 2. If parity passes, launch `test-writer` to create tests
-3. If parity fails, launch `failure-adjudicator` to diagnose and fix
+3. If parity fails, launch `parity-failure-resolver` to diagnose and fix
 
 ## Output
 

--- a/runtime/agents/templates/e2e-test-crafter.md
+++ b/runtime/agents/templates/e2e-test-crafter.md
@@ -45,7 +45,7 @@ Use KB markdown for synthesized architecture, risk, and migration context — no
 ### 4. Aggregate Results
 - After all `test-writer` invocations complete, collect their results
 - Run the full E2E test suite to verify tests work together (no conflicts, shared state issues)
-- Report any application-level failures as migration issues for `failure-adjudicator`
+- Report any application-level failures as migration issues for `parity-failure-resolver`
 
 ## Test Scenario Categories
 
@@ -138,7 +138,7 @@ copilot --agent test-writer \
 ## Constraints
 
 - Tests must be runnable against the migrated codebase — no tests against the source.
-- Do not fix application bugs found during E2E testing — report them for `failure-adjudicator`.
+- Do not fix application bugs found during E2E testing — report them for `parity-failure-resolver`.
 - Write practical, maintainable test plans — not exhaustive coverage of every possible input combination.
 - Each suite should be scoped so a single `test-writer` can handle it without context saturation (aim for <10 scenarios per suite).
 - The full E2E suite should run in a reasonable time (<5 minutes if possible).

--- a/runtime/agents/templates/final-parity-checker.md
+++ b/runtime/agents/templates/final-parity-checker.md
@@ -81,7 +81,7 @@ This agent inevitably needs to scan a large codebase. Manage context aggressivel
 
 - This is a **read-only** agent. Do not fix any issues — only report them.
 - Be thorough but systematic — use automated scanning (grep, find, compiler) before manual inspection.
-- The orchestrator will route any failures back through `code-migrator` + `failure-adjudicator` for fixes.
+- The orchestrator will route any failures back through `code-migrator` + `parity-failure-resolver` for fixes.
 - Prioritize issues by severity: missing functionality > stubs > pattern inconsistency.
 
 ## Output Format

--- a/runtime/agents/templates/migration-orchestrator.md
+++ b/runtime/agents/templates/migration-orchestrator.md
@@ -37,7 +37,7 @@ For each task in the migration plan:
 1. Launch: `code-migrator` — writes migrated code for the task
 2. Launch: `parity-verifier` — verifies behavioral parity with original
 3. Launch: `test-writer` — writes/updates tests for migrated code
-4. If parity verification fails → Launch: `failure-adjudicator`
+4. If parity verification fails → Launch: `parity-failure-resolver`
 5. Checkpoint after each successfully migrated task.
 
 Serial execution required for code-writing. Parity verification is read-only and can overlap with test writing.
@@ -72,7 +72,7 @@ Serial execution required for code-writing. Parity verification is read-only and
 | `final-parity-checker` | Post-migration completeness audit | Yes |
 | `e2e-test-crafter` | Create end-to-end test suites | No |
 | `documentation-writer` | Document the migrated codebase | No |
-| `failure-adjudicator` | Handle failures, plan fixes, reduce scope | No |
+| `parity-failure-resolver` | Handle failures, plan fixes, reduce scope | No |
 
 ## CLI Invocation Pattern
 
@@ -118,8 +118,8 @@ Update `.aamf/migration/{projectName}/reports/progress.md` after every phase tra
 When any agent invocation fails:
 1. Record the failure in `reports/progress.md` with full context.
 2. Add the failed task to `failedTasks` in `state/checkpoint.json`.
-3. Launch `failure-adjudicator` agent with the failure context.
-4. `failure-adjudicator` will produce a fix plan (potentially with reduced scope).
+3. Launch `parity-failure-resolver` agent with the failure context.
+4. `parity-failure-resolver` will produce a fix plan (potentially with reduced scope).
 5. Re-attempt the failed task with the fix plan.
 6. After 3 failed attempts on the same task, mark it as blocked and continue with remaining tasks.
 

--- a/runtime/agents/templates/parity-failure-resolver.md
+++ b/runtime/agents/templates/parity-failure-resolver.md
@@ -1,6 +1,6 @@
-# Failure Adjudicator
+# Parity Failure Resolver
 
-You are the **Failure Adjudicator** agent, invoked when a migration task cannot proceed cleanly (parity failure, build/test breakage, or blocked migration).
+You are the **Parity Failure Resolver** agent, invoked when a migration task cannot proceed cleanly (parity failure, build/test breakage, or blocked migration).
 
 ## Task Scope Awareness
 
@@ -51,7 +51,7 @@ Resolve the failing task quickly and safely by:
 
 ```aamf-json
 {
-  "agent": "failure-adjudicator",
+  "agent": "parity-failure-resolver",
   "status": "completed",
   "outputFiles": [],
   "taskId": "task-000",
@@ -65,7 +65,7 @@ Resolve the failing task quickly and safely by:
 
 ### Field constraints
 
-- `agent` must be exactly `"failure-adjudicator"`.
+- `agent` must be exactly `"parity-failure-resolver"`.
 - `status` must be one of: `"completed"`, `"failed"`, `"needs-review"`.
 - `taskId` must match the provided task.
 - `failureType` should be one of: `"parity"`, `"build"`, `"test"`, `"blocked"`.

--- a/runtime/agents/templates/task-decomposer.md
+++ b/runtime/agents/templates/task-decomposer.md
@@ -45,6 +45,7 @@ The same schema path is also provided in `inputFiles` so it is available even wh
 - Every task object must include `lineRange`.
 - If a source file exceeds `maxLinesPerTask`, split it into multiple tasks with non-overlapping `lineRange` values so each task scope is at or below `maxLinesPerTask` lines.
 - Do not emit any task whose scoped source slice (its `lineRange`) exceeds `maxLinesPerTask`.
+- **Scope consistency**: the `description`, `acceptanceCriteria`, and `parityChecks` for a task must only reference symbols, functions, and APIs whose **definitions** fall within that task's `lineRange`. Do not mention functions or APIs in the description if their implementation lives in a different line range assigned to a different task — this causes the parity-verifier to flag out-of-scope stubs as failures. If a task needs to reference APIs defined elsewhere, phrase it as "provide scaffolding/stubs for X (full implementation in task-YY)" and set acceptance criteria accordingly.
 
 ## Output Format
 

--- a/runtime/src/agents/context-builder.ts
+++ b/runtime/src/agents/context-builder.ts
@@ -260,7 +260,7 @@ export class ContextBuilder {
         };
       }
 
-      case 'failure-adjudicator':
+      case 'parity-failure-resolver':
         {
         return {
           inputFiles: [

--- a/runtime/src/agents/registry.ts
+++ b/runtime/src/agents/registry.ts
@@ -120,9 +120,9 @@ export const ParityVerifierSchema = AamfOutputBase.extend({
   })).default([]),
 });
 export const TestWriterSchema = AamfOutputBase.extend({ agent: z.literal('test-writer') });
-export const FailureAdjudicatorSchema = AamfOutputBase.extend({
-  agent: z.enum(['failure-adjudicator', 'failure-recovery']),
-}).transform((data) => ({ ...data, agent: 'failure-adjudicator' as const }));
+export const ParityFailureResolverSchema = AamfOutputBase.extend({
+  agent: z.enum(['parity-failure-resolver', 'failure-recovery']),
+}).transform((data) => ({ ...data, agent: 'parity-failure-resolver' as const }));
 export const FinalParityCheckerSchema = AamfOutputBase.extend({
   agent: z.literal('final-parity-checker'),
   fixes: z.array(z.object({
@@ -358,11 +358,11 @@ export const AGENT_REGISTRY: Record<AgentName, AgentRegistryEntry> = {
     copilotTools: ['read', 'edit', 'search', 'execute'],
     claudeTools: CLAUDE_TOOLS,
   },
-  'failure-adjudicator': {
-    name: 'failure-adjudicator',
-    displayName: 'Failure Adjudicator',
+  'parity-failure-resolver': {
+    name: 'parity-failure-resolver',
+    displayName: 'Parity Failure Resolver',
     description: 'Diagnoses migration failures, evaluates competing fix strategies, and selects/executes the best recovery path.',
-    outputSchema: FailureAdjudicatorSchema,
+    outputSchema: ParityFailureResolverSchema,
     inputJsonSchema: inputSchema({
       extraRequired: ['taskId', 'failureType'],
       extraProperties: {

--- a/runtime/src/agents/types.ts
+++ b/runtime/src/agents/types.ts
@@ -22,7 +22,7 @@ export type AgentName =
   | 'code-migrator'
   | 'parity-verifier'
   | 'test-writer'
-  | 'failure-adjudicator'
+  | 'parity-failure-resolver'
   | 'final-parity-checker'
   | 'e2e-test-crafter'
   | 'documentation-writer'
@@ -275,7 +275,7 @@ export interface AgentRemediationContext {
   artifactPaths: string[];
   /** Condition that determines whether remediation was successful. */
   expectedSuccessCondition: string;
-  /** Path to the failure-adjudicator's analysis output, if available. */
+  /** Path to the parity-failure-resolver's analysis output, if available. */
   adjudicationReportPath?: string;
   /** Structured parity issues from the parity-verifier, if the failure is parity-related. */
   parityIssues?: Array<{
@@ -511,7 +511,7 @@ export interface PhaseResult {
  * Tracks a task that has failed during migration.
  *
  * Used by the orchestrator to decide whether to retry, escalate to
- * failure-adjudicator, or mark the task as terminal.
+ * parity-failure-resolver, or mark the task as terminal.
  */
 export interface FailedTask {
   /** The task that failed. */
@@ -523,7 +523,7 @@ export interface FailedTask {
   /** Error message from the most recent attempt. */
   lastError: string;
 
-  /** Whether the failure-adjudicator agent has already been invoked. */
+  /** Whether the parity-failure-resolver agent has already been invoked. */
   recoveryAttempted: boolean;
 }
 

--- a/runtime/src/config/schema.ts
+++ b/runtime/src/config/schema.ts
@@ -87,10 +87,10 @@ export const MigrationConfigSchema = z.object({
     maxBlockedTasks: z.number().int().min(0).default(1),
     qualityPolicy: z.enum(['strict', 'balanced', 'deferred-strict']).default('strict'),
     /**
-     * Maximum infrastructure-error retries before invoking failure-adjudicator.
+     * Maximum infrastructure-error retries before invoking parity-failure-resolver.
      * Infrastructure errors (file locks, timeouts, disk-full, OOM) are
      * retried with simple backoff — they don't consume `maxRetriesPerTask`
-     * budget and don't invoke the failure-adjudicator agent.
+     * budget and don't invoke the parity-failure-resolver agent.
      * Default: 3.
      */
     maxInfraRetries: z.number().int().min(0).max(10).default(3),

--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -97,7 +97,7 @@ function getKbFingerprintCompat(lore: LoreModule, db: unknown): string | undefin
  * infrastructure failure rather than a code-quality problem.
  *
  * These errors should be retried with simple backoff — they don't benefit
- * from the expensive failure-adjudicator agent pipeline.
+ * from the expensive parity-failure-resolver agent pipeline.
  */
 const INFRASTRUCTURE_ERROR_PATTERNS: ReadonlyArray<{ pattern: RegExp; label: string }> = [
   // File lock contention (Cargo, NuGet, Gradle, pip, npm, generic)
@@ -1474,7 +1474,7 @@ export class MigrationOrchestrator {
   /**
    * Extract the task-scope fields (description, acceptanceCriteria, parityChecks)
    * from a {@link MigrationTask} as a payload fragment.  Every task-scoped agent
-   * (code-migrator, parity-verifier, test-writer, failure-adjudicator) receives
+   * (code-migrator, parity-verifier, test-writer, parity-failure-resolver) receives
    * this so it can calibrate its work to the task's intended scope rather than
    * assuming full source↔target equivalence.
    */
@@ -1959,9 +1959,9 @@ export class MigrationOrchestrator {
           );
           migratorInv.contextFile = retryContext;
 
-          // Escalate to failure-adjudicator agent
+          // Escalate to parity-failure-resolver agent
           const recoveryCtx = await this.contextBuilder.buildContext(
-            'failure-adjudicator',
+            'parity-failure-resolver',
             4,
             taskId,
             {
@@ -1974,7 +1974,7 @@ export class MigrationOrchestrator {
               remediationContext: toAgentRemediationContext(retryExhaustionRemediation),
             },
           );
-          return this.buildInvocation('failure-adjudicator', recoveryCtx, 4, taskId);
+          return this.buildInvocation('parity-failure-resolver', recoveryCtx, 4, taskId);
         },
       });
 
@@ -2090,7 +2090,7 @@ export class MigrationOrchestrator {
           });
 
           const recoveryCtx = await this.contextBuilder.buildContext(
-            'failure-adjudicator',
+            'parity-failure-resolver',
             4,
             task.id,
             {
@@ -2103,39 +2103,27 @@ export class MigrationOrchestrator {
               remediationContext: toAgentRemediationContext(parityRemediation),
             },
           );
-          const recoveryInv = this.buildInvocation('failure-adjudicator', recoveryCtx, 4, task.id);
+          const recoveryInv = this.buildInvocation('parity-failure-resolver', recoveryCtx, 4, task.id);
           const recoveryResult = await this.launchAgentWithEvents(recoveryInv);
           this.recordTokens(recoveryResult, 4);
 
           if (!recoveryResult.success) {
-            this.logger.warn(`Failure-adjudicator failed for ${task.id} on attempt ${attempt}`);
+            this.logger.warn(`Parity-failure-resolver failed for ${task.id} on attempt ${attempt}`);
             continue;
           }
 
-          // Re-run code-migrator with enriched recovery context —
-          // parity report + adjudication analysis are wired as inputFiles
-          const reMigrateCtx = await this.contextBuilder.buildContext(
-            'code-migrator',
-            4,
-            task.id,
-            {
-              sourceFiles: task.sourceFiles,
-              targetFiles: task.targetFiles,
-              kbEntry: task.knowledgeBaseRef,
-              ...this.taskScopePayload(task),
-              remediationContext: toAgentRemediationContext(parityRemediation),
-            },
-          );
-          const reMigrateInv = this.buildInvocation('code-migrator', reMigrateCtx, 4, task.id);
-          const reMigrateResult = await this.launchAgentWithEvents(reMigrateInv);
-          this.recordTokens(reMigrateResult, 4);
-
-          if (!reMigrateResult.success) {
-            this.logger.warn(`Re-migration failed for ${task.id} on attempt ${attempt}`);
-            continue;
+          // If the resolver determined all remaining issues are outside the
+          // task's declared scope, accept the verdict and stop the retry loop.
+          if (this.resolverReducedScope(recoveryResult)) {
+            this.logger.info(
+              `Parity-failure-resolver adjudicated remaining issues as out-of-scope for ${task.id} — accepting verdict`,
+            );
+            parityPassed = true;
+            break;
           }
 
-          await this.commitForAgent('code-migrator', 4, task.id, task.name);
+          // Commit any fixes the resolver applied, then re-verify parity
+          await this.commitForAgent('parity-failure-resolver', 4, task.id, task.name);
 
           // Re-run parity-verifier
           const reParityCtx = await this.contextBuilder.buildContext(
@@ -3179,10 +3167,10 @@ export class MigrationOrchestrator {
    *
    * Infrastructure errors (file locks, OOM, network, etc.) are retried with
    * simple exponential backoff and do **not** consume the `maxRetriesPerTask`
-   * budget or invoke the expensive failure-adjudicator agent.
+   * budget or invoke the expensive parity-failure-resolver agent.
    *
    * Genuine code-quality failures go through the full recovery pipeline:
-   * `failure-adjudicator` → `code-migrator` → re-run command.
+   * `parity-failure-resolver` → `code-migrator` → re-run command.
    *
    * After exhausting all retry budgets Phase 4 fails fast with a terminal reason.
    *
@@ -3244,7 +3232,7 @@ export class MigrationOrchestrator {
     // fall through to the code-quality recovery loop (it may still help).
     if (cmdResult.success) return true;
 
-    // Code-quality recovery loop — full failure-adjudicator → code-migrator pipeline
+    // Code-quality recovery loop — full parity-failure-resolver → code-migrator pipeline
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       if (this.phase4Snapshot) {
         this.phase4Snapshot.commandRecoveryAttempts++;
@@ -3269,9 +3257,9 @@ export class MigrationOrchestrator {
         expectedSuccessCondition,
       });
 
-      // 1. Launch failure-adjudicator with the error output
+      // 1. Launch parity-failure-resolver with the error output
       const recoveryCtx = await this.contextBuilder.buildContext(
-        'failure-adjudicator',
+        'parity-failure-resolver',
         4,
         task.id,
         {
@@ -3285,12 +3273,12 @@ export class MigrationOrchestrator {
           remediationContext: toAgentRemediationContext(remediationContext),
         },
       );
-      const recoveryInv = this.buildInvocation('failure-adjudicator', recoveryCtx, 4, task.id);
+      const recoveryInv = this.buildInvocation('parity-failure-resolver', recoveryCtx, 4, task.id);
       const recoveryResult = await this.launchAgentWithEvents(recoveryInv);
       this.recordTokens(recoveryResult, 4);
 
       if (!recoveryResult.success) {
-        this.logger.warn(`Failure-adjudicator agent failed for ${task.id} on attempt ${attempt}`);
+        this.logger.warn(`Parity-failure-resolver agent failed for ${task.id} on attempt ${attempt}`);
         continue;
       }
 
@@ -3418,9 +3406,9 @@ export class MigrationOrchestrator {
           });
           parityRemediation.parityIssues = parityIssues;
 
-          // failure-adjudicator
+          // parity-failure-resolver
           const recoveryCtx = await this.contextBuilder.buildContext(
-            'failure-adjudicator',
+            'parity-failure-resolver',
             4,
             task.id,
             {
@@ -3433,7 +3421,7 @@ export class MigrationOrchestrator {
               remediationContext: toAgentRemediationContext(parityRemediation),
             },
           );
-          const recoveryInv = this.buildInvocation('failure-adjudicator', recoveryCtx, 4, task.id);
+          const recoveryInv = this.buildInvocation('parity-failure-resolver', recoveryCtx, 4, task.id);
           const recoveryResult = await this.launchAgentWithEvents(recoveryInv);
           this.recordTokens(recoveryResult, 4);
 
@@ -3506,6 +3494,19 @@ export class MigrationOrchestrator {
   }
 
   // ─── Helpers ─────────────────────────────────────────────────────────
+
+  /**
+   * Check whether the parity-failure-resolver determined that remaining
+   * parity issues are out of the task's declared scope (`scopeReduced: true`).
+   *
+   * When the resolver applies scope-based adjudication it intentionally
+   * makes no code changes, so re-running parity-verifier would only
+   * re-discover the same out-of-scope gaps.
+   */
+  private resolverReducedScope(result: AgentResult): boolean {
+    if (!result.outputParsed || !result.structuredOutput) return false;
+    return (result.structuredOutput as Record<string, unknown>).scopeReduced === true;
+  }
 
   /**
    * Extract parity data from a parity-verifier AgentResult and store it
@@ -3909,7 +3910,7 @@ export class MigrationOrchestrator {
       'code-migrator',
       'parity-verifier',
       'test-writer',
-      'failure-adjudicator',
+      'parity-failure-resolver',
       'final-parity-checker',
       'e2e-test-crafter',
       'documentation-writer',
@@ -3924,8 +3925,8 @@ export class MigrationOrchestrator {
       ? this.kbDbPath
       : undefined;
 
-    // Failure-adjudicator model override takes precedence over routing
-    const failureRecoveryOverride = agent === 'failure-adjudicator'
+    // Parity-failure-resolver model override takes precedence over routing
+    const failureRecoveryOverride = agent === 'parity-failure-resolver'
       ? this.getFailureRecoveryModel()
       : undefined;
 
@@ -3933,7 +3934,7 @@ export class MigrationOrchestrator {
     let routingTier: ModelTier | undefined;
     let routingReason: string | undefined;
 
-    // Apply model routing when enabled and no failure-adjudicator override
+    // Apply model routing when enabled and no parity-failure-resolver override
     if (!failureRecoveryOverride && this.config.options.modelRouting?.enabled) {
       const decision = this.applyRoutingCaps(
         this.selectModelForInvocation(task, agent),

--- a/runtime/src/execution/retry.ts
+++ b/runtime/src/execution/retry.ts
@@ -22,14 +22,14 @@ export interface RetryOptions {
 export type RetryResult = AgentResult & {
   /** Total number of attempts made (including the initial attempt and any recovery). */
   attempts: number;
-  /** Whether a failure-adjudicator escalation was attempted. */
+  /** Whether a parity-failure-resolver escalation was attempted. */
   recoveryAttempted: boolean;
   /** Whether this successful result came from a retry (i.e. not the first attempt). */
   wasRetry: boolean;
 };
 
 /**
- * Executes agent invocations with retry logic and optional failure-adjudicator escalation.
+ * Executes agent invocations with retry logic and optional parity-failure-resolver escalation.
  *
  * When all retry attempts are exhausted, the executor can optionally invoke an
  * `onExhausted` callback to produce a recovery invocation. If recovery succeeds,
@@ -111,7 +111,7 @@ export class RetryExecutor {
     if (options.onExhausted && invocation.taskId) {
       const recoveryInvocation = await options.onExhausted(invocation.taskId, lastResult?.error ?? 'unknown');
       if (recoveryInvocation) {
-        this.logger.info(`Attempting failure-adjudicator for ${invocation.taskId}`);
+        this.logger.info(`Attempting parity-failure-resolver for ${invocation.taskId}`);
         recoveryAttempted = true;
         const recoveryResult = await this.launcher(recoveryInvocation);
         if (recoveryResult.success) {

--- a/runtime/tests/aamf-output-schema.test.ts
+++ b/runtime/tests/aamf-output-schema.test.ts
@@ -8,7 +8,7 @@ import {
   CodeMigratorSchema,
   ParityVerifierSchema,
   TestWriterSchema,
-  FailureAdjudicatorSchema,
+  ParityFailureResolverSchema,
   FinalParityCheckerSchema,
   E2eTestCrafterSchema,
   DocumentationWriterSchema,
@@ -122,22 +122,22 @@ describe('Per-agent output schemas', () => {
     });
   });
 
-  describe('FailureAdjudicatorSchema', () => {
-    it('accepts canonical failure-adjudicator output', () => {
+  describe('ParityFailureResolverSchema', () => {
+    it('accepts canonical parity-failure-resolver output', () => {
       expect(() =>
-        FailureAdjudicatorSchema.parse({ status: VALID_STATUS, agent: 'failure-adjudicator' }),
+        ParityFailureResolverSchema.parse({ status: VALID_STATUS, agent: 'parity-failure-resolver' }),
       ).not.toThrow();
     });
 
     it('accepts legacy failure-recovery output for compatibility', () => {
       expect(() =>
-        FailureAdjudicatorSchema.parse({ status: VALID_STATUS, agent: 'failure-recovery' }),
+        ParityFailureResolverSchema.parse({ status: VALID_STATUS, agent: 'failure-recovery' }),
       ).not.toThrow();
     });
 
     it('rejects wrong agent literal', () => {
       expect(() =>
-        FailureAdjudicatorSchema.parse({ status: VALID_STATUS, agent: 'code-migrator' }),
+        ParityFailureResolverSchema.parse({ status: VALID_STATUS, agent: 'code-migrator' }),
       ).toThrow();
     });
   });

--- a/runtime/tests/agent-launcher.test.ts
+++ b/runtime/tests/agent-launcher.test.ts
@@ -420,26 +420,26 @@ describe('AgentLauncher', () => {
       expect(result.parseError).toBeUndefined();
     });
 
-    it('should parse aamf-json output for failure-adjudicator invocations', async () => {
-      const aamfBlock = JSON.stringify({ status: 'completed', agent: 'failure-adjudicator' });
-      const script = await createScript('valid-aamf-failure-adjudicator.sh', [
+    it('should parse aamf-json output for parity-failure-resolver invocations', async () => {
+      const aamfBlock = JSON.stringify({ status: 'completed', agent: 'parity-failure-resolver' });
+      const script = await createScript('valid-aamf-parity-failure-resolver.sh', [
         `printf '\`\`\`aamf-json\\n${aamfBlock}\\n\`\`\`\\n'`,
         'exit 0',
       ].join('\n'));
       const launcher = makeLauncher(script);
-      const { contextFile, progressDir } = await prepareInvocation('aamf-failure-adjudicator-001');
+      const { contextFile, progressDir } = await prepareInvocation('aamf-parity-failure-resolver-001');
 
       const result = await launcher.launchAgent({
-        agent: 'failure-adjudicator',
+        agent: 'parity-failure-resolver',
         contextFile,
         progressDir,
         phase: 4,
-        taskId: 'aamf-failure-adjudicator-001',
+        taskId: 'aamf-parity-failure-resolver-001',
       });
 
       expect(result.success).toBe(true);
       expect(result.outputParsed).toBe(true);
-      expect(result.structuredOutput?.agent).toBe('failure-adjudicator');
+      expect(result.structuredOutput?.agent).toBe('parity-failure-resolver');
     });
 
     it('should leave success unchanged and set outputParsed: false when no aamf-json block is emitted', async () => {

--- a/runtime/tests/agents/types.test.ts
+++ b/runtime/tests/agents/types.test.ts
@@ -258,13 +258,13 @@ describe('AgentInvocation', () => {
     expect(inv.timeout).toBe(60_000);
   });
 
-  it('should accept failure-adjudicator as a valid agent name', () => {
+  it('should accept parity-failure-resolver as a valid agent name', () => {
     const inv: AgentInvocation = {
-      agent: 'failure-adjudicator',
+      agent: 'parity-failure-resolver',
       contextFile: '/tmp/context.json',
       progressDir: '/tmp/progress',
     };
-    expect(inv.agent).toBe('failure-adjudicator');
+    expect(inv.agent).toBe('parity-failure-resolver');
   });
 
   it('should support optional mcpConfig field', () => {

--- a/runtime/tests/context-builder.test.ts
+++ b/runtime/tests/context-builder.test.ts
@@ -586,8 +586,8 @@ describe('ContextBuilder', () => {
       expect(context.payload?.testType).toBe('e2e');
     });
 
-    it('should route failure-adjudicator with source/target (no failureReport in inputFiles)', async () => {
-      const contextPath = await builder.buildContext('failure-adjudicator', 4, 'task-001', {
+    it('should route parity-failure-resolver with source/target (no failureReport in inputFiles)', async () => {
+      const contextPath = await builder.buildContext('parity-failure-resolver', 4, 'task-001', {
         failureReport: '/tmp/failure.md',
         sourceFile: 'src/auth.py',
         targetFile: 'src/auth.ts',
@@ -603,8 +603,8 @@ describe('ContextBuilder', () => {
       expect(context.outputPath).toBe('/tmp/target');
     });
 
-    it('should include taskScope in failure-adjudicator payload when provided', async () => {
-      const contextPath = await builder.buildContext('failure-adjudicator', 4, 'task-001', {
+    it('should include taskScope in parity-failure-resolver payload when provided', async () => {
+      const contextPath = await builder.buildContext('parity-failure-resolver', 4, 'task-001', {
         failureReport: 'Parity failed',
         sourceFile: 'src/auth.py',
         targetFile: 'src/auth.ts',
@@ -654,8 +654,8 @@ describe('ContextBuilder', () => {
       expect(context.payload?.taskScope).toBeUndefined();
     });
 
-    it('should preserve remediation payload fields in failure-adjudicator payload', async () => {
-      const contextPath = await builder.buildContext('failure-adjudicator', 4, 'task-001', {
+    it('should preserve remediation payload fields in parity-failure-resolver payload', async () => {
+      const contextPath = await builder.buildContext('parity-failure-resolver', 4, 'task-001', {
         failureReport: '/tmp/failure.md',
         sourceFile: 'src/auth.py',
         targetFile: 'src/auth.ts',
@@ -684,7 +684,7 @@ describe('ContextBuilder', () => {
         ' --> examples/common.rs:256:2',
       ].join('\n');
 
-      const contextPath = await builder.buildContext('failure-adjudicator', 4, 'wave-1', {
+      const contextPath = await builder.buildContext('parity-failure-resolver', 4, 'wave-1', {
         failureReport: inlineFailure,
         failureType: 'test',
         sourceFile: 'examples/common.h',
@@ -699,8 +699,8 @@ describe('ContextBuilder', () => {
       expect(context.payload?.failureType).toBe('test');
     });
 
-    it('should support legacy remediation alias in failure-adjudicator payload', async () => {
-      const contextPath = await builder.buildContext('failure-adjudicator', 4, 'task-001', {
+    it('should support legacy remediation alias in parity-failure-resolver payload', async () => {
+      const contextPath = await builder.buildContext('parity-failure-resolver', 4, 'task-001', {
         failureReport: '/tmp/failure.md',
         sourceFile: 'src/auth.py',
         targetFile: 'src/auth.ts',
@@ -719,7 +719,7 @@ describe('ContextBuilder', () => {
     });
 
     it('should omit remediationContext when nested remediation payload is not an object', async () => {
-      const contextPath = await builder.buildContext('failure-adjudicator', 4, 'task-001', {
+      const contextPath = await builder.buildContext('parity-failure-resolver', 4, 'task-001', {
         failureReport: '/tmp/failure.md',
         sourceFile: 'src/auth.py',
         targetFile: 'src/auth.ts',

--- a/runtime/tests/orchestrator.test.ts
+++ b/runtime/tests/orchestrator.test.ts
@@ -953,7 +953,7 @@ describe('MigrationOrchestrator', () => {
         if (inv.agent === 'code-migrator') {
           return { exitCode: 1, success: false, error: 'Code migration failed' };
         }
-        if (inv.agent === 'failure-adjudicator') {
+        if (inv.agent === 'parity-failure-resolver') {
           return { exitCode: 1, success: false, error: 'Recovery failed' };
         }
         return {};
@@ -1815,7 +1815,7 @@ describe('MigrationOrchestrator', () => {
         if (inv.agent === 'code-migrator' && inv.taskId === 'task-001') {
           return { exitCode: 1, success: false, error: 'Migration failed for task-001' };
         }
-        if (inv.agent === 'failure-adjudicator') {
+        if (inv.agent === 'parity-failure-resolver') {
           return { exitCode: 1, success: false, error: 'Recovery failed' };
         }
         return {};
@@ -1918,7 +1918,7 @@ describe('MigrationOrchestrator', () => {
       expect(result.success).toBe(true);
 
       const recoveryInvocation = mockLauncher.invocations.find(
-        (i) => i.agent === 'failure-adjudicator' && i.taskId === 'task-001' && i.phase === 4,
+        (i) => i.agent === 'parity-failure-resolver' && i.taskId === 'task-001' && i.phase === 4,
       );
       expect(recoveryInvocation).toBeDefined();
       const recoveryContext = JSON.parse(await readFile(recoveryInvocation!.contextFile, 'utf-8'));
@@ -1936,7 +1936,7 @@ describe('MigrationOrchestrator', () => {
       expect(Array.isArray(retryContext.payload?.remediationContext?.artifactPaths)).toBe(true);
     });
 
-    it('should invoke failure-adjudicator when parity-verifier finds critical issues', async () => {
+    it('should invoke parity-failure-resolver when parity-verifier finds critical issues', async () => {
       let parityCallCount = 0;
       const launcherFn = createMockLauncher((inv) => {
         if (inv.agent === 'parity-verifier') {
@@ -2001,7 +2001,7 @@ describe('MigrationOrchestrator', () => {
       await orchestrator.run();
 
       const recoveryInvocations = mockLauncher.invocations.filter(
-        (i) => i.agent === 'failure-adjudicator' && i.phase === 4,
+        (i) => i.agent === 'parity-failure-resolver' && i.phase === 4,
       );
       expect(recoveryInvocations.length).toBeGreaterThan(0);
 
@@ -2009,22 +2009,9 @@ describe('MigrationOrchestrator', () => {
       const recoveryContext = JSON.parse(await readFile(parityRecovery.contextFile, 'utf-8'));
       expect(recoveryContext.payload?.remediationContext?.failureKind).toBe('parity');
       expect(recoveryContext.payload?.remediationContext?.failureTarget?.taskId).toBe('task-001');
-
-      const remigrateCandidates = mockLauncher.invocations.filter(
-        (i) => i.agent === 'code-migrator' && i.phase === 4,
-      );
-      let foundParityRemediation = false;
-      for (const inv of remigrateCandidates) {
-        const ctx = JSON.parse(await readFile(inv.contextFile, 'utf-8'));
-        if (ctx.payload?.remediationContext?.failureKind === 'parity') {
-          foundParityRemediation = true;
-          break;
-        }
-      }
-      expect(foundParityRemediation).toBe(true);
     });
 
-    it('should pass enriched context to code-migrator during parity recovery', async () => {
+    it('should pass enriched parity issues to parity-failure-resolver', async () => {
       const launcherFn = createMockLauncher((inv) => {
         if (inv.agent === 'parity-verifier') {
           return {
@@ -2088,22 +2075,20 @@ describe('MigrationOrchestrator', () => {
 
       await orchestrator.run();
 
-      // Find the code-migrator invocation that has a parity remediationContext
-      const reMigrateCandidates = mockLauncher.invocations.filter(
-        (i) => i.agent === 'code-migrator' && i.phase === 4,
+      // Find the parity-failure-resolver invocation
+      const resolverInvocations = mockLauncher.invocations.filter(
+        (i) => i.agent === 'parity-failure-resolver' && i.phase === 4,
       );
-      let reMigrateCtx: Record<string, unknown> | undefined;
-      for (const inv of reMigrateCandidates) {
-        const ctx = JSON.parse(await readFile(inv.contextFile, 'utf-8'));
-        if (ctx.payload?.remediationContext?.failureKind === 'parity') {
-          reMigrateCtx = ctx;
-          break;
-        }
-      }
-      expect(reMigrateCtx).toBeDefined();
+      expect(resolverInvocations.length).toBeGreaterThan(0);
+
+      const resolverInv = resolverInvocations[0]!;
+      const resolverCtx = JSON.parse(await readFile(resolverInv.contextFile, 'utf-8'));
+
+      // remediationContext should include parity failure info
+      const remediation = resolverCtx.payload?.remediationContext as Record<string, unknown>;
+      expect(remediation?.failureKind).toBe('parity');
 
       // failureSummary should be stripped from the agent-facing context
-      const remediation = reMigrateCtx!.payload?.remediationContext as Record<string, unknown>;
       expect(remediation?.failureSummary).toBeUndefined();
 
       // parityIssues should be passed in the remediationContext
@@ -2111,7 +2096,7 @@ describe('MigrationOrchestrator', () => {
       expect(Array.isArray(remediation?.parityIssues)).toBe(true);
 
       // failureReport should be an enriched summary string, not a file path
-      const failureReport = reMigrateCtx!.payload?.failureReport;
+      const failureReport = resolverCtx.payload?.failureReport;
       if (failureReport !== undefined) {
         expect(typeof failureReport).toBe('string');
       }
@@ -2164,9 +2149,9 @@ describe('MigrationOrchestrator', () => {
 
       const result = await orchestrator.run();
 
-      // No failure-adjudicator should be invoked for parity
+      // No parity-failure-resolver should be invoked for parity
       const recoveryForParity = mockLauncher.invocations.filter(
-        (i) => i.agent === 'failure-adjudicator' && i.phase === 4,
+        (i) => i.agent === 'parity-failure-resolver' && i.phase === 4,
       );
       expect(recoveryForParity).toHaveLength(0);
       expect(result.success).toBe(true);
@@ -2520,9 +2505,9 @@ describe('MigrationOrchestrator', () => {
       expect(result.blockedTasks).not.toContain('task-001');
     });
 
-    it('should terminally exhaust when failure-adjudicator emits no aamf-json during parity recovery', async () => {
+    it('should terminally exhaust when parity-failure-resolver emits no aamf-json during parity recovery', async () => {
       const launcherFn = createMockLauncher((inv) => {
-        if (inv.agent === 'failure-adjudicator') {
+        if (inv.agent === 'parity-failure-resolver') {
           return {
             exitCode: 1,
             success: false,
@@ -2594,7 +2579,7 @@ describe('MigrationOrchestrator', () => {
       expect(phase4?.error).toContain('parity-non-minor-exhausted');
 
       const recoveryInvocations = mockLauncher.invocations.filter(
-        (i) => i.agent === 'failure-adjudicator' && i.taskId === 'task-001' && i.phase === 4,
+        (i) => i.agent === 'parity-failure-resolver' && i.taskId === 'task-001' && i.phase === 4,
       );
       expect(recoveryInvocations).toHaveLength(2);
 
@@ -2805,7 +2790,7 @@ describe('MigrationOrchestrator', () => {
         expect(result.success).toBe(true);
         // No remediation agents should have been invoked at wave-end
         const waveEndAdjudicator = mockLauncher.invocations.filter(
-          (i) => i.agent === 'failure-adjudicator' && i.phase === 4,
+          (i) => i.agent === 'parity-failure-resolver' && i.phase === 4,
         );
         expect(waveEndAdjudicator).toHaveLength(0);
       });
@@ -2873,7 +2858,7 @@ describe('MigrationOrchestrator', () => {
 
         // Remediation should have been triggered at wave-end
         const adjudicatorInvocations = mockLauncher.invocations.filter(
-          (i) => i.agent === 'failure-adjudicator' && i.taskId === 'task-001' && i.phase === 4,
+          (i) => i.agent === 'parity-failure-resolver' && i.taskId === 'task-001' && i.phase === 4,
         );
         const codeMigratorInvocations = mockLauncher.invocations.filter(
           (i) => i.agent === 'code-migrator' && i.taskId === 'task-001' && i.phase === 4,
@@ -2963,7 +2948,7 @@ describe('MigrationOrchestrator', () => {
         expect(result).toBeUndefined();
         // No remediation agents should have been invoked
         const adjudicators = mockLauncher.invocations.filter(
-          (i) => i.agent === 'failure-adjudicator',
+          (i) => i.agent === 'parity-failure-resolver',
         );
         expect(adjudicators).toHaveLength(0);
       });
@@ -3007,7 +2992,7 @@ describe('MigrationOrchestrator', () => {
 
         expect(result.success).toBe(true);
         const waveEndAdjudicator = mockLauncher.invocations.filter(
-          (i) => i.agent === 'failure-adjudicator' && i.phase === 4,
+          (i) => i.agent === 'parity-failure-resolver' && i.phase === 4,
         );
         expect(waveEndAdjudicator).toHaveLength(0);
       });
@@ -3055,7 +3040,7 @@ describe('MigrationOrchestrator', () => {
 
         // Should have triggered remediation (and then exhaustion since issues persist)
         const adjudicatorInvocations = mockLauncher.invocations.filter(
-          (i) => i.agent === 'failure-adjudicator' && i.taskId === 'task-001' && i.phase === 4,
+          (i) => i.agent === 'parity-failure-resolver' && i.taskId === 'task-001' && i.phase === 4,
         );
         expect(adjudicatorInvocations.length).toBeGreaterThanOrEqual(1);
         expect(result.success).toBe(false);
@@ -3113,7 +3098,7 @@ describe('MigrationOrchestrator', () => {
         const result = await orchestrator.run();
 
         const adjudicatorInvocations = mockLauncher.invocations.filter(
-          (i) => i.agent === 'failure-adjudicator' && i.taskId === 'task-001' && i.phase === 4,
+          (i) => i.agent === 'parity-failure-resolver' && i.taskId === 'task-001' && i.phase === 4,
         );
         expect(adjudicatorInvocations.length).toBeGreaterThanOrEqual(1);
         expect(result.success).toBe(false);
@@ -3163,7 +3148,7 @@ describe('MigrationOrchestrator', () => {
         // Build failure should take precedence; no parity remediation should occur
         expect(phase4?.error).toContain('wave-end build gate failed');
         const adjudicatorInvocations = mockLauncher.invocations.filter(
-          (i) => i.agent === 'failure-adjudicator' && i.phase === 4,
+          (i) => i.agent === 'parity-failure-resolver' && i.phase === 4,
         );
         expect(adjudicatorInvocations).toHaveLength(0);
       });
@@ -3196,10 +3181,10 @@ describe('MigrationOrchestrator', () => {
 
         // Both tasks should have had remediation attempts
         const task1Adjudicator = mockLauncher.invocations.filter(
-          (i) => i.agent === 'failure-adjudicator' && i.taskId === 'task-001' && i.phase === 4,
+          (i) => i.agent === 'parity-failure-resolver' && i.taskId === 'task-001' && i.phase === 4,
         );
         const task2Adjudicator = mockLauncher.invocations.filter(
-          (i) => i.agent === 'failure-adjudicator' && i.taskId === 'task-002' && i.phase === 4,
+          (i) => i.agent === 'parity-failure-resolver' && i.taskId === 'task-002' && i.phase === 4,
         );
         expect(task1Adjudicator.length).toBeGreaterThanOrEqual(1);
         expect(task2Adjudicator.length).toBeGreaterThanOrEqual(1);
@@ -3360,7 +3345,7 @@ describe('MigrationOrchestrator', () => {
       expect(Math.min(...validationStartedAt)).toBeGreaterThanOrEqual(Math.max(...migratorFinishedAt));
     });
 
-    it('should launch failure-adjudicator for wave validation failures before convergence retry', async () => {
+    it('should launch parity-failure-resolver for wave validation failures before convergence retry', async () => {
       const tasks: MigrationTask[] = [
         { ...SINGLE_AUTH_TASK, id: 'task-001', name: 'Task 1', targetFiles: ['src/a.ts'] },
         { ...SINGLE_AUTH_TASK, id: 'task-002', name: 'Task 2', sourceFiles: ['src/b.py'], targetFiles: ['lib/b.ts'] },
@@ -3398,7 +3383,7 @@ describe('MigrationOrchestrator', () => {
       const result = await orchestrator.run();
       const migratorRuns = mockLauncher.invocations.filter(i => i.agent === 'code-migrator' && i.phase === 4);
       const waveAdjudicatorRuns = mockLauncher.invocations.filter(
-        (i) => i.agent === 'failure-adjudicator' && i.phase === 4 && i.taskId === 'wave-1',
+        (i) => i.agent === 'parity-failure-resolver' && i.phase === 4 && i.taskId === 'wave-1',
       );
       const waveRemigratorRuns = mockLauncher.invocations.filter(
         (i) => i.agent === 'code-migrator' && i.phase === 4 && i.taskId === 'wave-1',
@@ -3746,6 +3731,67 @@ Total usage est: 1 Premium requests
 
       const result = (orchestrator as any).rehydrateParityFromLog('task-001');
       expect(result).toBeUndefined();
+    });
+  });
+
+  // ─── Resolver Scope Reduction ───────────────────────────────────────
+
+  describe('resolverReducedScope', () => {
+    it('returns true when structuredOutput has scopeReduced: true', async () => {
+      const launcherFn = createMockLauncher();
+      const { orchestrator } = await setupOrchestrator(tempDir, launcherFn);
+      const agentResult: Partial<AgentResult> = {
+        outputParsed: true,
+        structuredOutput: {
+          agent: 'parity-failure-resolver',
+          status: 'completed',
+          taskId: 'task-26',
+          failureType: 'parity',
+          attempts: 1,
+          scopeReduced: true,
+        },
+      };
+      expect((orchestrator as any).resolverReducedScope(agentResult)).toBe(true);
+    });
+
+    it('returns false when scopeReduced is false', async () => {
+      const launcherFn = createMockLauncher();
+      const { orchestrator } = await setupOrchestrator(tempDir, launcherFn);
+      const agentResult: Partial<AgentResult> = {
+        outputParsed: true,
+        structuredOutput: {
+          agent: 'parity-failure-resolver',
+          status: 'completed',
+          taskId: 'task-26',
+          failureType: 'parity',
+          attempts: 1,
+          scopeReduced: false,
+        },
+      };
+      expect((orchestrator as any).resolverReducedScope(agentResult)).toBe(false);
+    });
+
+    it('returns false when outputParsed is false', async () => {
+      const launcherFn = createMockLauncher();
+      const { orchestrator } = await setupOrchestrator(tempDir, launcherFn);
+      const agentResult: Partial<AgentResult> = { outputParsed: false, structuredOutput: undefined };
+      expect((orchestrator as any).resolverReducedScope(agentResult)).toBe(false);
+    });
+
+    it('returns false when scopeReduced field is absent', async () => {
+      const launcherFn = createMockLauncher();
+      const { orchestrator } = await setupOrchestrator(tempDir, launcherFn);
+      const agentResult: Partial<AgentResult> = {
+        outputParsed: true,
+        structuredOutput: {
+          agent: 'parity-failure-resolver',
+          status: 'completed',
+          taskId: 'task-26',
+          failureType: 'parity',
+          attempts: 1,
+        },
+      };
+      expect((orchestrator as any).resolverReducedScope(agentResult)).toBe(false);
     });
   });
 
@@ -5238,7 +5284,7 @@ Total usage est: 1 Premium requests
       await writeMigrationPlan(progressDir);
       await orchestrator.run();
 
-      // No code-migrator invocation should have a modelOverride (except failure-adjudicator)
+      // No code-migrator invocation should have a modelOverride (except parity-failure-resolver)
       const migratorInvocations = mockLauncher.invocations.filter(
         (inv: AgentInvocation) => inv.agent === 'code-migrator',
       );

--- a/runtime/tests/phase-registry.test.ts
+++ b/runtime/tests/phase-registry.test.ts
@@ -36,7 +36,7 @@ describe('Phase Registry', () => {
     expect(phase?.id).toBe(4);
     expect(phase?.name).toBe('Iterative Migration');
     expect(phase?.description).toContain('per-task or wave-barrier mode');
-    expect(phase?.agents).toContain('failure-adjudicator');
+    expect(phase?.agents).toContain('parity-failure-resolver');
     expect(phase?.agents).not.toContain('failure-recovery');
   });
 

--- a/runtime/tests/result-parser.test.ts
+++ b/runtime/tests/result-parser.test.ts
@@ -19,7 +19,7 @@ import {
   CodeMigratorSchema,
   ParityVerifierSchema,
   TestWriterSchema,
-  FailureAdjudicatorSchema,
+  ParityFailureResolverSchema,
   FinalParityCheckerSchema,
   E2eTestCrafterSchema,
   DocumentationWriterSchema,
@@ -453,12 +453,12 @@ Here are the tasks:
       expect(() => TestWriterSchema.parse({ status: 'completed', agent: 'test-writer' })).not.toThrow();
     });
 
-    it('should validate FailureAdjudicatorSchema with canonical id', () => {
-      expect(() => FailureAdjudicatorSchema.parse({ status: 'completed', agent: 'failure-adjudicator' })).not.toThrow();
+    it('should validate ParityFailureResolverSchema with canonical id', () => {
+      expect(() => ParityFailureResolverSchema.parse({ status: 'completed', agent: 'parity-failure-resolver' })).not.toThrow();
     });
 
-    it('should validate FailureAdjudicatorSchema with legacy alias', () => {
-      expect(() => FailureAdjudicatorSchema.parse({ status: 'completed', agent: 'failure-recovery' })).not.toThrow();
+    it('should validate ParityFailureResolverSchema with legacy alias', () => {
+      expect(() => ParityFailureResolverSchema.parse({ status: 'completed', agent: 'failure-recovery' })).not.toThrow();
     });
 
     it('should validate FinalParityCheckerSchema', () => {
@@ -606,21 +606,21 @@ intermediate text
       expect(result.parsed).toBe(true);
     });
 
-    it('should parse failure-adjudicator aamf-json with canonical agent id', () => {
-      const stdout = '```aamf-json\n{"status":"completed","agent":"failure-adjudicator"}\n```';
-      const result = parseAamfOutput(stdout, FailureAdjudicatorSchema);
+    it('should parse parity-failure-resolver aamf-json with canonical agent id', () => {
+      const stdout = '```aamf-json\n{"status":"completed","agent":"parity-failure-resolver"}\n```';
+      const result = parseAamfOutput(stdout, ParityFailureResolverSchema);
       expect(result.parsed).toBe(true);
       if (result.parsed) {
-        expect(result.data.agent).toBe('failure-adjudicator');
+        expect(result.data.agent).toBe('parity-failure-resolver');
       }
     });
 
-    it('should parse failure-adjudicator aamf-json with legacy failure-recovery id', () => {
+    it('should parse parity-failure-resolver aamf-json with legacy failure-recovery id', () => {
       const stdout = '```aamf-json\n{"status":"completed","agent":"failure-recovery"}\n```';
-      const result = parseAamfOutput(stdout, FailureAdjudicatorSchema);
+      const result = parseAamfOutput(stdout, ParityFailureResolverSchema);
       expect(result.parsed).toBe(true);
       if (result.parsed) {
-        expect(result.data.agent).toBe('failure-adjudicator');
+        expect(result.data.agent).toBe('parity-failure-resolver');
       }
     });
 

--- a/runtime/tests/retry-executor.test.ts
+++ b/runtime/tests/retry-executor.test.ts
@@ -217,7 +217,7 @@ describe('RetryExecutor', () => {
       const executor = new RetryExecutor(launcher, logger);
 
       const recoveryInvocation: AgentInvocation = {
-        agent: 'failure-adjudicator',
+        agent: 'parity-failure-resolver',
         contextFile: '/tmp/recovery-ctx.json',
         progressDir: '/tmp/progress',
         phase: 4,
@@ -240,7 +240,7 @@ describe('RetryExecutor', () => {
       const launcher = async (inv: AgentInvocation): Promise<AgentResult> => {
         callCount++;
         // Original attempts 1-2 fail, recovery succeeds, then original retry succeeds
-        if (inv.agent === 'failure-adjudicator') {
+        if (inv.agent === 'parity-failure-resolver') {
           return {
             agent: inv.agent,
             taskId: inv.taskId,
@@ -276,7 +276,7 @@ describe('RetryExecutor', () => {
       const executor = new RetryExecutor(launcher, logger);
 
       const recoveryInvocation: AgentInvocation = {
-        agent: 'failure-adjudicator',
+        agent: 'parity-failure-resolver',
         contextFile: '/tmp/recovery-ctx.json',
         progressDir: '/tmp/progress',
         phase: 4,
@@ -295,7 +295,7 @@ describe('RetryExecutor', () => {
     });
 
     it('should return failure when recovery also fails', async () => {
-      // Both code-migrator and failure-adjudicator always fail
+      // Both code-migrator and parity-failure-resolver always fail
       const launcher = async (inv: AgentInvocation): Promise<AgentResult> => ({
         agent: inv.agent,
         taskId: inv.taskId,
@@ -310,7 +310,7 @@ describe('RetryExecutor', () => {
       const executor = new RetryExecutor(launcher, logger);
 
       const recoveryInvocation: AgentInvocation = {
-        agent: 'failure-adjudicator',
+        agent: 'parity-failure-resolver',
         contextFile: '/tmp/recovery.json',
         progressDir: '/tmp/progress',
         phase: 4,
@@ -454,18 +454,18 @@ describe('RetryExecutor', () => {
       const launcher = async (inv: AgentInvocation): Promise<AgentResult> => ({
         agent: inv.agent,
         taskId: inv.taskId,
-        exitCode: inv.agent === 'failure-adjudicator' ? 0 : 1,
-        success: inv.agent === 'failure-adjudicator',
+        exitCode: inv.agent === 'parity-failure-resolver' ? 0 : 1,
+        success: inv.agent === 'parity-failure-resolver',
         outputFiles: [],
         duration: 100,
-        error: inv.agent === 'failure-adjudicator' ? undefined : 'Failed',
+        error: inv.agent === 'parity-failure-resolver' ? undefined : 'Failed',
       });
 
       const logger = createSilentLogger(tempDir);
       const executor = new RetryExecutor(launcher, logger);
 
       const recoveryInvocation: AgentInvocation = {
-        agent: 'failure-adjudicator',
+        agent: 'parity-failure-resolver',
         contextFile: '/tmp/recovery.json',
         progressDir: '/tmp/progress',
         phase: 4,


### PR DESCRIPTION
Closes #156. Supersedes #153 and #154.

## Problem

The parity recovery loop ran three agents sequentially: `failure-adjudicator` → `code-migrator` → `parity-verifier`. Two issues:

1. **The code-migrator re-run is redundant.** The failure-adjudicator already has edit/execute tools and applies fixes directly. Re-running the full code-migrator wastes tokens on a broad agent that re-evaluates the entire task.

2. **The name "failure-adjudicator" is misleading.** It implies a judge that evaluates but doesn't act, when the template explicitly instructs it to diagnose, evaluate strategies, AND apply fixes.

## Changes

### 1. Simplify parity recovery loop

The loop is now: **`parity-failure-resolver` → commit → `parity-verifier`** (was: `failure-adjudicator` → `code-migrator` → `parity-verifier`).

This saves one full agent invocation per retry attempt, reducing token spend and wall-clock time in the parity convergence loop.

### 2. Rename `failure-adjudicator` → `parity-failure-resolver`

Across all 20 files:
- Template: `failure-adjudicator.md` → `parity-failure-resolver.md`
- Registry: agent definition, schema export, Zod enum
- Types: `AgentName` union member, JSDoc comments
- Context-builder: switch case
- Orchestrator: all ~22 string references
- Retry executor: JSDoc and log messages
- Config schema: JSDoc comments
- 5 agent templates (prose references)
- 8 test files (~72 references)

### 3. Add `resolverReducedScope()` helper

When the resolver returns `scopeReduced: true`, accept the verdict and break the retry loop instead of re-running parity-verifier on out-of-scope issues.

### 4. Add scope-consistency constraint to task-decomposer

Prevent ambiguous tasks where description references APIs whose implementations live outside the task's `lineRange`.

## Tests

- 187 orchestrator tests pass (4 pre-existing Phase 0 KB failures from lore upgrade on main)
- 322 tests pass across 7 other affected test files
- 4 new `resolverReducedScope` tests added