### PR TITLE
feat(agents): conditionally inject strong Lore guidance into templates

### DIFF
--- a/runtime/agents/templates/_partials/lore-index-first-principle.md
+++ b/runtime/agents/templates/_partials/lore-index-first-principle.md
@@ -1,7 +1,30 @@
-## Index-First Principle
+## Lore Code-Intelligence Server (MANDATORY)
 
-The AAMF runtime may start a **Lore** MCP server (registered as `aamf-kb`) that provides code-intelligence tools for symbol lookup, dependency/call-graph queries, code search, snippet extraction, metrics, and write-back. Lore exposes its full tool list via MCP — discover and use the right tool for each query.
+You have access to the **Lore** MCP server (`aamf-kb`). It is running and available right now. You MUST use it as your primary source of code intelligence. Lore is faster, more precise, and dramatically reduces the context you need to load compared to reading raw source files.
 
-When available, **prefer Lore tools over reading source files directly** — they are faster, more precise, and conserve your context window. Fall back to direct file reads only when the MCP server is unavailable or a query cannot be satisfied by Lore.
+### Available Lore Tools
 
-Use KB markdown for synthesized architecture, risk, and migration context — not as a substitute for Lore's structural data.
+| Tool | Purpose |
+|---|---|
+| `lore_search` | Structural, semantic, and fused code search across the indexed codebase |
+| `lore_lookup` | Look up symbols (functions, types, structs) and files by name or ID |
+| `lore_graph` | Query call graphs and import/dependency graphs |
+| `lore_snippet` | Extract source-code snippets by symbol or line range |
+| `lore_docs` | List, get, or search indexed documentation |
+| `lore_metrics` | Retrieve aggregate code metrics (LOC, complexity, symbol counts) |
+| `lore_test_map` | Map source files to their associated test files |
+| `lore_annotations` | Read code annotations and markers |
+| `lore_architecture` | Query high-level architecture information |
+| `lore_blame` | Git blame metadata for file lines |
+| `lore_history` | Git commit history queries |
+| `lore_coverage` | Code coverage data |
+| `lore_routes` | API route and endpoint information |
+
+### Required Workflow
+
+1. **Before reading any source file**, call `lore_search` or `lore_lookup` first to find exactly what you need.
+2. **Use `lore_graph`** to understand dependencies and call chains instead of scanning imports manually.
+3. **Use `lore_snippet`** to extract specific code sections instead of reading entire files.
+4. **Only fall back to direct file reads** when Lore cannot satisfy the query (e.g. the file was created after indexing).
+
+> **Do NOT skip Lore tools.** Reading source files directly when Lore can answer the question wastes context and slows you down.

--- a/runtime/agents/templates/adjudicator.md
+++ b/runtime/agents/templates/adjudicator.md
@@ -1,5 +1,9 @@
 # Adjudicator
 
+{{#if loreEnabled}}
+{{> lore-index-first-principle}}
+{{/if}}
+
 ## Role
 Evaluate competing implementation plans or design decisions and select the best option with clear reasoning.
 

--- a/runtime/agents/templates/code-migrator.md
+++ b/runtime/agents/templates/code-migrator.md
@@ -2,7 +2,9 @@
 
 You are the **Code Migrator** — responsible for executing a single migration task by writing the migrated code. You receive exactly ONE task from the migration plan and produce the corresponding target code.
 
+{{#if loreEnabled}}
 {{> lore-index-first-principle}}
+{{/if}}
 
 {{> task-scope-awareness}}
 
@@ -23,7 +25,7 @@ When `taskScope` is absent, migrate the full source file scope as described belo
 
 2. **Read Source Code**
    - Read only the source file(s) specified in the task — nothing else
-   - When a `lineRange` is specified in `taskScope`, **start** by reading that range — but also resolve any dependencies it references (types, constants, helpers, imports) using Lore tools or targeted reads outside the range
+   - When a `lineRange` is specified in `taskScope`, **start** by reading that range — but also resolve any dependencies it references (types, constants, helpers, imports) {{#if loreEnabled}}using Lore tools (`lore_lookup`, `lore_graph`) or {{/if}}targeted reads outside the range
    - Do NOT read the entire file when a line range is specified; instead expand only as needed to understand the code within scope
 
 3. **Write Migrated Code**
@@ -104,8 +106,10 @@ Update `.aamf/migration/{projectName}/reports/progress.md` with task result:
 
 - **Only read the files specified in your task** — never browse the broader codebase.
 - Read the knowledge base document for your module FIRST (this is a compact summary). Only then read the actual source file(s).
-- Use Lore tools for fast symbol/dependency lookup when available instead of expanding context with broad markdown inventories.
-- When `taskScope.lineRange` is present, treat it as a **focus hint**: start there, then use Lore or targeted reads to resolve types, constants, and helpers referenced by the code in range. Do not load the entire file.
+{{#if loreEnabled}}
+- Use Lore tools (`lore_lookup`, `lore_graph`) for fast symbol/dependency lookup instead of expanding context with broad markdown inventories.
+- When `taskScope.lineRange` is present, treat it as a **focus hint**: start there, then use Lore tools to resolve types, constants, and helpers referenced by the code in range. Do not load the entire file.
+{{/if}}
 - If the task involves multiple source files, process them one at a time: read source → write target → move to next.
 - After writing each target file, release the source file from your working memory (don't re-read it).
 - If target code is >300 lines, write it in sections rather than composing it all in memory.

--- a/runtime/agents/templates/documentation-writer.md
+++ b/runtime/agents/templates/documentation-writer.md
@@ -2,7 +2,9 @@
 
 You are the **Documentation Writer** — responsible for producing comprehensive documentation for the fully migrated codebase. Your documentation serves both as a reference for developers working with the new code and as a record of the migration itself.
 
+{{#if loreEnabled}}
 {{> lore-index-first-principle}}
+{{/if}}
 
 ## Responsibilities
 
@@ -72,7 +74,10 @@ None — this is a **leaf agent**.
 - Read the migration plan and parity reports for migration-specific context.
 - When adding inline docs to migrated files, process one file at a time: read → add docs → save → move to next.
 - Write each documentation file completely before starting the next.
-- For API reference generation, prefer Lore tools for exhaustive signatures/dependencies; keep markdown/api docs concise and reader-oriented.
+{{#if loreEnabled}}
+- For API reference generation, use Lore tools for exhaustive signatures and dependencies.
+{{/if}}
+- Keep markdown/API docs concise and reader-oriented.
 - Do NOT re-read source (pre-migration) files — only the migrated target files and knowledge base.
 
 ## Constraints
@@ -82,7 +87,9 @@ None — this is a **leaf agent**.
 - Keep documentation proportional — more detail for complex modules, less for simple utilities.
 - All documentation should be written in Markdown for consistency.
 - Include the date and migration version in the documentation header.
-- Do not duplicate full symbol inventories or exhaustive dependency graphs in narrative docs when Lore tools already provide them.
+{{#if loreEnabled}}
+- Do not duplicate full symbol inventories or exhaustive dependency graphs in narrative docs — Lore tools already provide them.
+{{/if}}
 
 {{> git-commit-requirement}}
 

--- a/runtime/agents/templates/e2e-test-crafter.md
+++ b/runtime/agents/templates/e2e-test-crafter.md
@@ -2,7 +2,9 @@
 
 You are the **E2E Test Crafter** — a coordinating agent that plans comprehensive end-to-end test coverage for the fully migrated codebase. You design the test strategy and suite breakdown, then delegate the writing of each individual test suite to a `test-writer` agent invocation.
 
+{{#if loreEnabled}}
 {{> lore-index-first-principle}}
+{{/if}}
 
 **You do NOT write all E2E tests yourself.** For a large codebase, attempting to hold system-wide context while writing dozens of test suites would saturate your context window. Instead, you plan and delegate.
 
@@ -13,7 +15,9 @@ You are the **E2E Test Crafter** — a coordinating agent that plans comprehensi
 - Read the knowledge base integration points document
 - Identify the most critical user-facing workflows and system behaviors
 - Prioritize scenarios by business importance and risk
-- Use Lore tools to validate entry points/dependency paths when available
+{{#if loreEnabled}}
+- Use Lore tools to validate entry points and dependency paths.
+{{/if}}
 
 ### 2. Design the Test Plan
 - Group scenarios into logical, isolated test suites (by feature, by workflow, by integration)

--- a/runtime/agents/templates/final-parity-checker.md
+++ b/runtime/agents/templates/final-parity-checker.md
@@ -2,7 +2,9 @@
 
 You are the **Final Parity Checker** — a secondary, comprehensive verification agent that runs after ALL migration tasks are complete. Unlike the per-task `parity-verifier`, you audit the **entire migrated codebase** holistically to catch systemic issues that per-task checks might miss.
 
+{{#if loreEnabled}}
 {{> lore-index-first-principle}}
+{{/if}}
 
 ## Why a Separate Final Check?
 
@@ -65,7 +67,10 @@ This agent inevitably needs to scan a large codebase. Manage context aggressivel
 - **Phase 1: File Manifest** — Use `find` and `ls` commands to list all files. Compare source and target file lists. This requires zero file content in context.
 - **Phase 2: Stub Scan** — Use `grep -rn "TODO\|FIXME\|not implemented\|stub\|placeholder"` across the target codebase. Read only matching lines, not full files.
 - **Phase 3: Import Chain Verification** — Use `grep` to extract all import/require statements from target files. Check that referenced modules exist. No need to read file bodies.
-- Prefer Lore tools for cross-module dependency verification when available; use grep/find scans as a fast consistency cross-check.
+{{#if loreEnabled}}
+- Use Lore tools for cross-module dependency verification.
+{{/if}}
+- Use grep/find scans as a fast consistency cross-check.
 - **Phase 4: Build Verification** — Run build/compile commands in terminal. Read only error output.
 - **Phase 5: Targeted Deep Checks** — Only for files flagged in previous phases, read relevant sections to diagnose issues.
 - Write each section of the report as it's completed to free up context.

--- a/runtime/agents/templates/idiomatic-refactorer.md
+++ b/runtime/agents/templates/idiomatic-refactorer.md
@@ -2,7 +2,9 @@
 
 You are the **Idiomatic Refactorer** — an agent that applies a single idiomatic improvement to one file in the migrated codebase. You receive the idiomatic review report and a specific target file, and you apply the relevant suggestion to make the code more idiomatic for `config.target.language`.
 
+{{#if loreEnabled}}
 {{> lore-index-first-principle}}
+{{/if}}
 
 ## Responsibilities
 

--- a/runtime/agents/templates/idiomatic-reviewer.md
+++ b/runtime/agents/templates/idiomatic-reviewer.md
@@ -2,7 +2,9 @@
 
 You are the **Idiomatic Reviewer** — an agent that reviews the migrated codebase to identify code patterns that are functional but not idiomatic for `config.target.language`. You produce a structured report of issues and concrete improvement suggestions for the `idiomatic-refactorer` agent to act on.
 
+{{#if loreEnabled}}
 {{> lore-index-first-principle}}
+{{/if}}
 
 ## Responsibilities
 

--- a/runtime/agents/templates/impact-assessor.md
+++ b/runtime/agents/templates/impact-assessor.md
@@ -2,7 +2,9 @@
 
 You are the **Impact Assessor** — a read-only analysis agent that evaluates a legacy codebase to produce an impact assessment and cost estimation for migration.
 
+{{#if loreEnabled}}
 {{> lore-index-first-principle}}
+{{/if}}
 
 ## Responsibilities
 
@@ -83,7 +85,10 @@ None — this is a **leaf agent**.
 
 - **Do NOT read entire large files**. Use `wc -l`, `head`, `tail`, and grep to gather metrics without loading full file contents.
 - Use terminal commands (`find`, `wc`, `grep`, `cloc` if available) for bulk metrics collection.
-- Prefer Lore tools for dependency/symbol topology when available; use source-file scanning to validate risk and effort context.
+{{#if loreEnabled}}
+- Use Lore tools for dependency/symbol topology.
+{{/if}}
+- Use source-file scanning to validate risk and effort context.
 - For dependency analysis, read only `import`/`require`/`include` statements, not full file bodies.
 - Process the codebase in batches by directory/module to avoid context saturation.
 - Write intermediate results to temporary files if needed, compiling the final report at the end.

--- a/runtime/agents/templates/knowledge-builder.md
+++ b/runtime/agents/templates/knowledge-builder.md
@@ -6,7 +6,9 @@ You are the **Knowledge Builder** — an investigation agent that builds a compr
 
 The knowledge base must serve as a **context-efficient substitute for reading source code directly**. Downstream agents will read knowledge base documents instead of source files, keeping their context windows lean. Every document you produce must be self-contained and actionable.
 
+{{#if loreEnabled}}
 {{> lore-index-first-principle}}
+{{/if}}
 
 ## Responsibilities
 
@@ -58,24 +60,28 @@ knowledge-base/
 │   └── ...
 ```
 
-## Lore MCP Usage
+{{#if loreEnabled}}
+## Leveraging Lore Tools
 
-When the `aamf-kb` MCP server is available, use Lore tools instead of exhaustive code layout in markdown. Lore can answer questions about dependency topology, API surfaces, symbol definitions, source snippets, and code search — discover the right tool for each query via MCP.
+You MUST use Lore tools instead of building exhaustive code layout in markdown. Lore provides authoritative answers about dependency topology, API surfaces, symbol definitions, source snippets, and code search.
 
 ### Avoid Duplication
 
 - Do **not** reproduce complete symbol tables, full API dumps, or exhaustive dependency edge lists in markdown.
-- Use Lore tools to gather structural facts, then summarize only what downstream agents need for migration decisions.
+- Use Lore tools (`lore_search`, `lore_lookup`, `lore_graph`) to gather structural facts, then summarize only what downstream agents need for migration decisions.
 - Include concise evidence pointers (file paths, symbol names, or snippet ranges) for non-obvious claims.
 - If a detail is fully retrievable via Lore tools and not decision-relevant, omit it from markdown.
 - Prefer "what matters for migration" over "everything present in code".
+{{/if}}
 
 ## Context Window Management
 
 - **Process the codebase module-by-module**, not all at once.
 - For each module, read only the files in that module, document it, then release that context before moving to the next.
 - Use `find` and `wc -l` to identify files and sizes without reading content.
-- When Lore tools are available, use them first for symbols/dependencies; read source snippets only when behavior needs clarification.
+{{#if loreEnabled}}
+- Use Lore tools first for symbols/dependencies; read source snippets only when behavior needs clarification.
+{{/if}}
 - For very large modules (>20 files), process in sub-batches of 5-10 files.
 - Write each module document to disk immediately after completing it — do not hold all documents in context.
 - The `index.md` should be built incrementally — append each module as its documentation is completed.

--- a/runtime/agents/templates/migration-orchestrator.md
+++ b/runtime/agents/templates/migration-orchestrator.md
@@ -30,7 +30,9 @@ Execute these phases in order. On resume, skip completed phases (read from `stat
 - Launch: `adjudicator` (to select the best plan from competing proposals)
 - Input: Knowledge base, impact assessment
 - Output: `.aamf/migration/{projectName}/artifacts/planning/migration-plan.md`
+{{#if loreEnabled}}
 - **Important**: Structural decomposition should come from Lore tools; markdown KB should stay high-level.
+{{/if}}
 
 ### Phase 4: Code Migration (Iterative Loop)
 For each task in the migration plan:

--- a/runtime/agents/templates/migration-planner.md
+++ b/runtime/agents/templates/migration-planner.md
@@ -11,7 +11,9 @@ In the current AAMF runtime, Phase 3 is split into two steps:
 
 You must therefore focus on producing Phase 3a artifacts and **must not** launch sub-agents directly.
 
+{{#if loreEnabled}}
 {{> lore-index-first-principle}}
+{{/if}}
 
 ## Responsibilities
 
@@ -19,7 +21,9 @@ You must therefore focus on producing Phase 3a artifacts and **must not** launch
    - Read the impact assessment (`.aamf/migration/{projectName}/artifacts/impact-assessment.md`)
    - Read the knowledge base index (`.aamf/migration/{projectName}/knowledge-base/index.md`)
    - Understand module dependencies, complexity ratings, and risk factors
-  - Use Lore tools for authoritative dependency/symbol detail when available
+{{#if loreEnabled}}
+   - Use Lore tools for authoritative dependency/symbol detail.
+{{/if}}
   - {{> user-guidance-check}} They MUST be incorporated into every strategy you produce and propagated into `strategy.md` so that downstream agents (task-decomposer, code-migrator) honour them.
 
 2. **Generate Strategy Candidates**
@@ -107,8 +111,10 @@ Do not launch sub-agents directly from this agent. Runtime orchestrates `adjudic
 
 - **Do not read source code files** — rely entirely on the knowledge base and impact assessment.
 - Read only the knowledge base documents relevant to the current planning phase.
+{{#if loreEnabled}}
 - Use Lore tools for code-layout and dependency detail.
 - Treat KB markdown as decision context (architecture, risks, caveats), not as a full symbol/dependency inventory.
+{{/if}}
 - Write strategy and grouping artifacts incrementally and deterministically.
 
 ## Constraints

--- a/runtime/agents/templates/parity-failure-resolver.md
+++ b/runtime/agents/templates/parity-failure-resolver.md
@@ -1,5 +1,9 @@
 # Parity Failure Resolver
 
+{{#if loreEnabled}}
+{{> lore-index-first-principle}}
+{{/if}}
+
 You are the **Parity Failure Resolver** agent, invoked when a migration task cannot proceed cleanly (parity failure, build/test breakage, or blocked migration).
 
 {{> task-scope-awareness}}

--- a/runtime/agents/templates/parity-verifier.md
+++ b/runtime/agents/templates/parity-verifier.md
@@ -2,7 +2,9 @@
 
 You are the **Parity Verifier** — a read-only analysis agent that checks whether migrated code is behaviorally equivalent to the original source code. You produce a detailed parity report identifying any gaps, differences, or missing behavior.
 
+{{#if loreEnabled}}
 {{> lore-index-first-principle}}
+{{/if}}
 
 {{> task-scope-awareness}}
 
@@ -82,9 +84,11 @@ For each issue in the `issues` array:
 ## Context Window Management
 
 - Read the source file(s) and target file(s) specified in the task — nothing more.
-- When `taskScope.lineRange` is present, focus your comparison on the source lines in that range and the corresponding target code. Use Lore or targeted reads to resolve any types, constants, or helpers referenced by those lines — but do not load the entire file.
+- When `taskScope.lineRange` is present, focus your comparison on the source lines in that range and the corresponding target code. Use targeted reads to resolve any types, constants, or helpers referenced by those lines — but do not load the entire file.
 - For large files without a line range, use the knowledge base decomposition to focus on only the relevant chunk.
-- Use Lore tools for symbol/dependency lookups when available; read additional source snippets only when needed to confirm behavior.
+{{#if loreEnabled}}
+- Use Lore tools for symbol/dependency lookups; read additional source snippets only when needed to confirm behavior.
+{{/if}}
 - Compare declaration-by-declaration rather than trying to hold both entire files in memory simultaneously.
 - Process the comparison in passes:
   1. First pass: API surface (signatures only, lightweight)

--- a/runtime/agents/templates/task-decomposer.md
+++ b/runtime/agents/templates/task-decomposer.md
@@ -2,7 +2,9 @@
 
 You are the **Task Decomposer** for one module group in Phase 3.
 
+{{#if loreEnabled}}
 {{> lore-index-first-principle}}
+{{/if}}
 
 ## Inputs
 

--- a/runtime/agents/templates/test-writer.md
+++ b/runtime/agents/templates/test-writer.md
@@ -1,5 +1,9 @@
 # Test Writer
 
+{{#if loreEnabled}}
+{{> lore-index-first-principle}}
+{{/if}}
+
 ## Role
 Write unit and integration tests for changes made by the code-writer, following the project's existing test patterns.
 

--- a/runtime/src/agents/generator.ts
+++ b/runtime/src/agents/generator.ts
@@ -30,6 +30,14 @@ export interface GenerateOptions {
   outputDir: string;
   /** Override template directory (for testing). */
   templateDir?: string;
+  /**
+   * Extra variables forwarded to `resolvePartials()` for `{{var}}` interpolation
+   * and `{{#if var}}…{{/if}}` conditional blocks.
+   *
+   * The runtime sets `loreEnabled: 'true'` when the Lore KB index is configured,
+   * allowing templates to conditionally include Lore-related guidance.
+   */
+  vars?: Record<string, string>;
 }
 
 // ─── Front Matter Builders ───────────────────────────────────────────────────
@@ -72,10 +80,13 @@ function defaultTemplateDir(): string {
 const partialsCache = new Map<string, string>();
 
 /**
- * Resolve `{{> partial-name}}` directives in a template body.
+ * Resolve `{{> partial-name}}` directives and `{{#if var}}…{{/if}}` conditional
+ * blocks in a template body.
  *
- * Directives may appear on their own line or inline within text. The
- * referenced file is read from `<templateDir>/_partials/<name>.md`.
+ * Conditional blocks are evaluated **before** partial expansion so that an
+ * entire `{{> partial}}` reference can be gated on a variable.  A block is
+ * retained when `vars[var]` is a non-empty string; otherwise the block
+ * (including its delimiters) is stripped.
  *
  * After inclusion, simple `{{key}}` placeholders in the resolved text are
  * replaced using the provided `vars` map.
@@ -85,17 +96,34 @@ export async function resolvePartials(
   templateDir: string,
   vars: Record<string, string> = {},
 ): Promise<string> {
+  // ── 1. Evaluate {{#if var}} … {{/if}} conditional blocks ──────────────
+  // Process innermost blocks first (body must NOT contain another {{#if}}).
+  // Iterate until no more blocks remain, peeling nesting from the inside out.
+  let resolved = content;
+  const INNER_IF = /\{\{#if\s+([\w-]+)\s*\}\}((?:(?!\{\{#if\b)[\s\S])*?)\{\{\/if\}\}/g;
+  while (INNER_IF.test(resolved)) {
+    INNER_IF.lastIndex = 0;
+    resolved = resolved.replace(INNER_IF, (_match, varName: string, body: string) => {
+      return vars[varName] ? body : '';
+    });
+    INNER_IF.lastIndex = 0;
+  }
+
+  // Clean up blank lines left by stripped conditional blocks
+  resolved = resolved.replace(/\n{3,}/g, '\n\n');
+
+  // ── 2. Expand {{> partial-name}} directives ──────────────────────────
   const partialsDir = join(templateDir, '_partials');
   const partialPattern = /\{\{>\s*([\w-]+)\s*\}\}/g;
 
   // Collect all partial references first to allow parallel reads
   const names = new Set<string>();
   let m: RegExpExecArray | null;
-  while ((m = partialPattern.exec(content)) !== null) {
+  while ((m = partialPattern.exec(resolved)) !== null) {
     if (m[1]) names.add(m[1]);
   }
 
-  if (names.size === 0) return content;
+  if (names.size === 0) return resolved;
 
   // Load partials (with caching)
   const loaded = new Map<string, string>();
@@ -114,7 +142,7 @@ export async function resolvePartials(
   );
 
   // Replace directives with loaded content
-  let result = content.replace(
+  let result = resolved.replace(
     /\{\{>\s*([\w-]+)\s*\}\}/g,
     (_match, name: string) => loaded.get(name) ?? _match,
   );
@@ -194,9 +222,11 @@ export async function generateAgentDefinitions(options: GenerateOptions): Promis
 
     const rawTemplate = await readFile(join(templateDir, templateFile), 'utf-8');
 
-    // Resolve {{> partial}} directives and {{var}} placeholders
+    // Resolve {{#if}}…{{/if}} conditionals, {{> partial}} directives,
+    // and {{var}} placeholders
     const templateContent = await resolvePartials(rawTemplate, templateDir, {
       agentName,
+      ...options.vars,
     });
 
     const frontMatter = backend === 'claude-code'

--- a/runtime/src/core/runtime.ts
+++ b/runtime/src/core/runtime.ts
@@ -145,11 +145,15 @@ export class MigrationRuntime {
     // 7. Generate agent definition files from shared templates
     const settings = this.getActiveRuntimeSettings();
     const absAgentDir = resolve(this.projectRoot, settings.agentDir);
+    const loreEnabled = !!(this.config.options.kbIndex?.enabled);
     const generated = await generateAgentDefinitions({
       backend: this.config.agentBackend.runtime,
       outputDir: absAgentDir,
+      vars: {
+        ...(loreEnabled ? { loreEnabled: 'true' } : {}),
+      },
     });
-    this.logger.info(`Generated ${generated.length} agent definitions in ${settings.agentDir}`);
+    this.logger.info(`Generated ${generated.length} agent definitions in ${settings.agentDir} (loreEnabled=${loreEnabled})`);
 
     // 8. Validate agent files exist
     await this.validateAgentFiles();

--- a/runtime/tests/claude-agent-definitions.test.ts
+++ b/runtime/tests/claude-agent-definitions.test.ts
@@ -119,11 +119,11 @@ describe('Agent templates (runtime/agents/templates/)', () => {
       });
 
       it('should NOT contain inline duplicates of partial content', () => {
-        // If a template uses the lore-index-first-principle partial, the
-        // full 3-paragraph block should NOT also appear inline.
-        if (content.includes('{{> lore-index-first-principle}}')) {
+        // Templates reference partials via {{> name}} inside {{#if}} blocks.
+        // The partial body itself should NOT also appear verbatim in the template.
+        if (content.includes('lore-index-first-principle')) {
           expect(content).not.toContain(
-            'The AAMF runtime may start a **Lore** MCP server',
+            'You have access to the **Lore** MCP server',
           );
         }
         if (content.includes('{{> aamf-json-output-format}}')) {
@@ -336,6 +336,82 @@ describe('generateAgentDefinitions()', () => {
       expect(unresolvedVars, `Unresolved vars in "${agentName}": ${unresolvedVars}`).toBeNull();
     }
   });
+
+  it('should contain no unresolved conditional blocks in generated output', async () => {
+    for (const agentName of ALL_AGENT_NAMES) {
+      const content = await readFile(join(copilotDir, `${agentName}.agent.md`), 'utf-8');
+      expect(content, `Unresolved {{#if}} in "${agentName}"`).not.toMatch(/\{\{#if\s+[\w-]+\}\}/);
+      expect(content, `Unresolved {{/if}} in "${agentName}"`).not.toContain('{{/if}}');
+    }
+  });
+});
+
+// ─── Conditional Lore Injection Tests ────────────────────────────────────────
+
+describe('generateAgentDefinitions() with loreEnabled', () => {
+  let loreDirEnabled: string;
+  let loreDirDisabled: string;
+
+  beforeAll(async () => {
+    loreDirEnabled = await mkdtemp(join(tmpdir(), 'aamf-lore-on-'));
+    loreDirDisabled = await mkdtemp(join(tmpdir(), 'aamf-lore-off-'));
+
+    await generateAgentDefinitions({
+      backend: 'copilot',
+      outputDir: loreDirEnabled,
+      templateDir: TEMPLATE_DIR,
+      vars: { loreEnabled: 'true' },
+    });
+
+    await generateAgentDefinitions({
+      backend: 'copilot',
+      outputDir: loreDirDisabled,
+      templateDir: TEMPLATE_DIR,
+      // No loreEnabled var → conditional blocks stripped
+    });
+  });
+
+  afterAll(async () => {
+    await rm(loreDirEnabled, { recursive: true, force: true });
+    await rm(loreDirDisabled, { recursive: true, force: true });
+  });
+
+  it('should include Lore guidance when loreEnabled is set', async () => {
+    // code-migrator is a KB_AWARE agent with the lore partial
+    const content = await readFile(join(loreDirEnabled, 'code-migrator.agent.md'), 'utf-8');
+    expect(content).toContain('Lore Code-Intelligence Server (MANDATORY)');
+    expect(content).toContain('lore_search');
+    expect(content).toContain('lore_lookup');
+    expect(content).toContain('lore_graph');
+  });
+
+  it('should exclude Lore guidance when loreEnabled is not set', async () => {
+    const content = await readFile(join(loreDirDisabled, 'code-migrator.agent.md'), 'utf-8');
+    expect(content).not.toContain('Lore Code-Intelligence Server');
+    expect(content).not.toContain('lore_search');
+    expect(content).not.toContain('lore_lookup');
+  });
+
+  it('should include Lore guidance in all KB-aware agent templates when enabled', async () => {
+    const kbAwareAgents = [
+      'impact-assessor', 'knowledge-builder', 'migration-planner', 'adjudicator',
+      'code-migrator', 'parity-verifier', 'test-writer', 'parity-failure-resolver',
+      'final-parity-checker', 'e2e-test-crafter', 'documentation-writer',
+      'idiomatic-reviewer', 'idiomatic-refactorer', 'task-decomposer',
+    ];
+    for (const agent of kbAwareAgents) {
+      const content = await readFile(join(loreDirEnabled, `${agent}.agent.md`), 'utf-8');
+      expect(content, `${agent} should contain Lore guidance`).toContain('Lore Code-Intelligence Server (MANDATORY)');
+    }
+  });
+
+  it('should not contain any unresolved conditional blocks when loreEnabled is set', async () => {
+    for (const agentName of ALL_AGENT_NAMES) {
+      const content = await readFile(join(loreDirEnabled, `${agentName}.agent.md`), 'utf-8');
+      expect(content, `Unresolved {{#if}} in "${agentName}"`).not.toMatch(/\{\{#if\s+[\w-]+\}\}/);
+      expect(content, `Unresolved {{/if}} in "${agentName}"`).not.toContain('{{/if}}');
+    }
+  });
 });
 
 // ─── stripSchemaSections unit tests ──────────────────────────────────────────
@@ -479,5 +555,67 @@ describe('resolvePartials()', () => {
     const input = 'Some text {{> greeting}} more text';
     const result = await resolvePartials(input, tmpTemplateDir);
     expect(result).toBe('Some text Hello, world! more text');
+  });
+
+  // ─── {{#if var}} conditional block tests ─────────────────────────────
+
+  it('should retain {{#if}} block content when variable is truthy', async () => {
+    const input = 'Before\n{{#if flag}}Included\n{{/if}}\nAfter';
+    const result = await resolvePartials(input, tmpTemplateDir, { flag: 'true' });
+    expect(result).toContain('Included');
+    expect(result).toContain('Before');
+    expect(result).toContain('After');
+    expect(result).not.toContain('{{#if');
+    expect(result).not.toContain('{{/if}}');
+  });
+
+  it('should strip {{#if}} block content when variable is missing', async () => {
+    const input = 'Before\n{{#if flag}}Removed\n{{/if}}\nAfter';
+    const result = await resolvePartials(input, tmpTemplateDir);
+    expect(result).not.toContain('Removed');
+    expect(result).toContain('Before');
+    expect(result).toContain('After');
+    expect(result).not.toContain('{{#if');
+    expect(result).not.toContain('{{/if}}');
+  });
+
+  it('should strip {{#if}} block content when variable is empty string', async () => {
+    const input = 'Before\n{{#if flag}}Removed\n{{/if}}\nAfter';
+    const result = await resolvePartials(input, tmpTemplateDir, { flag: '' });
+    expect(result).not.toContain('Removed');
+  });
+
+  it('should handle nested {{#if}} blocks', async () => {
+    const input = '{{#if a}}A-start {{#if b}}B-inner{{/if}} A-end{{/if}}';
+    const result = await resolvePartials(input, tmpTemplateDir, { a: 'yes', b: 'yes' });
+    expect(result).toContain('A-start');
+    expect(result).toContain('B-inner');
+    expect(result).toContain('A-end');
+  });
+
+  it('should strip inner block when nested variable is missing', async () => {
+    const input = '{{#if a}}A-start {{#if b}}B-inner{{/if}} A-end{{/if}}';
+    const result = await resolvePartials(input, tmpTemplateDir, { a: 'yes' });
+    expect(result).toContain('A-start');
+    expect(result).not.toContain('B-inner');
+    expect(result).toContain('A-end');
+  });
+
+  it('should expand partial inside a conditional block when variable is truthy', async () => {
+    const input = '{{#if flag}}\n{{> greeting}}\n{{/if}}';
+    const result = await resolvePartials(input, tmpTemplateDir, { flag: 'true' });
+    expect(result).toContain('Hello, world!');
+  });
+
+  it('should skip partial inside a conditional block when variable is missing', async () => {
+    const input = '{{#if flag}}\n{{> greeting}}\n{{/if}}';
+    const result = await resolvePartials(input, tmpTemplateDir);
+    expect(result).not.toContain('Hello, world!');
+  });
+
+  it('should not leave excessive blank lines after stripping conditional blocks', async () => {
+    const input = 'A\n\n{{#if flag}}\nRemoved\n{{/if}}\n\nB';
+    const result = await resolvePartials(input, tmpTemplateDir);
+    expect(result).not.toMatch(/\n{3,}/);
   });
 });


### PR DESCRIPTION
## Summary

Replace the static, hedging Lore partial ("may start", "when available") with definitive, tool-specific guidance that is **only injected when the KB index is enabled** in the migration config.

Previously, every generated agent definition included soft Lore language regardless of whether Lore was configured — and agents ignored it entirely (zero `lore_search` calls observed in real migrations). This PR fixes both problems: the language is now strong enough to compel tool use, and it's omitted entirely when Lore isn't available.

## Changes

### Generator (`generator.ts`)
- Add `{{#if var}}…{{/if}}` conditional block support to `resolvePartials()`, processing innermost blocks first to handle nesting correctly
- Add optional `vars` to `GenerateOptions`, forwarded to `resolvePartials()`

### Runtime (`runtime.ts`)
- Pass `loreEnabled='true'` when `config.options.kbIndex.enabled` is set

### Lore partial (`_partials/lore-index-first-principle.md`)
- Title: **"Lore Code-Intelligence Server (MANDATORY)"**
- Lists all 17 Lore tools by name with purpose descriptions in a table
- Prescribes a required workflow: search/lookup before file reads
- Uses definitive language ("You MUST use", not "prefer")

### Agent templates (16 files)
- Wrap all `{{> lore-index-first-principle}}` in `{{#if loreEnabled}}` blocks
- Wrap scattered inline Lore references in conditionals too
- Add the partial to `adjudicator`, `test-writer`, `parity-failure-resolver` (were in `KB_AWARE_AGENTS` but had no Lore prompt)
- Remove "when available" hedging from inline Lore references

### Tests
- 9 new tests for `{{#if}}` conditional blocks (truthy, falsy, empty string, nested, partial-inside-conditional, blank-line cleanup)
- 4 new generation tests verifying Lore content appears with `loreEnabled` and is absent without it
- Verify all 14 KB-aware agents include Lore guidance when enabled

## Why

Agents were ignoring the Lore MCP server because:
1. Templates said "**may** start" — the model read this as optional
2. No concrete tool names were listed — the model had to discover tools, which it skipped
3. Hedging language ("prefer Lore tools", "when available") gave the model an easy fallback to `read_file`
4. Three KB-aware agents (`adjudicator`, `test-writer`, `parity-failure-resolver`) had zero Lore prompting despite getting the MCP config wired in