### PR TITLE
feat(core): capture structured JSONL events from copilot CLI

### DIFF
--- a/runtime/src/agents/types.ts
+++ b/runtime/src/agents/types.ts
@@ -146,6 +146,20 @@ export interface AgentResult {
 
   /** Time in milliseconds from process spawn to the first output file being detected. */
   spawnToFirstOutput?: number;
+
+  /** Structured event data from `copilot --output-format json`, when available. */
+  copilotEvents?: {
+    totalEvents: number;
+    toolCalls: Array<{ name: string; status: string }>;
+    resultSummary?: {
+      exitCode: number;
+      premiumRequests?: number;
+      totalApiDurationMs?: number;
+      sessionDurationMs?: number;
+      codeChanges?: { linesAdded: number; linesRemoved: number; filesModified: string[] };
+    };
+    errorCount: number;
+  };
 }
 
 // ─── Agent Context ───────────────────────────────────────────────────────────

--- a/runtime/src/core/agent-launcher.ts
+++ b/runtime/src/core/agent-launcher.ts
@@ -50,6 +50,7 @@ function copilotDescriptor(config: MigrationConfig): CliBackendDescriptor {
         '--allow-all-tools',
         '--allow-all-paths',
         '--no-ask-user',
+        '--output-format', 'json',
       ];
       if (model) args.push('--model', model);
       if (cfg.source.path) args.push('--add-dir', cfg.source.path);
@@ -131,14 +132,136 @@ function stripVSCodeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return stripped;
 }
 
+// ─── Copilot JSONL event parsing ──────────────────────────────────────────────
+
+/** A single JSONL event emitted by `copilot --output-format json`. */
+interface CopilotEvent {
+  type: string;
+  data?: Record<string, unknown>;
+  id?: string;
+  timestamp?: string;
+  [key: string]: unknown;
+}
+
+/** Summary extracted from the copilot `result` event. */
+interface CopilotResultSummary {
+  exitCode: number;
+  premiumRequests?: number;
+  totalApiDurationMs?: number;
+  sessionDurationMs?: number;
+  codeChanges?: { linesAdded: number; linesRemoved: number; filesModified: string[] };
+}
+
+/**
+ * Parse copilot JSONL stdout into structured events and reconstruct the
+ * text content the agent produced (for backward-compatible aamf-json parsing).
+ */
+function parseCopilotJsonl(stdout: string): {
+  events: CopilotEvent[];
+  textContent: string;
+  toolCalls: Array<{ name: string; status: string }>;
+  resultSummary: CopilotResultSummary | undefined;
+  errorEvents: CopilotEvent[];
+} {
+  const events: CopilotEvent[] = [];
+  const toolCalls: Array<{ name: string; status: string }> = [];
+  const errorEvents: CopilotEvent[] = [];
+  let resultSummary: CopilotResultSummary | undefined;
+  let textContent = '';
+
+  for (const line of stdout.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line);
+      // Only treat as a copilot event if it has the expected `type` field.
+      // Otherwise it's likely text-mode output that happens to be valid JSON
+      // (e.g., an aamf-json payload line).
+      if (typeof parsed !== 'object' || parsed === null || typeof parsed.type !== 'string') {
+        textContent += line + '\n';
+        continue;
+      }
+      const event = parsed as CopilotEvent;
+      events.push(event);
+
+      switch (event.type) {
+        case 'assistant.message': {
+          const data = event.data as { content?: string } | undefined;
+          if (data?.content) textContent += data.content;
+          break;
+        }
+        case 'assistant.tool_call': {
+          const data = event.data as { toolName?: string } | undefined;
+          if (data?.toolName) toolCalls.push({ name: data.toolName, status: 'called' });
+          break;
+        }
+        case 'assistant.tool_call_result': {
+          const data = event.data as { toolName?: string; status?: string } | undefined;
+          if (data?.toolName) toolCalls.push({ name: data.toolName, status: data.status ?? 'completed' });
+          break;
+        }
+        case 'result': {
+          const data = event as { exitCode?: number; usage?: Record<string, unknown> };
+          const usage = data.usage as {
+            premiumRequests?: number;
+            totalApiDurationMs?: number;
+            sessionDurationMs?: number;
+            codeChanges?: { linesAdded: number; linesRemoved: number; filesModified: string[] };
+          } | undefined;
+          resultSummary = {
+            exitCode: data.exitCode ?? -1,
+            premiumRequests: usage?.premiumRequests,
+            totalApiDurationMs: usage?.totalApiDurationMs,
+            sessionDurationMs: usage?.sessionDurationMs,
+            codeChanges: usage?.codeChanges,
+          };
+          break;
+        }
+        case 'error': {
+          errorEvents.push(event);
+          break;
+        }
+      }
+    } catch {
+      // Not valid JSON — may be text-mode output if --output-format json wasn't applied.
+      textContent += line + '\n';
+    }
+  }
+
+  return { events, textContent, toolCalls, resultSummary, errorEvents };
+}
+
+/** Produce a human-readable summary of tool calls for logging. */
+function summarizeToolCalls(toolCalls: Array<{ name: string; status: string }>): string {
+  const counts = new Map<string, number>();
+  for (const tc of toolCalls) {
+    counts.set(tc.name, (counts.get(tc.name) ?? 0) + 1);
+  }
+  return [...counts.entries()].map(([name, count]) => `${name}(${count})`).join(', ');
+}
+
+/** Convert a copilot result summary to the internal TokenUsage shape. */
+function tokenUsageFromResult(summary: CopilotResultSummary): AgentResult['tokenUsage'] | undefined {
+  // The copilot result event doesn't provide raw token counts, only premium
+  // requests and timing.  We return undefined so the caller falls back to
+  // the text-based token parser which does extract per-model token counts.
+  return undefined;
+}
+
 /** Shared helper: write stdout/stderr to a per-agent log file. */
-async function writeAgentLog(logDir: string, agent: string, taskId: string, stdout: string, stderr: string, invocationId?: string): Promise<void> {
+async function writeAgentLog(logDir: string, agent: string, taskId: string, stdout: string, stderr: string, invocationId?: string, events?: CopilotEvent[]): Promise<void> {
   const targetDir = join(logDir, agent, taskId);
   await ensureDir(targetDir);
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
   const filename = invocationId ? `${invocationId}-${timestamp}.log` : `${timestamp}.log`;
   const content = `=== STDOUT ===\n${stdout}\n\n=== STDERR ===\n${stderr}\n`;
   await atomicWrite(join(targetDir, filename), content);
+
+  // Write structured JSONL event log when available.
+  if (events && events.length > 0) {
+    const eventsFilename = invocationId ? `${invocationId}-${timestamp}.events.jsonl` : `${timestamp}.events.jsonl`;
+    const eventsContent = events.map(e => JSON.stringify(e)).join('\n') + '\n';
+    await atomicWrite(join(targetDir, eventsFilename), eventsContent);
+  }
 }
 
 // ─── Live output streaming ────────────────────────────────────────────────────
@@ -357,8 +480,7 @@ export class CliAgentRunner implements AgentRunner {
     if (invocation.taskId) env.AAMF_TASK_ID = invocation.taskId;
 
     const startTime = Date.now();
-    invLogger.info(`Launching CLI agent: ${cliCommand} --agent ${invocation.agent}`);
-    invLogger.debug(`Full CLI command: ${cliCommand} ${args.join(' ')}`);
+    invLogger.info(`Launching CLI agent: ${cliCommand} ${args.join(' ')}`);
 
     // ── Heartbeat & output-directory watcher ─────────────────────────
     const HEARTBEAT_INTERVAL_MS = 30_000;
@@ -430,14 +552,35 @@ export class CliAgentRunner implements AgentRunner {
       await liveCallbacks.flush();
       const duration = Date.now() - startTime;
 
+      // Parse JSONL events when copilot outputs structured JSON.
+      const parsed = parseCopilotJsonl(result.stdout);
+      // Use reconstructed text content for aamf-json extraction (backward compat).
+      const stdoutForParsing = parsed.textContent || result.stdout;
+
       const taskId = invocation.taskId ?? 'main';
-      await writeAgentLog(this.logDir, invocation.agent, taskId, result.stdout, result.stderr, invocationId);
+      await writeAgentLog(this.logDir, invocation.agent, taskId, result.stdout, result.stderr, invocationId, parsed.events);
+
+      if (parsed.toolCalls.length > 0) {
+        const toolSummary = summarizeToolCalls(parsed.toolCalls);
+        invLogger.info(`Agent tool calls: ${toolSummary}`);
+      }
+      if (parsed.errorEvents.length > 0) {
+        for (const errEvt of parsed.errorEvents) {
+          invLogger.warn(`Agent error event: ${JSON.stringify(errEvt.data)}`);
+        }
+      }
 
       const outputFiles = await detectOutputFiles(invocation);
-      const tokenUsage = parseTokenUsage(
-        result.stdout + '\n' + result.stderr,
-        this.backend.tokenParserRuntime,
-      );
+      // Prefer structured usage from the copilot result event when available.
+      let tokenUsage = parsed.resultSummary
+        ? tokenUsageFromResult(parsed.resultSummary)
+        : undefined;
+      if (!tokenUsage) {
+        tokenUsage = parseTokenUsage(
+          result.stdout + '\n' + result.stderr,
+          this.backend.tokenParserRuntime,
+        );
+      }
 
       const agentResult: AgentResult = {
         agent: invocation.agent,
@@ -456,9 +599,15 @@ export class CliAgentRunner implements AgentRunner {
             ? result.stderr || `Exit code ${result.exitCode}`
             : undefined,
         stderr: (result.killed || result.exitCode !== 0) ? result.stderr : undefined,
+        copilotEvents: parsed.events.length > 0 ? {
+          totalEvents: parsed.events.length,
+          toolCalls: parsed.toolCalls,
+          resultSummary: parsed.resultSummary,
+          errorCount: parsed.errorEvents.length,
+        } : undefined,
       };
 
-      return finaliseResult(agentResult, result.stdout, prompt, invLogger);
+      return finaliseResult(agentResult, stdoutForParsing, prompt, invLogger);
     } catch (err) {
       stopTimers();
       await liveCallbacks.flush().catch(() => {});

--- a/runtime/tests/agent-launcher.test.ts
+++ b/runtime/tests/agent-launcher.test.ts
@@ -1126,4 +1126,119 @@ describe('AgentLauncher', () => {
       expect(liveContent).not.toContain('[stderr]');
     });
   });
+
+  // ─── Copilot JSONL event parsing ────────────────────────────────────────────
+
+  describe('copilot JSONL event parsing', () => {
+    it('should parse JSONL stdout, extract text content, and write .events.jsonl log', async () => {
+      const events = [
+        JSON.stringify({ type: 'session.tools_updated', data: { model: 'test' }, id: '1', timestamp: new Date().toISOString() }),
+        JSON.stringify({ type: 'assistant.message', data: { content: 'hello world' }, id: '2', timestamp: new Date().toISOString() }),
+        JSON.stringify({ type: 'result', exitCode: 0, usage: { premiumRequests: 1, totalApiDurationMs: 500, sessionDurationMs: 1000, codeChanges: { linesAdded: 0, linesRemoved: 0, filesModified: [] } }, timestamp: new Date().toISOString() }),
+      ];
+      const script = await createScript('jsonl-output.sh', events.map(e => `echo '${e}'`).join('\n') + '\nexit 0');
+      const launcher = makeLauncher(script);
+      const { contextFile, progressDir } = await prepareInvocation('jsonl-001');
+
+      const result = await launcher.launchAgent({
+        agent: 'code-migrator',
+        contextFile,
+        progressDir,
+        phase: 5,
+        taskId: 'jsonl-001',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.copilotEvents).toBeDefined();
+      expect(result.copilotEvents!.totalEvents).toBe(3);
+      expect(result.copilotEvents!.resultSummary).toBeDefined();
+      expect(result.copilotEvents!.resultSummary!.premiumRequests).toBe(1);
+      expect(result.copilotEvents!.resultSummary!.sessionDurationMs).toBe(1000);
+
+      // Should have written .events.jsonl
+      const agentLogDir = join(projectRoot, '.aamf', 'migration', config.projectName, 'logs', 'agents', 'code-migrator', 'jsonl-001');
+      const logFiles = await readdir(agentLogDir);
+      const eventsLog = logFiles.find(f => f.endsWith('.events.jsonl'));
+      expect(eventsLog).toBeDefined();
+
+      const eventsContent = await readFile(join(agentLogDir, eventsLog!), 'utf-8');
+      const eventLines = eventsContent.trim().split('\n');
+      expect(eventLines.length).toBe(3);
+    });
+
+    it('should extract tool calls from JSONL events', async () => {
+      const events = [
+        JSON.stringify({ type: 'assistant.tool_call', data: { toolName: 'read_file' }, id: '1', timestamp: new Date().toISOString() }),
+        JSON.stringify({ type: 'assistant.tool_call_result', data: { toolName: 'read_file', status: 'completed' }, id: '2', timestamp: new Date().toISOString() }),
+        JSON.stringify({ type: 'assistant.tool_call', data: { toolName: 'run_in_terminal' }, id: '3', timestamp: new Date().toISOString() }),
+        JSON.stringify({ type: 'assistant.message', data: { content: 'done' }, id: '4', timestamp: new Date().toISOString() }),
+        JSON.stringify({ type: 'result', exitCode: 0, usage: { premiumRequests: 1 }, timestamp: new Date().toISOString() }),
+      ];
+      const script = await createScript('jsonl-tools.sh', events.map(e => `echo '${e}'`).join('\n') + '\nexit 0');
+      const launcher = makeLauncher(script);
+      const { contextFile, progressDir } = await prepareInvocation('jsonl-tools-001');
+
+      const result = await launcher.launchAgent({
+        agent: 'code-migrator',
+        contextFile,
+        progressDir,
+        phase: 5,
+        taskId: 'jsonl-tools-001',
+      });
+
+      expect(result.copilotEvents).toBeDefined();
+      expect(result.copilotEvents!.toolCalls.length).toBe(3);
+      expect(result.copilotEvents!.toolCalls[0]).toEqual({ name: 'read_file', status: 'called' });
+      expect(result.copilotEvents!.toolCalls[1]).toEqual({ name: 'read_file', status: 'completed' });
+      expect(result.copilotEvents!.toolCalls[2]).toEqual({ name: 'run_in_terminal', status: 'called' });
+    });
+
+    it('should capture error events from JSONL output', async () => {
+      const events = [
+        JSON.stringify({ type: 'error', data: { message: 'Connection reset', code: 503 }, id: '1', timestamp: new Date().toISOString() }),
+        JSON.stringify({ type: 'result', exitCode: 1, usage: { premiumRequests: 0 }, timestamp: new Date().toISOString() }),
+      ];
+      const script = await createScript('jsonl-error.sh', events.map(e => `echo '${e}'`).join('\n') + '\nexit 1');
+      const launcher = makeLauncher(script);
+      const { contextFile, progressDir } = await prepareInvocation('jsonl-error-001');
+
+      const result = await launcher.launchAgent({
+        agent: 'code-migrator',
+        contextFile,
+        progressDir,
+        phase: 5,
+        taskId: 'jsonl-error-001',
+      });
+
+      expect(result.copilotEvents).toBeDefined();
+      expect(result.copilotEvents!.errorCount).toBe(1);
+    });
+
+    it('should handle mixed text and JSONL output gracefully', async () => {
+      const aamfBlock = JSON.stringify({ status: 'completed', agent: 'code-migrator' });
+      const script = await createScript('jsonl-mixed.sh', [
+        `echo 'plain text line'`,
+        `echo '${JSON.stringify({ type: 'assistant.message', data: { content: 'msg' }, id: '1', timestamp: new Date().toISOString() })}'`,
+        `printf '\`\`\`aamf-json\\n${aamfBlock}\\n\`\`\`\\n'`,
+        'exit 0',
+      ].join('\n'));
+      const launcher = makeLauncher(script);
+      const { contextFile, progressDir } = await prepareInvocation('jsonl-mixed-001');
+
+      const result = await launcher.launchAgent({
+        agent: 'code-migrator',
+        contextFile,
+        progressDir,
+        phase: 5,
+        taskId: 'jsonl-mixed-001',
+      });
+
+      // aamf-json should still be parsed from the text content
+      expect(result.outputParsed).toBe(true);
+      expect(result.structuredOutput?.status).toBe('completed');
+      // JSONL event should be captured
+      expect(result.copilotEvents).toBeDefined();
+      expect(result.copilotEvents!.totalEvents).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Capture the structured JSONL event stream from `copilot --output-format json` instead of relying solely on raw stdout/stderr text parsing. This provides much better observability into agent behavior, tool usage, and failure modes.

### Problem

When agents fail (e.g., 503 GOAWAY, timeouts), the only diagnostic data available is raw stdout/stderr text and whatever the regex-based token parser can extract. There's no structured record of which tools the agent called, what errors occurred during the session, or the copilot CLI's own usage summary.

### Solution

- Add `--output-format json` to copilot CLI args, which makes it emit one JSON object per line (JSONL) instead of the default text output
- Parse the JSONL stream with `parseCopilotJsonl()`, extracting:
  - **Tool calls** — which tools were invoked and their status
  - **Error events** — structured error data from the copilot CLI
  - **Result summary** — exit code, premium requests, API duration, session duration, code changes
  - **Text content** — reconstructed from `assistant.message` events for backward-compatible aamf-json block extraction
- Write a `.events.jsonl` file alongside each agent's `.log` file
- Log tool call summaries at info level and error events at warn level
- Add `copilotEvents` field to `AgentResult` for programmatic access

### What this enables

- **Debugging 503/GOAWAY failures**: Error events now contain structured data instead of being buried in stderr
- **Tool usage analysis**: See exactly which tools each agent used (file reads, shell commands, MCP tools) with counts
- **Session metrics**: Premium requests, API time, session time per invocation without regex parsing
- **Post-mortem analysis**: `.events.jsonl` files can be queried with `jq` for detailed session forensics