### PR TITLE
fix(checkpoint): sync completedPhases from flow execution IDs on every checkpoint save

### DIFF
--- a/src/core/checkpoint.ts
+++ b/src/core/checkpoint.ts
@@ -435,11 +435,16 @@ export class CheckpointManager {
     if (state.__flowCheckpoint && typeof state.__flowCheckpoint === 'object') {
       const fc = state.__flowCheckpoint as FlowCheckpointSnapshot<unknown>;
       if (Array.isArray(fc.completedExecutionIds)) {
-        fc.completedExecutionIds = fc.completedExecutionIds.filter(id => {
-          const phase = nodeIdToPhase(id);
+        fc.completedExecutionIds = fc.completedExecutionIds.filter((id: string) => {
+          // Execution IDs are namespaced: "<flowId>/<nodeId>".
+          // Strip the prefix to get the bare node ID for phase lookup.
+          const slashIdx = id.indexOf('/');
+          const bareId = slashIdx >= 0 ? id.slice(slashIdx + 1) : id;
+          const phase = nodeIdToPhase(bareId);
           // Keep nodes that belong to phases before fromPhase.
-          // Also keep unknown nodes (phase === -1) to be safe.
-          return phase < fromPhase && phase !== -1;
+          // Keep unknown nodes (phase === -1) to be safe — they may be
+          // internal framework nodes not mapped to any phase.
+          return phase === -1 || phase < fromPhase;
         });
       }
     }

--- a/src/flow/checkpoint-adapter.ts
+++ b/src/flow/checkpoint-adapter.ts
@@ -6,6 +6,7 @@
 import type { FlowCheckpointAdapter, FlowCheckpointSnapshot } from '@cadre-dev/framework/flow';
 import type { CheckpointManager } from '../core/checkpoint.js';
 import type { MigrationFlowContext } from './context.js';
+import { PHASE_BOUNDARY_NODE_IDS } from './migration-flow.js';
 
 /**
  * Wraps AAMF's existing {@link CheckpointManager} to satisfy the framework's
@@ -42,6 +43,11 @@ export class AamfFlowCheckpointAdapter implements FlowCheckpointAdapter<Migratio
       // The context is reconstructed from the runtime on resume.
     };
     state.__flowCheckpoint = serialisable;
+
+    // Sync completedPhases from flow execution IDs so that --from-phase
+    // prerequisite checks work even if the run fails mid-pipeline.
+    syncCompletedPhases(state, snapshot.completedExecutionIds, snapshot.flowId);
+
     await this.checkpoint.save(state);
   }
 }
@@ -79,5 +85,47 @@ export class Phase4CheckpointAdapter implements FlowCheckpointAdapter<MigrationF
     };
     state.__phase4FlowCheckpoint = serialisable;
     await this.checkpoint.save(state);
+  }
+}
+
+
+// ─── completedPhases sync ───────────────────────────────────────────
+
+/**
+ * Derive completed phases from the flow's completedExecutionIds and merge
+ * them into checkpoint state. A phase is complete when its boundary node
+ * (the last node belonging to that phase) appears in the completed set.
+ *
+ * This ensures `--from-phase N` prerequisite checks pass even when the
+ * pipeline fails in a later phase, since completedPhases is updated
+ * incrementally on every checkpoint save rather than only at end-of-run.
+ */
+function syncCompletedPhases(
+  state: import('../core/checkpoint.js').CheckpointState,
+  completedExecutionIds: string[],
+  flowId: string,
+): void {
+  // Execution IDs are namespaced: "<flowId>/<nodeId>"
+  const prefix = flowId + '/';
+  const completedNodes = new Set(
+    completedExecutionIds
+      .filter(id => id.startsWith(prefix))
+      .map(id => id.slice(prefix.length)),
+  );
+
+  for (let phase = 0; phase < PHASE_BOUNDARY_NODE_IDS.length; phase++) {
+    const boundaryNode = PHASE_BOUNDARY_NODE_IDS[phase]!;
+    if (completedNodes.has(boundaryNode) && !state.completedPhases.includes(phase)) {
+      state.completedPhases.push(phase);
+    }
+  }
+
+  // Keep sorted for deterministic output
+  state.completedPhases.sort((a, b) => a - b);
+
+  // Advance currentPhase to at least max(completedPhases) + 1
+  if (state.completedPhases.length > 0) {
+    const maxCompleted = state.completedPhases[state.completedPhases.length - 1]!;
+    state.currentPhase = Math.max(state.currentPhase, maxCompleted + 1);
   }
 }

--- a/src/flow/index.ts
+++ b/src/flow/index.ts
@@ -4,7 +4,7 @@
  * Declarative migration flow replacing MigrationOrchestrator.
  */
 
-export { migrationFlow, buildFlowUpToPhase, nodeIdToPhase } from './migration-flow.js';
+export { migrationFlow, buildFlowUpToPhase, nodeIdToPhase, PHASE_BOUNDARY_NODE_IDS } from './migration-flow.js';
 export { AamfFlowCheckpointAdapter, Phase4CheckpointAdapter } from './checkpoint-adapter.js';
 export type { MigrationFlowContext } from './context.js';
 export type { TaskGraphOutput } from './steps/task-graph.js';

--- a/src/flow/migration-flow.ts
+++ b/src/flow/migration-flow.ts
@@ -237,7 +237,7 @@ export function nodeIdToPhase(nodeId: string): number {
  * Ordered list of phase boundary node IDs for `--phase` filtering.
  * Each entry is the last top-level node ID belonging to that phase.
  */
-const PHASE_BOUNDARY_NODE_IDS: readonly string[] = [
+export const PHASE_BOUNDARY_NODE_IDS: readonly string[] = [
   'kb-index',                // Phase 0
   'task-graph-construction', // Phase 1
   'budget-check-2',         // Phase 2

--- a/tests/core/checkpoint.test.ts
+++ b/tests/core/checkpoint.test.ts
@@ -672,22 +672,22 @@ describe('CheckpointManager', () => {
     for (let p = 0; p <= 5; p++) {
       await manager.completePhase(p, `/out/${p}`);
     }
-    // Simulate a flow checkpoint with completed execution IDs
+    // Simulate a flow checkpoint with namespaced completed execution IDs
     state.__flowCheckpoint = {
       flowId: 'aamf-migration',
       status: 'completed',
       startedAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       completedExecutionIds: [
-        'kb-index',              // phase 0
-        'task-graph-construction', // phase 1
-        'kb-construction',       // phase 2
-        'budget-check-2',        // phase 2
-        'migration-planning',    // phase 3
-        'budget-check-3',        // phase 3
-        'iterative-migration',   // phase 4
-        'budget-check-4',        // phase 4
-        'final-parity-loop',     // phase 5
+        'aamf-migration/kb-index',              // phase 0
+        'aamf-migration/task-graph-construction', // phase 1
+        'aamf-migration/kb-construction',       // phase 2
+        'aamf-migration/budget-check-2',        // phase 2
+        'aamf-migration/migration-planning',    // phase 3
+        'aamf-migration/budget-check-3',        // phase 3
+        'aamf-migration/iterative-migration',   // phase 4
+        'aamf-migration/budget-check-4',        // phase 4
+        'aamf-migration/final-parity-loop',     // phase 5
       ],
       outputs: {},
       executionOutputs: {},
@@ -700,12 +700,12 @@ describe('CheckpointManager', () => {
     const fc = reset.__flowCheckpoint as { completedExecutionIds: string[] };
     // Should keep phases 0-3 execution IDs, remove 4+
     expect(fc.completedExecutionIds).toEqual([
-      'kb-index',
-      'task-graph-construction',
-      'kb-construction',
-      'budget-check-2',
-      'migration-planning',
-      'budget-check-3',
+      'aamf-migration/kb-index',
+      'aamf-migration/task-graph-construction',
+      'aamf-migration/kb-construction',
+      'aamf-migration/budget-check-2',
+      'aamf-migration/migration-planning',
+      'aamf-migration/budget-check-3',
     ]);
   });
 

--- a/tests/flow/checkpoint-adapter.test.ts
+++ b/tests/flow/checkpoint-adapter.test.ts
@@ -15,6 +15,7 @@ import {
   migrationFlow,
   buildFlowUpToPhase,
   nodeIdToPhase,
+  PHASE_BOUNDARY_NODE_IDS,
 } from '../../src/flow/index.js';
 
 let tempDir: string;
@@ -60,6 +61,100 @@ describe('AamfFlowCheckpointAdapter', () => {
     expect(loaded!.flowId).toBe('aamf-migration');
     expect(loaded!.completedExecutionIds).toEqual(['kb-index', 'task-graph-construction']);
   });
+
+  it('should sync completedPhases from flow execution IDs on save', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'aamf-ckpt-'));
+    await mkdir(tempDir, { recursive: true });
+    const logger = new Logger({ logDir: join(tempDir, 'logs'), level: 'error', console: false });
+    const cm = new CheckpointManager(tempDir, logger);
+    await cm.load('test');
+    const adapter = new AamfFlowCheckpointAdapter(cm);
+
+    // Save a snapshot where phases 0-2 boundary nodes are completed
+    const snapshot = {
+      flowId: 'aamf-migration',
+      status: 'running' as const,
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      completedExecutionIds: [
+        'aamf-migration/kb-index',              // phase 0 boundary
+        'aamf-migration/task-graph-construction', // phase 1 boundary
+        'aamf-migration/kb-construction',        // phase 2 (not boundary)
+        'aamf-migration/budget-check-2',         // phase 2 boundary
+      ],
+      outputs: {},
+      executionOutputs: {},
+    };
+    await adapter.save(snapshot as any);
+
+    const state = cm.getState();
+    expect(state.completedPhases).toEqual([0, 1, 2]);
+    expect(state.currentPhase).toBe(3);
+  });
+
+  it('should not mark a phase complete if its boundary node is missing', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'aamf-ckpt-'));
+    await mkdir(tempDir, { recursive: true });
+    const logger = new Logger({ logDir: join(tempDir, 'logs'), level: 'error', console: false });
+    const cm = new CheckpointManager(tempDir, logger);
+    await cm.load('test');
+    const adapter = new AamfFlowCheckpointAdapter(cm);
+
+    // Phase 2 has kb-construction done but NOT budget-check-2 (boundary)
+    const snapshot = {
+      flowId: 'aamf-migration',
+      status: 'running' as const,
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      completedExecutionIds: [
+        'aamf-migration/kb-index',
+        'aamf-migration/task-graph-construction',
+        'aamf-migration/kb-construction',
+        // budget-check-2 NOT completed yet
+      ],
+      outputs: {},
+      executionOutputs: {},
+    };
+    await adapter.save(snapshot as any);
+
+    const state = cm.getState();
+    // Phase 2 should NOT be in completedPhases since its boundary node is missing
+    expect(state.completedPhases).toEqual([0, 1]);
+    expect(state.currentPhase).toBe(2);
+  });
+
+  it('should accumulate completedPhases across multiple saves', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'aamf-ckpt-'));
+    await mkdir(tempDir, { recursive: true });
+    const logger = new Logger({ logDir: join(tempDir, 'logs'), level: 'error', console: false });
+    const cm = new CheckpointManager(tempDir, logger);
+    await cm.load('test');
+    const adapter = new AamfFlowCheckpointAdapter(cm);
+
+    // First save: phase 0 complete
+    await adapter.save({
+      flowId: 'aamf-migration',
+      status: 'running' as const,
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      completedExecutionIds: ['aamf-migration/kb-index'],
+      outputs: {},
+      executionOutputs: {},
+    } as any);
+    expect(cm.getState().completedPhases).toEqual([0]);
+
+    // Second save: phases 0-1 complete
+    await adapter.save({
+      flowId: 'aamf-migration',
+      status: 'running' as const,
+      startedAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      completedExecutionIds: ['aamf-migration/kb-index', 'aamf-migration/task-graph-construction'],
+      outputs: {},
+      executionOutputs: {},
+    } as any);
+    expect(cm.getState().completedPhases).toEqual([0, 1]);
+  });
 });
 
 describe('flow/index re-exports', () => {
@@ -91,5 +186,11 @@ describe('flow/index re-exports', () => {
   it('should export nodeIdToPhase', () => {
     expect(nodeIdToPhase).toBeDefined();
     expect(nodeIdToPhase('kb-index')).toBe(0);
+  });
+
+  it('should export PHASE_BOUNDARY_NODE_IDS', () => {
+    expect(PHASE_BOUNDARY_NODE_IDS).toBeDefined();
+    expect(PHASE_BOUNDARY_NODE_IDS[0]).toBe('kb-index');
+    expect(PHASE_BOUNDARY_NODE_IDS).toHaveLength(9);
   });
 });


### PR DESCRIPTION
## Problem

`--from-phase N` always fails with:
```
Cannot --from-phase 4: prerequisite phase(s) 0, 1, 2, 3 not completed. Completed phases: []
```

The `completedPhases` array in checkpoint state was never populated during flow execution. It was only written in a post-run loop (`runtime.ts` line ~340) that iterates `flowResult.executionOutputs` — but when the flow fails mid-pipeline (e.g., Phase 4 convergence exhaustion), that loop never runs, leaving `completedPhases: []`.

## Root Cause

Three related bugs:

1. **`completedPhases` never synced during execution** — The flow checkpoint adapter (`AamfFlowCheckpointAdapter.save()`) persisted the flow snapshot but never derived phase completion state from it.

2. **`resetFromPhase` dropped all execution IDs** — `nodeIdToPhase()` maps bare node IDs (e.g., `kb-index`), but `completedExecutionIds` are namespaced (e.g., `aamf-migration/kb-index`). Every lookup returned `-1`, and the filter `phase < fromPhase && phase !== -1` dropped everything.

3. **Comment/code mismatch for unknown nodes** — The comment said "keep unknown nodes (phase === -1) to be safe" but the predicate dropped them.

## Fix

- **`AamfFlowCheckpointAdapter.save()`** now calls `syncCompletedPhases()` on every checkpoint save. It derives completed phases from `completedExecutionIds` using `PHASE_BOUNDARY_NODE_IDS` — a phase is complete when its boundary node appears in the completed set.

- **`resetFromPhase`** now strips the `<flowId>/` prefix before calling `nodeIdToPhase()`, and keeps unknown nodes (`phase === -1 || phase < fromPhase`).

- **`PHASE_BOUNDARY_NODE_IDS`** exported from `migration-flow.ts` for use by the adapter.

## Testing

- Updated existing `resetFromPhase` test to use namespaced execution IDs (matching runtime behavior).
- Added 3 new adapter tests:
  - Syncs `completedPhases` from flow execution IDs on save
  - Does not mark a phase complete if its boundary node is missing
  - Accumulates `completedPhases` across multiple saves
- Added re-export test for `PHASE_BOUNDARY_NODE_IDS`.
- All 56 tests pass (44 checkpoint + 12 adapter).