### PR TITLE
feat(progress): update progress.md per-task instead of per-wave

### DIFF
--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -472,7 +472,7 @@ export class MigrationOrchestrator {
           }
         }
 
-        this.progress.setTokenUsage(this.tokenTracker.toCheckpointData());
+        await this.progress.setTokenUsage(this.tokenTracker.toCheckpointData());
       }
     } finally {
       // Always stop the KB server and dispose the embedder, whether migration succeeded, failed, or was aborted
@@ -2345,6 +2345,13 @@ export class MigrationOrchestrator {
     }
 
     if (mode === 'wave-migration') {
+      // In wave-barrier mode, completePhase5Task runs later (after the wave
+      // barrier releases).  Update progress now so observers see that the
+      // task's core migration substeps are done.
+      await this.progress.updateTask(task.id, 'migrated', {
+        sourceFiles: task.sourceFiles,
+        targetFiles: task.targetFiles,
+      });
       return { migrated: true, durationMs: Date.now() - taskStartMs };
     }
 
@@ -4105,6 +4112,9 @@ export class MigrationOrchestrator {
       // Sync token snapshot to checkpoint state so the next save() persists accurate data
       const state = this.checkpoint.getState();
       state.tokenUsage = this.tokenTracker.toCheckpointData();
+      // Keep progress.md token display in sync (fire-and-forget; the next
+      // progress.updateTask call will also flush to disk)
+      void this.progress.setTokenUsage(this.tokenTracker.toCheckpointData());
     }
   }
 

--- a/runtime/src/core/progress.ts
+++ b/runtime/src/core/progress.ts
@@ -131,9 +131,10 @@ export class ProgressWriter {
     await this.writeCurrentState();
   }
 
-  /** Update token usage with full breakdown */
-  setTokenUsage(data: { total: number; byPhase: Record<number, number>; byAgent: Record<string, number> }): void {
+  /** Update token usage with full breakdown and flush to disk */
+  async setTokenUsage(data: { total: number; byPhase: Record<number, number>; byAgent: Record<string, number> }): Promise<void> {
     this.tokenUsage = { total: data.total, byPhase: { ...data.byPhase }, byAgent: { ...data.byAgent } };
+    await this.writeCurrentState();
   }
 
   /** Append a timestamped event */
@@ -269,11 +270,17 @@ export class ProgressWriter {
     // Task progress bar (Phase 5)
     if (this.totalTasks > 0) {
       md += `## Task Progress\n\n`;
-      const pct = this.totalTasks > 0 ? Math.round((completedTasks / this.totalTasks) * 100) : 0;
+      const migratedTasks = [...this.tasks.values()].filter(t => t.status === 'migrated').length;
+      const doneTasks = completedTasks + migratedTasks;
+      const pct = this.totalTasks > 0 ? Math.round((doneTasks / this.totalTasks) * 100) : 0;
       const filled = Math.round(pct / 5);
       const empty = 20 - filled;
       const bar = '█'.repeat(filled) + '░'.repeat(empty);
-      md += `[${bar}] ${pct}% (${completedTasks}/${this.totalTasks} tasks)\n\n`;
+      if (migratedTasks > 0 && migratedTasks !== doneTasks) {
+        md += `[${bar}] ${pct}% (${completedTasks} completed, ${migratedTasks} migrated / ${this.totalTasks} tasks)\n\n`;
+      } else {
+        md += `[${bar}] ${pct}% (${doneTasks}/${this.totalTasks} tasks)\n\n`;
+      }
 
       // Failed/blocked tasks
       const failed = [...this.tasks.entries()].filter(([_, t]) => t.status === 'failed');


### PR DESCRIPTION
## Problem

In wave-barrier mode, `progress.md` showed `0% (0/286 tasks)` even after 65 tasks completed all core migration substeps. This happened because:

1. `completePhase5Task()` — the only place that marks tasks "completed" in progress — only runs after the wave barrier releases. If the run is interrupted by terminal exhaustion before the barrier, no tasks are ever marked completed.
2. Token usage in `progress.md` was stale — `setTokenUsage()` only updated in-memory state without flushing to disk, and was only called once per phase boundary.

## Fix

1. **Mark tasks "migrated" after core substeps** — In wave-barrier mode, call `progress.updateTask(task.id, 'migrated')` after migrator/parity/test/gate/repass complete, before the wave barrier. This gives immediate visibility into task progress.

2. **Flush token usage to disk** — `setTokenUsage()` is now async and writes to disk. `recordTokens()` syncs to the progress writer on every agent invocation (fire-and-forget).

3. **Count "migrated" tasks in progress bar** — The bar now shows both completed and migrated tasks, e.g. `23% (0 completed, 65 migrated / 286 tasks)`.