### PR TITLE
feat(core): pre-extract code snippets into parity-failure-resolver context

### DIFF
--- a/runtime/agents/templates/parity-failure-resolver.md
+++ b/runtime/agents/templates/parity-failure-resolver.md
@@ -22,9 +22,9 @@ Resolve the failing task quickly and safely by:
 ## Required Process
 
 1. **Diagnose**
-        - Read the parity issues provided in `context.agentPayload.remediationContext.parityIssues` — a JSON array of `{ severity, description, details, sourceLocation, targetLocation? }` objects. Use your file-read tools to inspect the cited source and target locations.
-        - Read the referenced source/target files and relevant context artifacts.
+        - Read the parity issues provided in `context.agentPayload.remediationContext.parityIssues` — a JSON array of `{ severity, description, details, sourceLocation, targetLocation?, sourceSnippet?, targetSnippet? }` objects. Each issue includes pre-extracted `sourceSnippet` and `targetSnippet` fields containing the relevant code with line numbers — use these directly instead of reading the full source/target files.
         - Identify the most likely root cause in one concise sentence.
+        - Only read additional file sections if the pre-extracted snippets are insufficient for your fix.
         - Do NOT write any markdown report file. All output goes into the `aamf-json` block.
 2. **Evaluate Strategies**
 	- Propose at least 2 strategies (e.g., direct fix, scope reduction, compatibility shim, decomposition).

--- a/runtime/package-lock.json
+++ b/runtime/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aamf-runtime",
       "version": "0.1.0",
       "dependencies": {
-        "@aamf/lore": "npm:@jafreck/lore@^0.3.4",
+        "@aamf/lore": "npm:@jafreck/lore@^0.3.6",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@types/better-sqlite3": "^7.6.13",
         "better-sqlite3": "^12.6.2",
@@ -36,11 +36,12 @@
     },
     "node_modules/@aamf/lore": {
       "name": "@jafreck/lore",
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@jafreck/lore/-/lore-0.3.4.tgz",
-      "integrity": "sha512-O0qY7qXsQ63+FFDEvauQd38O6WK7IRTXOPq+/hwzqQrEhrrWqgolS/BE0ti5sJWwoZRV5EC8lpudj8GHvXB0PA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@jafreck/lore/-/lore-0.3.6.tgz",
+      "integrity": "sha512-D+WwUwHLKIgR4aYIM7V/GKa+Iq2s6iO14DX0m97PYkwnTqpBbBGYdFdgmXIPaDjc5D+Kn17xHyxOH2nAONGmVQ==",
       "license": "MIT",
       "dependencies": {
+        "@bufbuild/protobuf": "^2.11.0",
         "@elm-tooling/tree-sitter-elm": "^5.9.0",
         "@huggingface/transformers": "^3.8.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -483,6 +484,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
+      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.8.1",

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -15,7 +15,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@aamf/lore": "npm:@jafreck/lore@^0.3.4",
+    "@aamf/lore": "npm:@jafreck/lore@^0.3.6",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@types/better-sqlite3": "^7.6.13",
     "better-sqlite3": "^12.6.2",

--- a/runtime/src/agents/types.ts
+++ b/runtime/src/agents/types.ts
@@ -280,6 +280,10 @@ export interface AgentRemediationContext {
     details: string;
     sourceLocation: string;
     targetLocation?: string;
+    /** Pre-extracted source code snippet for the cited sourceLocation. */
+    sourceSnippet?: string;
+    /** Pre-extracted target code snippet for the cited targetLocation. */
+    targetSnippet?: string;
   }>;
   /** Outcomes of prior recovery attempts, enabling the agent to avoid repeating failed strategies. */
   priorAttempts?: PriorRecoveryAttempt[];

--- a/runtime/src/core/orchestrator.ts
+++ b/runtime/src/core/orchestrator.ts
@@ -12,6 +12,7 @@ import {
   AgentInvocation,
   AgentResult,
   AgentName,
+  AgentRemediationContext,
   MigrationResult,
   MigrationTask,
   CompilationUnit,
@@ -2157,6 +2158,7 @@ export class MigrationOrchestrator {
 
           // Attach structured parity issues and prior attempt history
           parityRemediation.parityIssues = parityIssues;
+          this.enrichParityIssuesWithSnippets(parityRemediation.parityIssues);
           if (priorAttempts.length > 0) {
             parityRemediation.priorAttempts = [...priorAttempts];
           }
@@ -3516,6 +3518,7 @@ export class MigrationOrchestrator {
             expectedSuccessCondition: `Parity checks pass (or only minor issues) for ${task.id}`,
           });
           parityRemediation.parityIssues = parityIssues;
+          this.enrichParityIssuesWithSnippets(parityRemediation.parityIssues);
 
           // parity-failure-resolver
           const recoveryCtx = await this.contextBuilder.buildContext(
@@ -3603,6 +3606,65 @@ export class MigrationOrchestrator {
   }
 
   // ─── Helpers ─────────────────────────────────────────────────────────
+
+  /**
+   * Extract source/target code snippets for each parity issue and attach them
+   * directly to the issue objects.  This lets the parity-failure-resolver see
+   * the relevant code without reading entire files, dramatically reducing
+   * token usage on large target files.
+   */
+  private enrichParityIssuesWithSnippets(
+    issues: NonNullable<AgentRemediationContext['parityIssues']>,
+  ): void {
+    for (const issue of issues) {
+      if (issue.sourceLocation) {
+        issue.sourceSnippet = this.extractSnippet(issue.sourceLocation);
+      }
+      if (issue.targetLocation) {
+        issue.targetSnippet = this.extractSnippet(issue.targetLocation);
+      }
+    }
+  }
+
+  /**
+   * Parse a location string like `"path/to/file.c:100-120"` and extract those
+   * lines from the file on disk.  Returns undefined if the file or range can't
+   * be read.
+   */
+  private extractSnippet(location: string): string | undefined {
+    // Format: "relative/path:startLine-endLine" or "relative/path:line"
+    const colonIdx = location.lastIndexOf(':');
+    if (colonIdx === -1) return undefined;
+
+    const relPath = location.substring(0, colonIdx);
+    const rangeStr = location.substring(colonIdx + 1);
+    const filePath = resolve(this.projectRoot, relPath);
+
+    let startLine: number;
+    let endLine: number;
+    const dashIdx = rangeStr.indexOf('-');
+    if (dashIdx !== -1) {
+      startLine = parseInt(rangeStr.substring(0, dashIdx), 10);
+      endLine = parseInt(rangeStr.substring(dashIdx + 1), 10);
+    } else {
+      startLine = parseInt(rangeStr, 10);
+      endLine = startLine;
+    }
+    if (isNaN(startLine) || isNaN(endLine)) return undefined;
+
+    // Add a few lines of context on each side
+    const ctxLines = 5;
+    const from = Math.max(1, startLine - ctxLines);
+    const to = endLine + ctxLines;
+
+    try {
+      const content = readFileSync(filePath, 'utf-8');
+      const lines = content.split('\n');
+      return lines.slice(from - 1, to).map((l, i) => `${from + i}: ${l}`).join('\n');
+    } catch {
+      return undefined;
+    }
+  }
 
   /**
    * Check whether the parity-failure-resolver determined that remaining


### PR DESCRIPTION
## Summary

Pre-extract source and target code snippets into the parity-failure-resolver's context payload, eliminating the need for the agent to read entire files to understand parity issues.

### Problem

The parity-failure-resolver agent receives precise line locations for each parity issue (e.g., `src:minigzip.c:254-283`, `tgt:minigzip.rs:1686-1718`) but ignores them — instead reading entire source/target files via tool calls. For a 2,563-line target file, this wastes ~60K tokens per issue on file reads that could be ~2K tokens of targeted snippets.

### Solution

The orchestrator now reads the exact line ranges cited in each parity issue and embeds them as `sourceSnippet` / `targetSnippet` fields directly in the `parityIssues` array. Each snippet includes 5 lines of surrounding context with line numbers.

When the agent reads its context JSON (always the first thing it does), the relevant code is already there — no file reads needed for diagnosis.

### Changes

- Added `sourceSnippet` and `targetSnippet` optional fields to the parity issue type in `AgentRemediationContext`
- Added `enrichParityIssuesWithSnippets()` and `extractSnippet()` helpers to the orchestrator
- Wired enrichment into both parity retry loops (main per-task and wave-barrier batch)
- Updated parity-failure-resolver template to reference the new snippet fields and prefer them over file reads