### PR TITLE
feat(checkpoint): add --from-phase flag to restart from a fixed phase boundary

### DIFF
--- a/src/core/checkpoint.ts
+++ b/src/core/checkpoint.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { atomicWrite, ensureDir, fileExists, readJson, writeJson } from '../util/fs.js';
 import { Logger } from '../logging/logger.js';
+import type { FlowCheckpointSnapshot } from '@cadre-dev/framework/flow';
 import type { TerminalReasonCode } from '../agents/types.js';
 
 export interface TerminalExhaustionState {
@@ -347,6 +348,104 @@ export class CheckpointManager {
   getResumePoint(): { phase: number; taskId: string | null } {
     const state = this.getState();
     return { phase: state.currentPhase, taskId: state.currentTask };
+  }
+
+  /**
+   * Reset all checkpoint state from `fromPhase` onward, preserving earlier phases.
+   * Used by `--from-phase N` to restart from a fixed phase boundary.
+   *
+   * @param fromPhase  The phase number to restart from (0-8).
+   * @param nodeIdToPhase  Maps flow node IDs to phase numbers (returns -1 for unknown).
+   *
+   * Requires that all phases 0..fromPhase-1 are already completed (or fromPhase === 0).
+   * Throws if the prerequisite phases are missing.
+   */
+  async resetFromPhase(fromPhase: number, nodeIdToPhase: (id: string) => number): Promise<void> {
+    const state = this.getState();
+
+    // Validate prerequisites: all phases before fromPhase must be completed
+    if (fromPhase > 0) {
+      const missing: number[] = [];
+      for (let p = 0; p < fromPhase; p++) {
+        if (!state.completedPhases.includes(p)) {
+          missing.push(p);
+        }
+      }
+      if (missing.length > 0) {
+        throw new Error(
+          `Cannot --from-phase ${fromPhase}: prerequisite phase(s) ${missing.join(', ')} ` +
+          `not completed. Completed phases: [${state.completedPhases.sort((a, b) => a - b).join(', ')}]`,
+        );
+      }
+    }
+
+    // 1. completedPhases — keep only < fromPhase
+    state.completedPhases = state.completedPhases.filter(p => p < fromPhase);
+
+    // 2. currentPhase — set to fromPhase
+    state.currentPhase = fromPhase;
+
+    // 3. currentTask — clear
+    state.currentTask = null;
+
+    // 4. phaseOutputs — remove keys >= fromPhase
+    for (const key of Object.keys(state.phaseOutputs)) {
+      if (Number(key) >= fromPhase) {
+        delete state.phaseOutputs[Number(key)];
+      }
+    }
+
+    // 5. Phase-specific state
+    if (fromPhase <= 0) {
+      state.phase0Fingerprint = undefined;
+    }
+    if (fromPhase <= 2) {
+      state.completedPhase2Groups = [];
+    }
+    if (fromPhase <= 3) {
+      state.phase3aComplete = false;
+      state.scaffoldComplete = false;
+    }
+    if (fromPhase <= 4) {
+      state.completedTasks = [];
+      state.failedTasks = [];
+      state.blockedTasks = [];
+      state.completedTaskDurationsMs = [];
+      state.terminalExhaustion = undefined;
+      state.adjudicationWaivers = [];
+      state.adjudicationEvents = [];
+      state.phaseCursors ??= {};
+      state.phaseCursors['4'] = { tasks: {} };
+      state.__phase4FlowCheckpoint = undefined;
+    }
+    if (fromPhase <= 5) {
+      state.phaseCursors ??= {};
+      state.phaseCursors['5'] = { iteration: 0, fixIndex: 0 };
+    }
+    if (fromPhase <= 6) {
+      state.phaseCursors ??= {};
+      state.phaseCursors['6'] = { completedAgents: [], completedSuites: [] };
+    }
+    if (fromPhase <= 7) {
+      state.phaseCursors ??= {};
+      state.phaseCursors['7'] = { iteration: 0, issueIndex: 0 };
+    }
+
+    // 6. Flow checkpoint — remove completedExecutionIds for phases >= fromPhase
+    if (state.__flowCheckpoint && typeof state.__flowCheckpoint === 'object') {
+      const fc = state.__flowCheckpoint as FlowCheckpointSnapshot<unknown>;
+      if (Array.isArray(fc.completedExecutionIds)) {
+        fc.completedExecutionIds = fc.completedExecutionIds.filter(id => {
+          const phase = nodeIdToPhase(id);
+          // Keep nodes that belong to phases before fromPhase.
+          // Also keep unknown nodes (phase === -1) to be safe.
+          return phase < fromPhase && phase !== -1;
+        });
+      }
+    }
+
+    this.logger.info(`Reset checkpoint from phase ${fromPhase} onward — preserving phases [${state.completedPhases.join(', ')}]`);
+    await this.save(state);
   }
 
   /** Add token usage */

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -30,7 +30,8 @@ export interface RuntimeOptions {
   configPath: string;
   resume?: boolean;
   dryRun?: boolean;
-  phase?: number;   // run up to and including this phase
+  phase?: number;      // run up to and including this phase
+  fromPhase?: number;  // restart from this phase, preserving earlier phases
   logLevel?: 'debug' | 'info' | 'warn' | 'error';
 }
 
@@ -86,6 +87,7 @@ export class MigrationRuntime {
   private paths!: ReturnType<typeof buildRuntimePaths>;
   private projectRoot!: string;
   private phase?: number;
+  private fromPhase?: number;
   private runId!: string;
   /** Mutable flow context — populated during run(), used by shutdown handler. */
   private flowContext?: MigrationFlowContext;
@@ -125,6 +127,14 @@ export class MigrationRuntime {
       resume: options.resume,
     });
     this.phase = options.phase;
+    this.fromPhase = options.fromPhase;
+
+    // Validate --from-phase / --phase compatibility
+    if (this.fromPhase !== undefined && this.phase !== undefined && this.fromPhase > this.phase) {
+      throw new Error(
+        `--from-phase ${this.fromPhase} must be <= --phase ${this.phase}`,
+      );
+    }
 
     // Fail fast if source tree or configured entry points are missing.
     await validateSourceAvailability(this.config);
@@ -176,11 +186,21 @@ export class MigrationRuntime {
   }
 
   async run(): Promise<MigrationResult> {
-    // Load or create checkpoint. resume=false always forces a fresh start.
-    await this.checkpoint.load(this.config.projectName, { fresh: !this.config.options.resume });
+    // Load or create checkpoint.
+    //   --from-phase implies resume for earlier phases (load existing checkpoint).
+    //   resume=false (without --from-phase) forces a fresh start.
+    const impliedResume = this.fromPhase !== undefined;
+    await this.checkpoint.load(this.config.projectName, {
+      fresh: !this.config.options.resume && !impliedResume,
+    });
+
+    // Apply --from-phase reset before anything else
+    if (this.fromPhase !== undefined) {
+      await this.checkpoint.resetFromPhase(this.fromPhase, nodeIdToPhase);
+    }
 
     // Initialize progress
-    if (!this.config.options.resume) {
+    if (!this.config.options.resume && !impliedResume) {
       await this.progress.initialize(this.config);
     } else {
       // Reconstruct progress state from checkpoint on resume

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ program
   .option('--resume', 'Resume from last checkpoint')
   .option('--dry-run', 'Validate config and produce plan only')
   .option('--phase <number>', 'Run up to and including this phase (0-8)', parseInt)
+  .option('--from-phase <number>', 'Restart from this phase (0-8), preserving earlier phases', parseInt)
   .option('--log-level <level>', 'Log level (debug|info|warn|error)', 'info')
   .action(async (opts) => {
     try {
@@ -25,6 +26,7 @@ program
         resume: opts.resume,
         dryRun: opts.dryRun,
         phase: opts.phase,
+        fromPhase: opts.fromPhase,
         logLevel: opts.logLevel,
       });
       const result = await runtime.run();

--- a/tests/core/checkpoint.test.ts
+++ b/tests/core/checkpoint.test.ts
@@ -579,4 +579,211 @@ describe('CheckpointManager', () => {
     expect(loaded.adjudicationWaivers).toEqual([]);
     expect(loaded.adjudicationEvents).toEqual([]);
   });
+
+  // ─── resetFromPhase ─────────────────────────────────────────────
+
+  /** Stub nodeIdToPhase mapper for tests */
+  const testNodeIdToPhase = (id: string): number => {
+    const map: Record<string, number> = {
+      'kb-index': 0,
+      'task-graph-construction': 1,
+      'kb-construction': 2,
+      'budget-check-2': 2,
+      'migration-planning': 3,
+      'budget-check-3': 3,
+      'iterative-migration': 4,
+      'budget-check-4': 4,
+      'final-parity-loop': 5,
+      'final-parity-iteration': 5,
+      'e2e-test-plan': 6,
+      'finalization': 6,
+      'e2e-suite-writers': 6,
+      'documentation-writer': 6,
+      'idiomatic-refactor-gate': 7,
+      'idiomatic-loop': 7,
+      'idiomatic-iteration': 7,
+      'completion': 8,
+    };
+    return map[id] ?? -1;
+  };
+
+  it('resetFromPhase should clear phases >= N and preserve earlier', async () => {
+    const state = await manager.load('test-project');
+    // Simulate phases 0-5 completed
+    for (let p = 0; p <= 5; p++) {
+      await manager.completePhase(p, `/out/${p}`);
+    }
+    await manager.completeTask('task-001', 1000);
+    await manager.completeTask('task-002', 2000);
+    state.phase3aComplete = true;
+    state.scaffoldComplete = true;
+    await manager.save(state);
+
+    await manager.resetFromPhase(4, testNodeIdToPhase);
+
+    const reset = manager.getState();
+    expect(reset.currentPhase).toBe(4);
+    expect(reset.completedPhases).toEqual([0, 1, 2, 3]);
+    expect(reset.currentTask).toBeNull();
+    expect(reset.completedTasks).toEqual([]);
+    expect(reset.failedTasks).toEqual([]);
+    expect(reset.blockedTasks).toEqual([]);
+    expect(reset.completedTaskDurationsMs).toEqual([]);
+    // Phase 3 state preserved since fromPhase=4
+    expect(reset.phase3aComplete).toBe(true);
+    expect(reset.scaffoldComplete).toBe(true);
+    // Phase outputs for 4+ cleared
+    expect(reset.phaseOutputs[3]).toBe('/out/3');
+    expect(reset.phaseOutputs[4]).toBeUndefined();
+    expect(reset.phaseOutputs[5]).toBeUndefined();
+  });
+
+  it('resetFromPhase(0) should clear everything like a fresh start', async () => {
+    const state = await manager.load('test-project');
+    for (let p = 0; p <= 3; p++) {
+      await manager.completePhase(p, `/out/${p}`);
+    }
+    state.phase0Fingerprint = 'abc123';
+    state.phase3aComplete = true;
+    await manager.save(state);
+
+    await manager.resetFromPhase(0, testNodeIdToPhase);
+
+    const reset = manager.getState();
+    expect(reset.currentPhase).toBe(0);
+    expect(reset.completedPhases).toEqual([]);
+    expect(reset.phase0Fingerprint).toBeUndefined();
+    expect(reset.phase3aComplete).toBe(false);
+    expect(reset.scaffoldComplete).toBe(false);
+  });
+
+  it('resetFromPhase should throw if prerequisite phases are missing', async () => {
+    await manager.load('test-project');
+    await manager.completePhase(0, '/out/0');
+    // Phase 1 not completed — trying to start from phase 3 should fail
+
+    await expect(manager.resetFromPhase(3, testNodeIdToPhase)).rejects.toThrow(
+      /Cannot --from-phase 3.*prerequisite phase\(s\) 1, 2/,
+    );
+  });
+
+  it('resetFromPhase should filter flow checkpoint completedExecutionIds', async () => {
+    const state = await manager.load('test-project');
+    for (let p = 0; p <= 5; p++) {
+      await manager.completePhase(p, `/out/${p}`);
+    }
+    // Simulate a flow checkpoint with completed execution IDs
+    state.__flowCheckpoint = {
+      flowId: 'aamf-migration',
+      status: 'completed',
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      completedExecutionIds: [
+        'kb-index',              // phase 0
+        'task-graph-construction', // phase 1
+        'kb-construction',       // phase 2
+        'budget-check-2',        // phase 2
+        'migration-planning',    // phase 3
+        'budget-check-3',        // phase 3
+        'iterative-migration',   // phase 4
+        'budget-check-4',        // phase 4
+        'final-parity-loop',     // phase 5
+      ],
+      outputs: {},
+      executionOutputs: {},
+    };
+    await manager.save(state);
+
+    await manager.resetFromPhase(4, testNodeIdToPhase);
+
+    const reset = manager.getState();
+    const fc = reset.__flowCheckpoint as { completedExecutionIds: string[] };
+    // Should keep phases 0-3 execution IDs, remove 4+
+    expect(fc.completedExecutionIds).toEqual([
+      'kb-index',
+      'task-graph-construction',
+      'kb-construction',
+      'budget-check-2',
+      'migration-planning',
+      'budget-check-3',
+    ]);
+  });
+
+  it('resetFromPhase should clear phase4FlowCheckpoint when resetting from phase <= 4', async () => {
+    const state = await manager.load('test-project');
+    for (let p = 0; p <= 4; p++) {
+      await manager.completePhase(p, `/out/${p}`);
+    }
+    state.__phase4FlowCheckpoint = { flowId: 'phase4', status: 'completed' };
+    await manager.save(state);
+
+    await manager.resetFromPhase(4, testNodeIdToPhase);
+
+    const reset = manager.getState();
+    expect(reset.__phase4FlowCheckpoint).toBeUndefined();
+  });
+
+  it('resetFromPhase should clear phase-specific cursors', async () => {
+    const state = await manager.load('test-project');
+    for (let p = 0; p <= 6; p++) {
+      await manager.completePhase(p, `/out/${p}`);
+    }
+    state.phaseCursors = {
+      '4': { tasks: { 'task-1': { completedSubsteps: ['migrate', 'verify'] } } },
+      '5': { iteration: 2, fixIndex: 3 },
+      '6': { completedAgents: ['e2e-test-crafter'], completedSuites: ['suite-a'] },
+      '7': { iteration: 1, issueIndex: 5 },
+    };
+    await manager.save(state);
+
+    await manager.resetFromPhase(5, testNodeIdToPhase);
+
+    const reset = manager.getState();
+    // Phase 4 cursor preserved (fromPhase=5 > 4)
+    expect(reset.phaseCursors?.['4']?.tasks['task-1']).toBeDefined();
+    // Phase 5+ cursors reset
+    expect(reset.phaseCursors?.['5']).toEqual({ iteration: 0, fixIndex: 0 });
+    expect(reset.phaseCursors?.['6']).toEqual({ completedAgents: [], completedSuites: [] });
+    expect(reset.phaseCursors?.['7']).toEqual({ iteration: 0, issueIndex: 0 });
+  });
+
+  it('resetFromPhase should persist the reset to disk', async () => {
+    await manager.load('test-project');
+    for (let p = 0; p <= 3; p++) {
+      await manager.completePhase(p, `/out/${p}`);
+    }
+
+    await manager.resetFromPhase(2, testNodeIdToPhase);
+
+    // Reload from disk
+    const manager2 = new CheckpointManager(tempDir, logger);
+    const reloaded = await manager2.load('test-project');
+    expect(reloaded.currentPhase).toBe(2);
+    expect(reloaded.completedPhases).toContain(0);
+    expect(reloaded.completedPhases).toContain(1);
+    expect(reloaded.completedPhases).not.toContain(2);
+    expect(reloaded.completedPhases).not.toContain(3);
+  });
+
+  it('resetFromPhase should clear adjudication state when resetting from phase <= 4', async () => {
+    const state = await manager.load('test-project');
+    for (let p = 0; p <= 4; p++) {
+      await manager.completePhase(p, `/out/${p}`);
+    }
+    await manager.recordAdjudicationWaiver({
+      issueFingerprint: 'fp-1',
+      decision: 'false_positive',
+    });
+    await manager.appendAdjudicationEvent({
+      decision: 'false_positive',
+      issueFingerprint: 'fp-1',
+    });
+
+    await manager.resetFromPhase(4, testNodeIdToPhase);
+
+    const reset = manager.getState();
+    expect(reset.adjudicationWaivers).toEqual([]);
+    expect(reset.adjudicationEvents).toEqual([]);
+    expect(reset.terminalExhaustion).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Adds a `--from-phase <N>` CLI flag to the `migrate` command that restarts execution from a specific phase boundary while preserving all earlier phases. This is distinct from `--resume` (which picks up from the exact last checkpoint position, potentially mid-task).

## Motivation

When a migration fails partway through a phase (e.g., phase 4), the only options today are:
- `--resume` — continues from the exact checkpoint (mid-task), which may not be desirable if the failure left corrupted state
- Fresh start — reruns everything from scratch, wasting phases 0–3

`--from-phase` fills the gap: reset phase N onward and restart cleanly, without replaying earlier expensive phases.

## Usage

```bash
# Restart from phase 4, keeping phases 0-3 intact:
npx aamf migrate -c migration.config.json --from-phase 4

# Restart phases 4-6 only:
npx aamf migrate -c migration.config.json --from-phase 4 --phase 6
```

## Changes

### `src/core/checkpoint.ts`
- Added `resetFromPhase(fromPhase, nodeIdToPhase)` method that:
  - Validates all prerequisite phases (0..N-1) are completed
  - Keeps `completedPhases` and `phaseOutputs` only for phases < N
  - Clears phase-specific state conditionally (fingerprint, tasks, cursors, adjudication, flow checkpoints)
  - Filters `__flowCheckpoint.completedExecutionIds` to remove nodes for phases ≥ N

### `src/core/runtime.ts`
- Added `fromPhase` to `RuntimeOptions`
- Validates `--from-phase <= --phase` at init
- `--from-phase` implies resume for earlier phases (loads existing checkpoint)
- Calls `checkpoint.resetFromPhase()` before flow execution

### `src/index.ts`
- Added `--from-phase <number>` option to the `migrate` command

### `tests/core/checkpoint.test.ts`
- 8 new tests covering: phase clearing, full reset (phase 0), prerequisite validation, flow checkpoint ID filtering, nested flow checkpoint clearing, cursor reset, disk persistence, adjudication state clearing