### PR TITLE
fix(flow): restore per-task parity and wave recovery agents in wave-barrier mode

### DIFF
--- a/src/flow/steps/migration.ts
+++ b/src/flow/steps/migration.ts
@@ -462,6 +462,7 @@ function buildWaveBarrierFlow(
   const waves = computeTopologicalWaves(tasks);
   const nodes: FlowNode<MigrationFlowContext>[] = [];
   const maxConvergence = ctx.config.options.waveControl?.maxConvergenceIterations ?? 3;
+  const gateMode = getQualityGateMode(ctx);
 
   for (let w = 0; w < waves.length; w++) {
     const waveTasks = waves[w]!;
@@ -482,16 +483,44 @@ function buildWaveBarrierFlow(
     }));
 
     // Wave task execution (parallel branches)
+    // Each branch runs: migrate → commit → target-index → parity → parity-gate → minor-repass
+    // Build/test gates run at the wave barrier, but parity is per-task.
     nodes.push(parallel<MigrationFlowContext>({
       id: `wave-${w}-tasks`,
       dependsOn: [`wave-${w}-start`],
-      branches: Object.fromEntries(waveTasksCopy.map(task => [
-        task.id,
-        [step<MigrationFlowContext>({
-          id: `${task.id}/migrate`,
-          run: (c) => runMigrateSubstep(c.context, task, retryExec),
-        })],
-      ])),
+      branches: Object.fromEntries(waveTasksCopy.map(task => {
+        const branchSteps: FlowNode<MigrationFlowContext>[] = [
+          step<MigrationFlowContext>({
+            id: `${task.id}/migrate`,
+            run: (c) => runMigrateSubstep(c.context, task, retryExec),
+          }),
+          step<MigrationFlowContext>({
+            id: `${task.id}/commit`,
+            run: (c) => runCommitSubstep(c.context, task),
+          }),
+          step<MigrationFlowContext>({
+            id: `${task.id}/target-index`,
+            run: (c) => runTargetIndexSubstep(c.context, task),
+          }),
+          step<MigrationFlowContext>({
+            id: `${task.id}/parity`,
+            run: (c) => runParitySubstep(c.context, task),
+          }),
+        ];
+        if (gateMode !== 'skip') {
+          branchSteps.push(
+            step<MigrationFlowContext>({
+              id: `${task.id}/parity-gate`,
+              run: (c) => runParityGateSubstep(c.context, task),
+            }),
+            step<MigrationFlowContext>({
+              id: `${task.id}/minor-repass`,
+              run: (c) => runMinorRepassSubstep(c.context, task),
+            }),
+          );
+        }
+        return [task.id, branchSteps];
+      })),
     }));
 
     // Barrier entry marker
@@ -524,7 +553,16 @@ function buildWaveBarrierFlow(
           },
           then: [step<MigrationFlowContext>({
             id: `wave-${w}-fix`,
-            run: async (c) => recoverWaveValidationFailure(c.context, w, waveTasksCopy),
+            run: async (c) => {
+              const validation = c.getStepOutput<WaveValidationResult>(`wave-${w}-validate`);
+              if (!validation) {
+                throw new Error(
+                  `Wave ${w} recovery triggered but no validation result found for step wave-${w}-validate. ` +
+                  `This is a runtime bug — the convergence loop conditional should only fire after validation completes.`,
+                );
+              }
+              return recoverWaveValidationFailure(c.context, w, waveTasksCopy, validation);
+            },
           })],
         }),
       ],
@@ -821,13 +859,18 @@ function buildWaveRecoveryTask(wave: number, waveCandidates: MigrationTask[]): M
 async function recoverWaveValidationFailure(
   ctx: MigrationFlowContext, wave: number,
   waveCandidates: MigrationTask[],
-  validation?: WaveValidationResult,
+  validation: WaveValidationResult,
 ): Promise<boolean> {
-  if (validation?.success) return true;
-  const failedLabel = validation?.failedLabel;
-  const failedCommand = validation?.failedCommand;
-  const failure = validation?.failure;
-  if (!failedLabel || !failedCommand || !failure || failure.success) return false;
+  if (validation.success) return true;
+  const { failedLabel, failedCommand, failure } = validation;
+  if (!failedLabel || !failedCommand || !failure) {
+    throw new Error(
+      `Wave ${wave} validation failed but returned incomplete result ` +
+      `(failedLabel=${failedLabel}, failedCommand=${failedCommand}, failure=${!!failure}). ` +
+      `This is a runtime bug — WaveValidationResult must include failure details when success=false.`,
+    );
+  }
+  if (failure.success) return true;
   const waveTask = buildWaveRecoveryTask(wave, waveCandidates);
   const artifactPaths = Array.from(new Set(waveCandidates.flatMap(t => [...t.sourceFiles, ...t.targetFiles])));
   return runCommandWithRecovery(ctx, failedLabel, failedCommand, waveTask, undefined, {


### PR DESCRIPTION
Closes #187

## Summary

The Cadre framework refactor introduced two regressions in wave-barrier execution mode that caused parity verification to be silently skipped and wave recovery agents to never launch.

## Bug 1 — Per-task parity dropped from wave-barrier branches

Each wave-barrier branch only ran the `migrate` substep. The full per-task sequence (`commit → target-index → parity → parity-gate → minor-repass`) was only present in `buildPerTaskFlow`, not `buildWaveBarrierFlow`.

**Impact:** `parity-verifier` and `test-writer` agents never launched during Phase 4 wave-barrier execution, regardless of `qualityPolicy` setting.

**Fix:** Wave-barrier branches now run the full per-task sequence. Build/test gates remain at the wave barrier level as intended — waves create compilable units, but parity is checked per-task.

## Bug 2 — Wave convergence recovery never launched agents

`recoverWaveValidationFailure` expects a `WaveValidationResult` parameter, but the flow step called it without one:

```ts
// Before (broken) — validation is always undefined
run: async (c) => recoverWaveValidationFailure(c.context, w, waveTasksCopy),
```

Since `validation` was `undefined`, the guard clause `if (!failedLabel || !failedCommand || !failure || failure.success) return false` silently returned `false`. No `parity-failure-resolver` or `code-migrator` agents ever fired. The convergence loop just re-ran deterministic build commands.

**Fix:**
- The flow step now retrieves the validation result via `getStepOutput()` and passes it through
- `recoverWaveValidationFailure` signature changed to **require** `validation` (non-optional)
- Missing or incomplete results now **throw** with diagnostic messages instead of silently returning `false`

## Testing

All 254 flow tests pass, including 16 wave-specific tests.