### PR TITLE
fix(checkpoint): clear stale failedTasks entry after successful retry

### DIFF
--- a/runtime/src/core/checkpoint.ts
+++ b/runtime/src/core/checkpoint.ts
@@ -239,6 +239,16 @@ export class CheckpointManager {
     await this.save(state);
   }
 
+  /** Remove a task from failedTasks (e.g. after a retry succeeds). */
+  async clearFailedTask(taskId: string): Promise<void> {
+    const state = this.getState();
+    const before = state.failedTasks.length;
+    state.failedTasks = state.failedTasks.filter(f => f.taskId !== taskId);
+    if (state.failedTasks.length < before) {
+      await this.save(state);
+    }
+  }
+
   /** Record a task failure */
   async failTask(taskId: string, error: string, attempt: number, recoveryAttempted: boolean): Promise<void> {
     const state = this.getState();

--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -2068,6 +2068,9 @@ export class MigrationOrchestrator {
         });
       }
 
+      // Clear any stale failedTasks entry left by intermediate retry failures
+      await this.checkpoint.clearFailedTask(task.id);
+
       completionEventDurationMs = migratorResult.duration;
       await this.markPhase5Substep(task.id, 'migrator');
     }


### PR DESCRIPTION
## Bug

When a code-migrator retry succeeds after intermediate failures, the `failedTasks` checkpoint entry recorded by `onFailedAttempt` is not cleared until `completeTask()` runs at the very end of the task pipeline (after parity, tests, quality gates, etc.).

If the process is interrupted between the successful retry and the final `completeTask()` — which can be hours later — the stale entry persists, making the task appear permanently failed despite all substeps having completed successfully.

**Observed in production:** task-43-0 in the zstd-to-rust migration had all 5 substeps completed (`migrator`, `migrator-commit`, `parity-tests`, `parity-gate`, `minor-parity-repass`) but was listed in `failedTasks` with an error from the initial code-migrator attempt (malformed JSON). The task was not in `completedTasks`.

## Fix

- Add `checkpoint.clearFailedTask(taskId)` method that removes a task from `failedTasks`
- Call it immediately after a successful retry result, before proceeding to subsequent substeps

This ensures the `failedTasks` entry has the correct lifecycle: written on failure, cleared on retry success, not left dangling until eventual task completion.