### PR TITLE
fix(agent-launcher): upgrade framework to 0.2.4 for MCP config and log fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aamf",
       "version": "0.1.0",
       "dependencies": {
-        "@cadre-dev/framework": "0.2.3",
+        "@cadre-dev/framework": "^0.2.4",
         "@jafreck/lore": "^0.3.9",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@types/better-sqlite3": "^7.6.13",
@@ -102,9 +102,9 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cadre-dev/framework": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@cadre-dev/framework/-/framework-0.2.3.tgz",
-      "integrity": "sha512-jY/0JvzHdS1Qeb5MG73e9jovWwBnKH1bY9aWI8ZPCPu3mx2f0ZhVWViAgwvJgL0fWlwUWYVQxO1LdqKVmUlt1g==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@cadre-dev/framework/-/framework-0.2.4.tgz",
+      "integrity": "sha512-6vAEgPA6cbyrnD3jFiGIOKBAVOiBtzC0QJGWpsbIBMvTpEn7V2T+c2fQw17oRHnDMlwyOwcxGsGqisVPAFZ20w==",
       "license": "MIT",
       "dependencies": {
         "p-limit": "^7",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "hooks:install": "git config core.hooksPath .githooks"
   },
   "dependencies": {
-    "@cadre-dev/framework": "0.2.3",
+    "@cadre-dev/framework": "^0.2.4",
     "@jafreck/lore": "^0.3.9",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@types/better-sqlite3": "^7.6.13",

--- a/src/core/agent-launcher.ts
+++ b/src/core/agent-launcher.ts
@@ -192,12 +192,14 @@ function adaptLogger(logger: Logger): BackendLoggerLike {
 /** Map an AAMF AgentInvocation to the framework's AgentInvocation. */
 export function toFrameworkInvocation(inv: AgentInvocation): FrameworkInvocation {
   // Build mcpServers map from AAMF extension fields.
-  let mcpServers: Record<string, { url: string }> | undefined;
+  // The framework passes these through directly to the CLI, so include
+  // `type: 'http'` as required by the Copilot CLI's --additional-mcp-config.
+  let mcpServers: Record<string, Record<string, unknown>> | undefined;
   if (inv.extensions?.mcpConfig) {
-    mcpServers = { 'aamf-kb': { url: inv.extensions.mcpConfig.url } };
+    mcpServers = { 'aamf-kb': { type: 'http', url: inv.extensions.mcpConfig.url } };
   }
   if (inv.extensions?.targetMcpConfig) {
-    mcpServers = { ...mcpServers, 'aamf-kb-target': { url: inv.extensions.targetMcpConfig.url } };
+    mcpServers = { ...mcpServers, 'aamf-kb-target': { type: 'http', url: inv.extensions.targetMcpConfig.url } };
   }
 
   return {

--- a/tests/core/agent-launcher.test.ts
+++ b/tests/core/agent-launcher.test.ts
@@ -89,7 +89,7 @@ describe('toFrameworkInvocation', () => {
     });
     const fw = toFrameworkInvocation(inv);
     expect((fw as any).mcpServers).toEqual({
-      'aamf-kb': { url: 'http://localhost:3000/mcp' },
+      'aamf-kb': { type: 'http', url: 'http://localhost:3000/mcp' },
     });
   });
 
@@ -99,7 +99,7 @@ describe('toFrameworkInvocation', () => {
     });
     const fw = toFrameworkInvocation(inv);
     expect((fw as any).mcpServers).toEqual({
-      'aamf-kb-target': { url: 'http://localhost:3001/mcp' },
+      'aamf-kb-target': { type: 'http', url: 'http://localhost:3001/mcp' },
     });
   });
 
@@ -112,8 +112,8 @@ describe('toFrameworkInvocation', () => {
     });
     const fw = toFrameworkInvocation(inv);
     expect((fw as any).mcpServers).toEqual({
-      'aamf-kb': { url: 'http://localhost:3000/mcp' },
-      'aamf-kb-target': { url: 'http://localhost:3001/mcp' },
+      'aamf-kb': { type: 'http', url: 'http://localhost:3000/mcp' },
+      'aamf-kb-target': { type: 'http', url: 'http://localhost:3001/mcp' },
     });
   });
 


### PR DESCRIPTION
## Summary

Upgrades `@cadre-dev/framework` from 0.2.3 to 0.2.4 and aligns AAMF's MCP config format with the framework's new passthrough model.

## Problem

Two issues in framework 0.2.3 caused all KB-aware agent invocations (code-migrator, parity-verifier, parity-failure-resolver, test-writer) to fail silently:

1. **MCP config format** — The Copilot CLI requires `type: 'http'` on MCP server entries passed via `--additional-mcp-config`. The framework was serializing `{ url }` without the `type` field, causing every agent to exit immediately with `Invalid MCP server configuration`.

2. **Duplicate `.cadre/issues/` logs** — The framework unconditionally wrote agent logs under `<worktreePath>/.cadre/issues/`, duplicating logs AAMF already writes under `.aamf/migration/<project>/logs/agents/`.

## Changes

- **Bump** `@cadre-dev/framework` from 0.2.3 → 0.2.4
- **Pass `type: 'http'`** in `mcpServers` entries in `toFrameworkInvocation()` — the framework now forwards config objects directly to the CLI instead of extracting only `url`
- **Remove `issuesDir: false` workaround** from `buildBackendRuntimeConfig()` — framework 0.2.4 no longer writes `.cadre/issues/` logs
- **Update 3 tests** to assert the new `{ type: 'http', url }` shape

## Testing

All 1438 tests pass.