### PR TITLE
fix(launcher): pass allowAllPaths and allowAllTools to copilot backend

### DIFF
--- a/src/core/agent-launcher.ts
+++ b/src/core/agent-launcher.ts
@@ -168,6 +168,8 @@ export function buildBackendRuntimeConfig(config: MigrationConfig): BackendRunti
       copilot: {
         cliCommand: backendName === 'copilot' ? config.agentBackend.cliCommand : undefined,
         agentDir: config.agentBackend.agentDir,
+        allowAllPaths: true,
+        allowAllTools: true,
       },
       claude: {
         cliCommand: backendName === 'claude' ? config.agentBackend.cliCommand : undefined,

--- a/tests/core/agent-launcher.test.ts
+++ b/tests/core/agent-launcher.test.ts
@@ -41,6 +41,8 @@ describe('buildBackendRuntimeConfig', () => {
     const rtConfig = buildBackendRuntimeConfig(config);
     expect(rtConfig.agent.copilot?.cliCommand).toBe('/usr/local/bin/copilot');
     expect(rtConfig.agent.copilot?.agentDir).toBe('.github/agents');
+    expect(rtConfig.agent.copilot?.allowAllPaths).toBe(true);
+    expect(rtConfig.agent.copilot?.allowAllTools).toBe(true);
   });
 
   it('should include claude cliCommand for claude backend', () => {


### PR DESCRIPTION
## Problem

Code-migrator agents spawned via the Copilot CLI produce zero output files. Every write and shell command is rejected with "Permission denied and could not request permission from user."

# Root Cause

`buildBackendRuntimeConfig` never sets `allowAllPaths` or `allowAllTools` on the copilot backend options. The framework's `CopilotBackend` defaults both to `false`, so the CLI is launched with `--no-ask-user` but without `--allow-all-paths` or `--allow-all-tools`. In headless mode this causes every file mutation and shell command to be silently rejected.

## Fix

Set `allowAllPaths: true` and `allowAllTools: true` in the copilot backend config. These are required for any headless agent invocation that needs to write files or run commands."