### PR TITLE
refactor(agents): remove agent field from all output schemas

### DIFF
--- a/runtime/agents/templates/parity-failure-resolver.md
+++ b/runtime/agents/templates/parity-failure-resolver.md
@@ -48,7 +48,6 @@ Resolve the failing task quickly and safely by:
 
 ```aamf-json
 {
-  "agent": "parity-failure-resolver",
   "status": "completed",
   "outputFiles": [],
   "taskId": "task-000",
@@ -62,7 +61,6 @@ Resolve the failing task quickly and safely by:
 
 ### Field constraints
 
-- `agent` must be exactly `"parity-failure-resolver"`.
 - `status` must be one of: `"completed"`, `"failed"`, `"needs-review"`.
 - `taskId` must match the provided task.
 - `failureType` should be one of: `"parity"`, `"build"`, `"test"`, `"blocked"`.

--- a/runtime/src/agents/agent-output-schemas.ts
+++ b/runtime/src/agents/agent-output-schemas.ts
@@ -15,7 +15,6 @@ import { fileExists, readJson } from '../util/fs.js';
  */
 export const AamfOutputBase = z.object({
   status: z.enum(['completed', 'failed', 'needs-review']),
-  agent: z.string().min(1).optional(),
   taskId: z.string().min(1).optional(),
   tokenUsage: z.object({
     prompt: z.number().int(),
@@ -34,7 +33,6 @@ export type AamfOutputBaseType = z.infer<typeof AamfOutputBase>;
  */
 export const TaskResultSchema = z.object({
   taskId: z.string().min(1),
-  agent: z.string().min(1).optional(),
   status: z.enum(['completed', 'failed', 'needs-review']),
   outputFiles: z.array(z.string()).default([]),
   parity: z.enum(['pass', 'partial', 'fail']).optional(),
@@ -62,7 +60,6 @@ export const MISSING_BLOCK_ERROR = 'missing aamf-json block';
  * Not part of the standard AgentName union — used by the KB indexing step.
  */
 export const KbIndexerOutput = AamfOutputBase.extend({
-  agent: z.literal('kb-indexer').optional(),
   /** Absolute path to the SQLite knowledge-base database written by the indexer. */
   dbPath: z.string().min(1),
 });

--- a/runtime/src/agents/registry.ts
+++ b/runtime/src/agents/registry.ts
@@ -24,7 +24,7 @@ const BASE_INPUT_PROPERTIES: Record<string, JsonSchema> = {
 /** The minimum required keys for every agent input. */
 const BASE_INPUT_REQUIRED = ['contextFile', 'projectRoot', 'progressDir', 'phase'] as const;
 
-/** Properties common to every agent's output schema (excluding `agent`). */
+/** Properties common to every agent's output schema. */
 const BASE_OUTPUT_PROPERTIES: Record<string, JsonSchema> = {
   status:      { enum: ['completed', 'failed', 'needs-review'] },
   outputFiles: { type: 'array', items: { type: 'string', minLength: 1 } },
@@ -47,10 +47,9 @@ function inputSchema(
 
 /**
  * Build an output JSON Schema, merging base properties with agent-specific extras.
- * The `agent` const is always injected from the agent name.
  */
 function outputSchema(
-  agentName: string,
+  _agentName: string,
   opts: {
     extraRequired?: readonly string[];
     extraProperties?: Record<string, JsonSchema>;
@@ -62,7 +61,6 @@ function outputSchema(
     type: 'object',
     required: ['status', 'outputFiles', ...(opts.extraRequired ?? [])],
     properties: {
-      agent: { const: agentName },
       ...BASE_OUTPUT_PROPERTIES,
       outputFiles,
       ...(opts.extraProperties ?? {}),
@@ -96,13 +94,12 @@ export interface AgentRegistryEntry {
 // ─── Per-Agent Output Schema Extensions ──────────────────────────────────────
 // These extend AamfOutputBase with agent-specific fields.
 
-export const MigrationOrchestratorSchema = AamfOutputBase.extend({ agent: z.literal('migration-orchestrator').optional() });
-export const KnowledgeBuilderSchema = AamfOutputBase.extend({ agent: z.literal('knowledge-builder').optional() });
-export const MigrationPlannerSchema = AamfOutputBase.extend({ agent: z.literal('migration-planner').optional() });
-export const AdjudicatorSchema = AamfOutputBase.extend({ agent: z.literal('adjudicator').optional() });
-export const CodeMigratorSchema = AamfOutputBase.extend({ agent: z.literal('code-migrator').optional() });
+export const MigrationOrchestratorSchema = AamfOutputBase;
+export const KnowledgeBuilderSchema = AamfOutputBase;
+export const MigrationPlannerSchema = AamfOutputBase;
+export const AdjudicatorSchema = AamfOutputBase;
+export const CodeMigratorSchema = AamfOutputBase;
 export const ParityVerifierSchema = AamfOutputBase.extend({
-  agent: z.literal('parity-verifier').optional(),
   parity: z.enum(['pass', 'partial', 'fail']),
   issues: z.array(z.object({
     severity: z.enum(['critical', 'major', 'minor']),
@@ -112,12 +109,9 @@ export const ParityVerifierSchema = AamfOutputBase.extend({
     targetLocation: z.string().optional(),
   })).default([]),
 });
-export const TestWriterSchema = AamfOutputBase.extend({ agent: z.literal('test-writer').optional() });
-export const ParityFailureResolverSchema = AamfOutputBase.extend({
-  agent: z.enum(['parity-failure-resolver', 'failure-recovery']).optional(),
-}).transform((data) => ({ ...data, agent: data.agent ? 'parity-failure-resolver' as const : undefined }));
+export const TestWriterSchema = AamfOutputBase;
+export const ParityFailureResolverSchema = AamfOutputBase;
 export const FinalParityCheckerSchema = AamfOutputBase.extend({
-  agent: z.literal('final-parity-checker').optional(),
   fixes: z.array(z.object({
     description: z.string().min(1),
     details: z.string(),
@@ -127,11 +121,10 @@ export const FinalParityCheckerSchema = AamfOutputBase.extend({
     targetLocation: z.string().optional(),
   })).optional(),
 });
-export const E2eTestCrafterSchema = AamfOutputBase.extend({ agent: z.literal('e2e-test-crafter').optional() });
-export const DocumentationWriterSchema = AamfOutputBase.extend({ agent: z.literal('documentation-writer').optional() });
-export const MigrationRunnerSchema = AamfOutputBase.extend({ agent: z.literal('migration-runner').optional() });
+export const E2eTestCrafterSchema = AamfOutputBase;
+export const DocumentationWriterSchema = AamfOutputBase;
+export const MigrationRunnerSchema = AamfOutputBase;
 export const IdiomaticReviewerSchema = AamfOutputBase.extend({
-  agent: z.literal('idiomatic-reviewer').optional(),
   issues: z.array(z.object({
     file: z.string().min(1),
     location: z.string(),
@@ -140,7 +133,7 @@ export const IdiomaticReviewerSchema = AamfOutputBase.extend({
     details: z.string(),
   })).optional(),
 });
-export const IdiomaticRefactorerSchema = AamfOutputBase.extend({ agent: z.literal('idiomatic-refactorer').optional() });
+export const IdiomaticRefactorerSchema = AamfOutputBase;
 
 // ─── The Registry ────────────────────────────────────────────────────────────
 

--- a/runtime/tests/aamf-output-schema.test.ts
+++ b/runtime/tests/aamf-output-schema.test.ts
@@ -20,168 +20,96 @@ describe('Per-agent output schemas', () => {
   describe('MigrationOrchestratorSchema', () => {
     it('accepts valid output', () => {
       expect(() =>
-        MigrationOrchestratorSchema.parse({ status: VALID_STATUS, agent: 'migration-orchestrator' }),
-      ).not.toThrow();
-    });
-    it('accepts output without agent field', () => {
-      expect(() =>
         MigrationOrchestratorSchema.parse({ status: VALID_STATUS }),
       ).not.toThrow();
-    });
-    it('rejects wrong agent literal', () => {
-      expect(() =>
-        MigrationOrchestratorSchema.parse({ status: VALID_STATUS, agent: 'knowledge-builder' }),
-      ).toThrow();
     });
   });
 
   describe('KnowledgeBuilderSchema', () => {
     it('accepts valid output', () => {
       expect(() =>
-        KnowledgeBuilderSchema.parse({ status: VALID_STATUS, agent: 'knowledge-builder' }),
+        KnowledgeBuilderSchema.parse({ status: VALID_STATUS }),
       ).not.toThrow();
-    });
-    it('rejects wrong agent literal', () => {
-      expect(() =>
-        KnowledgeBuilderSchema.parse({ status: VALID_STATUS, agent: 'code-migrator' }),
-      ).toThrow();
     });
   });
 
   describe('MigrationPlannerSchema', () => {
     it('accepts valid output', () => {
       expect(() =>
-        MigrationPlannerSchema.parse({ status: VALID_STATUS, agent: 'migration-planner' }),
+        MigrationPlannerSchema.parse({ status: VALID_STATUS }),
       ).not.toThrow();
-    });
-    it('rejects wrong agent literal', () => {
-      expect(() =>
-        MigrationPlannerSchema.parse({ status: VALID_STATUS, agent: 'migration-runner' }),
-      ).toThrow();
     });
   });
 
   describe('AdjudicatorSchema', () => {
     it('accepts valid output', () => {
       expect(() =>
-        AdjudicatorSchema.parse({ status: VALID_STATUS, agent: 'adjudicator' }),
+        AdjudicatorSchema.parse({ status: VALID_STATUS }),
       ).not.toThrow();
-    });
-    it('rejects wrong agent literal', () => {
-      expect(() =>
-        AdjudicatorSchema.parse({ status: VALID_STATUS, agent: 'code-migrator' }),
-      ).toThrow();
     });
   });
 
   describe('CodeMigratorSchema', () => {
     it('accepts valid output', () => {
       expect(() =>
-        CodeMigratorSchema.parse({ status: VALID_STATUS, agent: 'code-migrator' }),
+        CodeMigratorSchema.parse({ status: VALID_STATUS }),
       ).not.toThrow();
-    });
-    it('rejects wrong agent literal', () => {
-      expect(() =>
-        CodeMigratorSchema.parse({ status: VALID_STATUS, agent: 'adjudicator' }),
-      ).toThrow();
     });
   });
 
   describe('ParityVerifierSchema', () => {
     it('accepts valid output', () => {
       expect(() =>
-        ParityVerifierSchema.parse({ status: VALID_STATUS, agent: 'parity-verifier', parity: 'pass' }),
+        ParityVerifierSchema.parse({ status: VALID_STATUS, parity: 'pass' }),
       ).not.toThrow();
-    });
-    it('rejects wrong agent literal', () => {
-      expect(() =>
-        ParityVerifierSchema.parse({ status: VALID_STATUS, agent: 'code-migrator', parity: 'pass' }),
-      ).toThrow();
     });
   });
 
   describe('TestWriterSchema', () => {
     it('accepts valid output', () => {
       expect(() =>
-        TestWriterSchema.parse({ status: VALID_STATUS, agent: 'test-writer' }),
+        TestWriterSchema.parse({ status: VALID_STATUS }),
       ).not.toThrow();
-    });
-    it('rejects wrong agent literal', () => {
-      expect(() =>
-        TestWriterSchema.parse({ status: VALID_STATUS, agent: 'code-migrator' }),
-      ).toThrow();
     });
   });
 
   describe('ParityFailureResolverSchema', () => {
-    it('accepts canonical parity-failure-resolver output', () => {
+    it('accepts valid output', () => {
       expect(() =>
-        ParityFailureResolverSchema.parse({ status: VALID_STATUS, agent: 'parity-failure-resolver' }),
+        ParityFailureResolverSchema.parse({ status: VALID_STATUS }),
       ).not.toThrow();
-    });
-
-    it('accepts legacy failure-recovery output for compatibility', () => {
-      expect(() =>
-        ParityFailureResolverSchema.parse({ status: VALID_STATUS, agent: 'failure-recovery' }),
-      ).not.toThrow();
-    });
-
-    it('rejects wrong agent literal', () => {
-      expect(() =>
-        ParityFailureResolverSchema.parse({ status: VALID_STATUS, agent: 'code-migrator' }),
-      ).toThrow();
     });
   });
 
   describe('FinalParityCheckerSchema', () => {
     it('accepts valid output', () => {
       expect(() =>
-        FinalParityCheckerSchema.parse({ status: VALID_STATUS, agent: 'final-parity-checker' }),
+        FinalParityCheckerSchema.parse({ status: VALID_STATUS }),
       ).not.toThrow();
-    });
-    it('rejects wrong agent literal', () => {
-      expect(() =>
-        FinalParityCheckerSchema.parse({ status: VALID_STATUS, agent: 'parity-verifier' }),
-      ).toThrow();
     });
   });
 
   describe('E2eTestCrafterSchema', () => {
     it('accepts valid output', () => {
       expect(() =>
-        E2eTestCrafterSchema.parse({ status: VALID_STATUS, agent: 'e2e-test-crafter' }),
+        E2eTestCrafterSchema.parse({ status: VALID_STATUS }),
       ).not.toThrow();
-    });
-    it('rejects wrong agent literal', () => {
-      expect(() =>
-        E2eTestCrafterSchema.parse({ status: VALID_STATUS, agent: 'test-writer' }),
-      ).toThrow();
     });
   });
 
   describe('DocumentationWriterSchema', () => {
     it('accepts valid output', () => {
       expect(() =>
-        DocumentationWriterSchema.parse({ status: VALID_STATUS, agent: 'documentation-writer' }),
+        DocumentationWriterSchema.parse({ status: VALID_STATUS }),
       ).not.toThrow();
-    });
-    it('rejects wrong agent literal', () => {
-      expect(() =>
-        DocumentationWriterSchema.parse({ status: VALID_STATUS, agent: 'code-migrator' }),
-      ).toThrow();
     });
   });
 
   describe('MigrationRunnerSchema', () => {
     it('accepts valid output', () => {
       expect(() =>
-        MigrationRunnerSchema.parse({ status: VALID_STATUS, agent: 'migration-runner' }),
+        MigrationRunnerSchema.parse({ status: VALID_STATUS }),
       ).not.toThrow();
-    });
-    it('rejects wrong agent literal', () => {
-      expect(() =>
-        MigrationRunnerSchema.parse({ status: VALID_STATUS, agent: 'migration-planner' }),
-      ).toThrow();
     });
   });
 });

--- a/runtime/tests/agent-launcher.test.ts
+++ b/runtime/tests/agent-launcher.test.ts
@@ -466,8 +466,8 @@ describe('AgentLauncher', () => {
     });
 
     it('should force success: false and set parseError when aamf-json block is present but schema-invalid', async () => {
-      // wrong agent literal → schema validation fails
-      const aamfBlock = JSON.stringify({ status: 'completed', agent: 'knowledge-builder' });
+      // invalid status value → schema validation fails
+      const aamfBlock = JSON.stringify({ status: 'bogus-status' });
       const script = await createScript('bad-aamf.sh', [
         `printf '\`\`\`aamf-json\\n${aamfBlock}\\n\`\`\`\\n'`,
         'exit 0',
@@ -476,7 +476,7 @@ describe('AgentLauncher', () => {
       const { contextFile, progressDir } = await prepareInvocation('aamf-invalid-001');
 
       const result = await launcher.launchAgent({
-        agent: 'code-migrator',  // schema expects agent === 'code-migrator'
+        agent: 'code-migrator',
         contextFile,
         progressDir,
         phase: 5,

--- a/runtime/tests/claude-agent-definitions.test.ts
+++ b/runtime/tests/claude-agent-definitions.test.ts
@@ -159,8 +159,6 @@ describe('Registry JSON schemas', () => {
         expect(schema.required).not.toContain('agent');
         expect(schema.required).toContain('status');
         expect(schema.required).toContain('outputFiles');
-        const props = schema.properties as Record<string, unknown>;
-        expect(props.agent).toBeDefined();
       });
     });
   }

--- a/runtime/tests/orchestrator.test.ts
+++ b/runtime/tests/orchestrator.test.ts
@@ -3530,7 +3530,6 @@ Some preamble text
 
 \`\`\`aamf-json
 {
-  "agent": "parity-verifier",
   "status": "completed",
   "outputFiles": ["artifacts/parity/task-001.md"],
   "taskId": "task-001",
@@ -3578,7 +3577,7 @@ Total usage est: 1 Premium requests
 
       const makeLog = (parity: string) => `=== STDOUT ===
 \`\`\`aamf-json
-{"agent":"parity-verifier","status":"completed","parity":"${parity}","issues":[]}
+{"status":"completed","parity":"${parity}","issues":[]}
 \`\`\`
 === STDERR ===
 `;

--- a/runtime/tests/result-parser.test.ts
+++ b/runtime/tests/result-parser.test.ts
@@ -257,7 +257,6 @@ Here are the tasks:
     it('should validate a well-formed result JSON', () => {
       const result = TaskResultSchema.parse({
         taskId: 'task-001',
-        agent: 'code-migrator',
         status: 'completed',
         outputFiles: ['src/auth/login.ts'],
         parity: 'pass',
@@ -268,7 +267,7 @@ Here are the tasks:
     });
 
     it('should reject a result with missing taskId', () => {
-      expect(() => TaskResultSchema.parse({ agent: 'x', status: 'completed' })).toThrow();
+      expect(() => TaskResultSchema.parse({ status: 'completed' })).toThrow();
     });
   });
 
@@ -282,7 +281,6 @@ Here are the tasks:
         await mkdir(resultsDir, { recursive: true });
         const sidecar = {
           taskId: 'task-001',
-          agent: 'parity-verifier',
           status: 'completed',
           outputFiles: [],
           parity: 'pass',
@@ -324,7 +322,6 @@ Here are the tasks:
         await mkdir(legacyDir, { recursive: true });
         const sidecar = {
           taskId: 'task-001',
-          agent: 'parity-verifier',
           status: 'completed',
           outputFiles: [],
           parity: 'pass',
@@ -365,24 +362,16 @@ Here are the tasks:
 
   describe('AamfOutputBase schema', () => {
     it('should accept a minimal valid output', () => {
-      const result = AamfOutputBase.parse({ status: 'completed', agent: 'code-migrator' });
+      const result = AamfOutputBase.parse({ status: 'completed' });
       expect(result.status).toBe('completed');
-      expect(result.agent).toBe('code-migrator');
       expect(result.taskId).toBeUndefined();
       expect(result.tokenUsage).toBeUndefined();
       expect(result.notes).toBeUndefined();
     });
 
-    it('should accept output without agent field', () => {
-      const result = AamfOutputBase.parse({ status: 'completed' });
-      expect(result.status).toBe('completed');
-      expect(result.agent).toBeUndefined();
-    });
-
     it('should accept all optional fields', () => {
       const result = AamfOutputBase.parse({
         status: 'needs-review',
-        agent: 'parity-verifier',
         taskId: 'task-007',
         tokenUsage: { prompt: 100, completion: 50, total: 150 },
         notes: 'Some note',
@@ -393,18 +382,13 @@ Here are the tasks:
     });
 
     it('should reject invalid status values', () => {
-      expect(() => AamfOutputBase.parse({ status: 'unknown', agent: 'x' })).toThrow();
-    });
-
-    it('should reject empty agent string', () => {
-      expect(() => AamfOutputBase.parse({ status: 'completed', agent: '' })).toThrow();
+      expect(() => AamfOutputBase.parse({ status: 'unknown' })).toThrow();
     });
 
     it('should reject non-integer tokenUsage fields', () => {
       expect(() =>
         AamfOutputBase.parse({
           status: 'completed',
-          agent: 'x',
           tokenUsage: { prompt: 1.5, completion: 0, total: 1 },
         }),
       ).toThrow();
@@ -412,104 +396,87 @@ Here are the tasks:
 
     it('should accept all valid status enum values', () => {
       for (const status of ['completed', 'failed', 'needs-review'] as const) {
-        expect(() => AamfOutputBase.parse({ status, agent: 'a' })).not.toThrow();
+        expect(() => AamfOutputBase.parse({ status })).not.toThrow();
       }
     });
   });
 
   describe('per-agent output schemas', () => {
-    it('should accept a matching agent literal for MigrationOrchestratorSchema', () => {
-      const result = MigrationOrchestratorSchema.parse({ status: 'completed', agent: 'migration-orchestrator' });
-      expect(result.agent).toBe('migration-orchestrator');
-    });
-
-    it('should reject a wrong agent literal for MigrationOrchestratorSchema', () => {
-      expect(() =>
-        MigrationOrchestratorSchema.parse({ status: 'completed', agent: 'code-migrator' }),
-      ).toThrow();
+    it('should accept valid MigrationOrchestratorSchema output', () => {
+      const result = MigrationOrchestratorSchema.parse({ status: 'completed' });
+      expect(result.status).toBe('completed');
     });
 
     it('should validate KnowledgeBuilderSchema', () => {
-      expect(() => KnowledgeBuilderSchema.parse({ status: 'completed', agent: 'knowledge-builder' })).not.toThrow();
+      expect(() => KnowledgeBuilderSchema.parse({ status: 'completed' })).not.toThrow();
     });
 
     it('should validate MigrationPlannerSchema', () => {
-      expect(() => MigrationPlannerSchema.parse({ status: 'completed', agent: 'migration-planner' })).not.toThrow();
+      expect(() => MigrationPlannerSchema.parse({ status: 'completed' })).not.toThrow();
     });
 
     it('should validate AdjudicatorSchema', () => {
-      expect(() => AdjudicatorSchema.parse({ status: 'completed', agent: 'adjudicator' })).not.toThrow();
+      expect(() => AdjudicatorSchema.parse({ status: 'completed' })).not.toThrow();
     });
 
     it('should validate CodeMigratorSchema', () => {
-      expect(() => CodeMigratorSchema.parse({ status: 'completed', agent: 'code-migrator' })).not.toThrow();
+      expect(() => CodeMigratorSchema.parse({ status: 'completed' })).not.toThrow();
     });
 
     it('should validate ParityVerifierSchema', () => {
-      expect(() => ParityVerifierSchema.parse({ status: 'completed', agent: 'parity-verifier', parity: 'pass' })).not.toThrow();
+      expect(() => ParityVerifierSchema.parse({ status: 'completed', parity: 'pass' })).not.toThrow();
     });
 
     it('should validate TestWriterSchema', () => {
-      expect(() => TestWriterSchema.parse({ status: 'completed', agent: 'test-writer' })).not.toThrow();
+      expect(() => TestWriterSchema.parse({ status: 'completed' })).not.toThrow();
     });
 
-    it('should validate ParityFailureResolverSchema with canonical id', () => {
-      expect(() => ParityFailureResolverSchema.parse({ status: 'completed', agent: 'parity-failure-resolver' })).not.toThrow();
-    });
-
-    it('should validate ParityFailureResolverSchema with legacy alias', () => {
-      expect(() => ParityFailureResolverSchema.parse({ status: 'completed', agent: 'failure-recovery' })).not.toThrow();
+    it('should validate ParityFailureResolverSchema', () => {
+      expect(() => ParityFailureResolverSchema.parse({ status: 'completed' })).not.toThrow();
     });
 
     it('should validate FinalParityCheckerSchema', () => {
-      expect(() => FinalParityCheckerSchema.parse({ status: 'completed', agent: 'final-parity-checker' })).not.toThrow();
+      expect(() => FinalParityCheckerSchema.parse({ status: 'completed' })).not.toThrow();
     });
 
     it('should validate E2eTestCrafterSchema', () => {
-      expect(() => E2eTestCrafterSchema.parse({ status: 'completed', agent: 'e2e-test-crafter' })).not.toThrow();
+      expect(() => E2eTestCrafterSchema.parse({ status: 'completed' })).not.toThrow();
     });
 
     it('should validate DocumentationWriterSchema', () => {
-      expect(() => DocumentationWriterSchema.parse({ status: 'completed', agent: 'documentation-writer' })).not.toThrow();
+      expect(() => DocumentationWriterSchema.parse({ status: 'completed' })).not.toThrow();
     });
 
     it('should validate MigrationRunnerSchema', () => {
-      expect(() => MigrationRunnerSchema.parse({ status: 'completed', agent: 'migration-runner' })).not.toThrow();
+      expect(() => MigrationRunnerSchema.parse({ status: 'completed' })).not.toThrow();
     });
 
     describe('KbIndexerOutput', () => {
       it('should validate with required dbPath field', () => {
         expect(() =>
-          KbIndexerOutput.parse({ status: 'completed', agent: 'kb-indexer', dbPath: '/tmp/kb.db' }),
+          KbIndexerOutput.parse({ status: 'completed', dbPath: '/tmp/kb.db' }),
         ).not.toThrow();
       });
 
       it('should reject missing dbPath', () => {
         expect(() =>
-          KbIndexerOutput.parse({ status: 'completed', agent: 'kb-indexer' }),
+          KbIndexerOutput.parse({ status: 'completed' }),
         ).toThrow();
       });
 
       it('should reject empty dbPath', () => {
         expect(() =>
-          KbIndexerOutput.parse({ status: 'completed', agent: 'kb-indexer', dbPath: '' }),
-        ).toThrow();
-      });
-
-      it('should reject wrong agent literal', () => {
-        expect(() =>
-          KbIndexerOutput.parse({ status: 'completed', agent: 'code-migrator', dbPath: '/tmp/kb.db' }),
+          KbIndexerOutput.parse({ status: 'completed', dbPath: '' }),
         ).toThrow();
       });
 
       it('should parse correctly and expose dbPath', () => {
-        const result = KbIndexerOutput.parse({ status: 'completed', agent: 'kb-indexer', dbPath: '/var/db/kb.sqlite' });
-        expect(result.agent).toBe('kb-indexer');
+        const result = KbIndexerOutput.parse({ status: 'completed', dbPath: '/var/db/kb.sqlite' });
         expect(result.dbPath).toBe('/var/db/kb.sqlite');
       });
 
       it('should parse a KbIndexerOutput aamf-json block', () => {
-        const stdout = '```aamf-json\n{"status":"completed","agent":"kb-indexer","dbPath":"/tmp/kb.db"}\n```';
+        const stdout = '```aamf-json\n{"status":"completed","dbPath":"/tmp/kb.db"}\n```';
         const result = parseAamfOutput(stdout, KbIndexerOutput);
         expect(result.parsed).toBe(true);
         if (result.parsed) {
@@ -524,25 +491,24 @@ Here are the tasks:
       const stdout = `
 Some output text.
 \`\`\`aamf-json
-{"status":"completed","agent":"code-migrator"}
+{"status":"completed"}
 \`\`\`
 `;
       const result = parseAamfOutput(stdout, CodeMigratorSchema);
       expect(result.parsed).toBe(true);
       if (result.parsed) {
         expect(result.data.status).toBe('completed');
-        expect(result.data.agent).toBe('code-migrator');
       }
     });
 
     it('should return the last aamf-json block when multiple are present', () => {
       const stdout = `
 \`\`\`aamf-json
-{"status":"failed","agent":"code-migrator"}
+{"status":"failed"}
 \`\`\`
 intermediate text
 \`\`\`aamf-json
-{"status":"completed","agent":"code-migrator"}
+{"status":"completed"}
 \`\`\`
 `;
       const result = parseAamfOutput(stdout, CodeMigratorSchema);
@@ -570,16 +536,7 @@ intermediate text
     });
 
     it('should return parsed: false for schema validation failure', () => {
-      const stdout = '```aamf-json\n{"status":"invalid-status","agent":"code-migrator"}\n```';
-      const result = parseAamfOutput(stdout, CodeMigratorSchema);
-      expect(result.parsed).toBe(false);
-      if (!result.parsed) {
-        expect(result.error).toContain('schema validation failed');
-      }
-    });
-
-    it('should return parsed: false when agent literal does not match schema', () => {
-      const stdout = '```aamf-json\n{"status":"completed","agent":"knowledge-builder"}\n```';
+      const stdout = '```aamf-json\n{"status":"invalid-status"}\n```';
       const result = parseAamfOutput(stdout, CodeMigratorSchema);
       expect(result.parsed).toBe(false);
       if (!result.parsed) {
@@ -589,7 +546,7 @@ intermediate text
 
     it('should parse optional fields when provided', () => {
       const stdout = `\`\`\`aamf-json
-{"status":"completed","agent":"test-writer","taskId":"task-003","tokenUsage":{"prompt":100,"completion":50,"total":150},"notes":"All good"}
+{"status":"completed","taskId":"task-003","tokenUsage":{"prompt":100,"completion":50,"total":150},"notes":"All good"}
 \`\`\``;
       const result = parseAamfOutput(stdout, TestWriterSchema);
       expect(result.parsed).toBe(true);
@@ -601,31 +558,19 @@ intermediate text
     });
 
     it('should handle CRLF line endings in the fenced block', () => {
-      const stdout = '```aamf-json\r\n{"status":"completed","agent":"adjudicator"}\r\n```';
+      const stdout = '```aamf-json\r\n{"status":"completed"}\r\n```';
       const result = parseAamfOutput(stdout, AdjudicatorSchema);
       expect(result.parsed).toBe(true);
     });
 
-    it('should parse parity-failure-resolver aamf-json with canonical agent id', () => {
-      const stdout = '```aamf-json\n{"status":"completed","agent":"parity-failure-resolver"}\n```';
+    it('should parse parity-failure-resolver aamf-json', () => {
+      const stdout = '```aamf-json\n{"status":"completed"}\n```';
       const result = parseAamfOutput(stdout, ParityFailureResolverSchema);
       expect(result.parsed).toBe(true);
-      if (result.parsed) {
-        expect(result.data.agent).toBe('parity-failure-resolver');
-      }
-    });
-
-    it('should parse parity-failure-resolver aamf-json with legacy failure-recovery id', () => {
-      const stdout = '```aamf-json\n{"status":"completed","agent":"failure-recovery"}\n```';
-      const result = parseAamfOutput(stdout, ParityFailureResolverSchema);
-      expect(result.parsed).toBe(true);
-      if (result.parsed) {
-        expect(result.data.agent).toBe('parity-failure-resolver');
-      }
     });
 
     it('should work with the base AamfOutputBase schema', () => {
-      const stdout = '```aamf-json\n{"status":"needs-review","agent":"any-agent"}\n```';
+      const stdout = '```aamf-json\n{"status":"needs-review"}\n```';
       const result = parseAamfOutput(stdout, AamfOutputBase);
       expect(result.parsed).toBe(true);
       if (result.parsed) {


### PR DESCRIPTION
## Summary

Remove the `agent` field from all agent input and output schemas. The runtime already knows which agent it launched — agents don't need to echo it back.

## Changes

**Source:**
- `agent-output-schemas.ts` — Removed `agent` from `AamfOutputBase`, `TaskResultSchema`, and `KbIndexerOutput` Zod schemas
- `registry.ts` — Removed `agent` from all 14 per-agent Zod schema extensions and the `outputSchema()` JSON schema builder
- `parity-failure-resolver.md` — Removed `agent` from the example aamf-json block and field constraints

**Tests:**
- Updated `aamf-output-schema.test.ts`, `result-parser.test.ts`, `claude-agent-definitions.test.ts`, `orchestrator.test.ts`, and `agent-launcher.test.ts` to remove agent-field-specific assertions

## Verification

All 1443 tests pass (179 skipped, 0 failures).