### PR TITLE
deps: bump @cadre-dev/framework 0.2.1 → 0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aamf",
       "version": "0.1.0",
       "dependencies": {
-        "@cadre-dev/framework": "0.2.1",
+        "@cadre-dev/framework": "0.2.2",
         "@jafreck/lore": "^0.3.9",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@types/better-sqlite3": "^7.6.13",
@@ -102,9 +102,9 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cadre-dev/framework": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@cadre-dev/framework/-/framework-0.2.1.tgz",
-      "integrity": "sha512-2Fp9lFcuL1Rh3mTxCXBlVhq8fAerVzZfu/jnC9WMad9CXetA/3KssyuDVUui3HuO1Y+SQvC5OXVCBoeRI1EXAQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@cadre-dev/framework/-/framework-0.2.2.tgz",
+      "integrity": "sha512-TQw+b09AlbGirXAcPdvbhYAS8xviySK6Owjw/4xSMXfZGq2TQ1l/GSdX2x8v4ol6DQJhz7lZA9tblSeq6aBN9Q==",
       "license": "MIT",
       "dependencies": {
         "p-limit": "^7",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "hooks:install": "git config core.hooksPath .githooks"
   },
   "dependencies": {
-    "@cadre-dev/framework": "0.2.1",
+    "@cadre-dev/framework": "0.2.2",
     "@jafreck/lore": "^0.3.9",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@types/better-sqlite3": "^7.6.13",


### PR DESCRIPTION
Bumps `@cadre-dev/framework` from 0.2.1 to 0.2.2 (pinned, no caret).

- Type-check passes
- All 1,413 tests pass
- AAMF does not use any Cadre extension-point APIs — the removed extensions feature has no impact