### PR TITLE
fix: add migration run lock to prevent overlapping runs

### DIFF
--- a/src/core/run-lock.ts
+++ b/src/core/run-lock.ts
@@ -1,0 +1,152 @@
+import { open, readFile, rm } from 'node:fs/promises';
+import { readFileSync, rmSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { hostname } from 'node:os';
+import type { Logger } from '../logging/logger.js';
+import { ensureDir } from '../util/fs.js';
+
+export interface MigrationRunLockMetadata {
+  version: 1;
+  projectName: string;
+  runId: string;
+  pid: number;
+  hostname: string;
+  acquiredAt: string;
+}
+
+export class ActiveMigrationRunError extends Error {
+  constructor(lockPath: string, metadata?: Partial<MigrationRunLockMetadata>) {
+    const owner = metadata
+      ? `runId=${metadata.runId ?? 'unknown'}, pid=${metadata.pid ?? 'unknown'}, host=${metadata.hostname ?? 'unknown'}, acquiredAt=${metadata.acquiredAt ?? 'unknown'}`
+      : 'unknown owner';
+    super(`Migration directory is already locked by another active runtime (${owner}). Lock file: ${lockPath}`);
+    this.name = 'ActiveMigrationRunError';
+  }
+}
+
+export class MigrationRunLock {
+  private acquired = false;
+
+  constructor(
+    private readonly lockPath: string,
+    private readonly logger: Logger,
+    private readonly projectName: string,
+    private readonly runId: string,
+    private readonly pid: number = process.pid,
+    private readonly host: string = hostname(),
+  ) {}
+
+  async acquire(): Promise<void> {
+    if (this.acquired) return;
+
+    await ensureDir(dirname(this.lockPath));
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const handle = await open(this.lockPath, 'wx');
+        try {
+          await handle.writeFile(JSON.stringify(this.buildMetadata(), null, 2) + '\n', 'utf-8');
+        } finally {
+          await handle.close();
+        }
+        this.acquired = true;
+        return;
+      } catch (err) {
+        const error = err as NodeJS.ErrnoException;
+        if (error.code !== 'EEXIST') throw err;
+
+        const existing = await this.readLockFile();
+        if (existing && this.isActiveLock(existing)) {
+          throw new ActiveMigrationRunError(this.lockPath, existing);
+        }
+
+        if (attempt === 1) {
+          throw new Error(`Failed to acquire migration run lock at ${this.lockPath}`);
+        }
+
+        if (existing) {
+          this.logger.warn(
+            `Removing stale migration run lock held by runId=${existing.runId ?? 'unknown'} pid=${existing.pid ?? 'unknown'} at ${this.lockPath}`,
+          );
+        } else {
+          this.logger.warn(`Removing unreadable migration run lock at ${this.lockPath}`);
+        }
+        await rm(this.lockPath, { force: true });
+      }
+    }
+  }
+
+  async release(): Promise<void> {
+    if (!this.acquired) return;
+    this.acquired = false;
+
+    const existing = await this.readLockFile();
+    if (existing && !this.isOwnedByCurrentRun(existing)) {
+      return;
+    }
+
+    await rm(this.lockPath, { force: true });
+  }
+
+  releaseSync(): void {
+    if (!this.acquired) return;
+    this.acquired = false;
+
+    const existing = this.readLockFileSync();
+    if (existing && !this.isOwnedByCurrentRun(existing)) {
+      return;
+    }
+
+    rmSync(this.lockPath, { force: true });
+  }
+
+  private buildMetadata(): MigrationRunLockMetadata {
+    return {
+      version: 1,
+      projectName: this.projectName,
+      runId: this.runId,
+      pid: this.pid,
+      hostname: this.host,
+      acquiredAt: new Date().toISOString(),
+    };
+  }
+
+  private isActiveLock(metadata: Partial<MigrationRunLockMetadata>): boolean {
+    if (metadata.hostname && metadata.hostname !== this.host) {
+      return true;
+    }
+    if (typeof metadata.pid !== 'number' || !Number.isInteger(metadata.pid) || metadata.pid <= 0) {
+      return false;
+    }
+
+    try {
+      process.kill(metadata.pid, 0);
+      return true;
+    } catch (err) {
+      const error = err as NodeJS.ErrnoException;
+      return error.code === 'EPERM';
+    }
+  }
+
+  private isOwnedByCurrentRun(metadata: Partial<MigrationRunLockMetadata>): boolean {
+    return metadata.runId === this.runId && metadata.pid === this.pid;
+  }
+
+  private async readLockFile(): Promise<Partial<MigrationRunLockMetadata> | undefined> {
+    try {
+      const raw = await readFile(this.lockPath, 'utf-8');
+      return JSON.parse(raw) as Partial<MigrationRunLockMetadata>;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private readLockFileSync(): Partial<MigrationRunLockMetadata> | undefined {
+    try {
+      const raw = readFileSync(this.lockPath, 'utf-8');
+      return JSON.parse(raw) as Partial<MigrationRunLockMetadata>;
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/src/core/runtime-paths.ts
+++ b/src/core/runtime-paths.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 export interface RuntimePaths {
   root: string;
   stateDir: string;
+  runLockFile: string;
   checkpointFile: string;
   checkpointBackupFile: string;
   runManifestFile: string;
@@ -53,6 +54,7 @@ export function buildRuntimePaths(projectRoot: string, projectName: string): Run
   return {
     root,
     stateDir,
+    runLockFile: join(stateDir, 'run.lock.json'),
     checkpointFile: join(stateDir, 'checkpoint.json'),
     checkpointBackupFile: join(stateDir, 'checkpoint.backup.json'),
     runManifestFile: join(stateDir, 'run-manifest.json'),

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -15,6 +15,7 @@ import { fileExists } from '../util/fs.js';
 import { formatDuration } from '../util/format.js';
 import { killAllActiveProcesses } from '../util/process.js';
 import { buildRuntimePaths } from './runtime-paths.js';
+import { MigrationRunLock } from './run-lock.js';
 import { generateAgentDefinitions } from '../agents/generator.js';
 import { ContextBuilder } from '../agents/context-builder.js';
 import { MetricsCollector } from '../observability/metrics-collector.js';
@@ -92,6 +93,7 @@ export class MigrationRuntime {
   /** Mutable flow context — populated during run(), used by shutdown handler. */
   private flowContext?: MigrationFlowContext;
   private abortController?: AbortController;
+  private runLock?: MigrationRunLock;
 
   private getActiveRuntimeSettings(): {
     agentDir: string;
@@ -186,6 +188,9 @@ export class MigrationRuntime {
   }
 
   async run(): Promise<MigrationResult> {
+    await this.acquireRunLock();
+
+    try {
     // Load or create checkpoint.
     //   --from-phase implies resume for earlier phases (load existing checkpoint).
     //   resume=false (without --from-phase) forces a fresh start.
@@ -420,6 +425,9 @@ export class MigrationRuntime {
     await this.logger.flush();
     this.printSummary(migrationResult);
     return migrationResult;
+    } finally {
+      await this.releaseRunLock();
+    }
   }
 
   async getStatus(): Promise<string> {
@@ -463,6 +471,40 @@ export class MigrationRuntime {
       this.logger.info('Reset all migration state');
     }
     await this.checkpoint.save(state);
+  }
+
+  private async acquireRunLock(): Promise<void> {
+    this.runLock = new MigrationRunLock(
+      this.paths.runLockFile,
+      this.logger,
+      this.config.projectName,
+      this.runId,
+    );
+    await this.runLock.acquire();
+  }
+
+  private async releaseRunLock(): Promise<void> {
+    if (!this.runLock) return;
+
+    const lock = this.runLock;
+    this.runLock = undefined;
+    try {
+      await lock.release();
+    } catch (err) {
+      this.logger.warn(`Failed to release migration run lock: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  private releaseRunLockSync(): void {
+    if (!this.runLock) return;
+
+    const lock = this.runLock;
+    this.runLock = undefined;
+    try {
+      lock.releaseSync();
+    } catch {
+      // Best-effort
+    }
   }
 
   private printSummary(result: MigrationResult): void {
@@ -650,12 +692,16 @@ export class MigrationRuntime {
       } catch {
         // Best-effort save
       }
+      await this.releaseRunLock();
       clearTimeout(shutdownTimeout);
       process.exit(signal === 'SIGINT' ? 130 : 143);
     };
     
     process.on('SIGINT', () => void handler('SIGINT'));
     process.on('SIGTERM', () => void handler('SIGTERM'));
+    process.on('exit', () => {
+      this.releaseRunLockSync();
+    });
   }
 
   /**

--- a/tests/agents/context-builder.test.ts
+++ b/tests/agents/context-builder.test.ts
@@ -27,6 +27,7 @@ describe('ContextBuilder', () => {
     return {
       root,
       stateDir,
+      runLockFile: join(stateDir, 'run.lock.json'),
       checkpointFile: join(stateDir, 'checkpoint.json'),
       checkpointBackupFile: join(stateDir, 'checkpoint.backup.json'),
       runManifestFile: join(stateDir, 'run-manifest.json'),
@@ -36,6 +37,8 @@ describe('ContextBuilder', () => {
       logsCommandsDir,
       logsCommandBuildDir: join(logsCommandsDir, 'build'),
       logsCommandTestDir: join(logsCommandsDir, 'test'),
+      logsCommandFormatDir: join(logsCommandsDir, 'format'),
+      logsCommandLintDir: join(logsCommandsDir, 'lint'),
       artifactsDir,
       artifactsContextsDir: join(artifactsDir, 'contexts'),
       artifactsResultsDir: join(artifactsDir, 'results'),
@@ -49,12 +52,15 @@ describe('ContextBuilder', () => {
       metricsInvocationsFile: join(metricsDir, 'invocations.jsonl'),
       metricsSummaryFile: join(metricsDir, 'summary.json'),
       kbDbFile: join(root, 'kb.db'),
+      kbTargetDbFile: join(root, 'kb-target.db'),
       knowledgeBaseDir: join(root, 'knowledge-base'),
       dependencySummaryFile: join(artifactsPlanningDir, 'dependency-summary.json'),
       migrationPlanFile: join(artifactsPlanningDir, 'migration-plan.md'),
       competingStrategiesFile: join(artifactsPlanningDir, 'competing-strategies.md'),
       finalParityReportFile: join(artifactsParityDir, 'final-parity-report.md'),
       idiomaticReviewReportFile: join(artifactsParityDir, 'idiomatic-review-report.md'),
+      loreLogFile: join(logsRuntimeDir, 'lore.log'),
+      loreTargetLogFile: join(logsRuntimeDir, 'lore-target.log'),
     };
   }
 

--- a/tests/core/runtime.test.ts
+++ b/tests/core/runtime.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { hostname, tmpdir } from 'node:os';
 import { MigrationRuntime, validateSourceAvailability } from '../../src/core/runtime.js';
 import type { MigrationResult } from '../../src/agents/types.js';
 import { Logger } from '../../src/logging/logger.js';
@@ -21,6 +21,10 @@ function makeResult(overrides: Partial<MigrationResult> = {}): MigrationResult {
     blockedTasks: [],
     ...overrides,
   };
+}
+
+function makeRunLockPath(label: string): string {
+  return join(tmpdir(), `aamf-${label}-${Math.random().toString(36).slice(2)}.lock.json`);
 }
 
 describe('MigrationRuntime', () => {
@@ -215,6 +219,9 @@ describe('MigrationRuntime', () => {
         projectName: 'test-project',
         options: { resume: false, dryRun: true },
       };
+      runtime.paths = {
+        runLockFile: makeRunLockPath('dry-run-fresh'),
+      };
       runtime.checkpoint = {
         load: vi.fn().mockResolvedValue(undefined),
       };
@@ -253,6 +260,9 @@ describe('MigrationRuntime', () => {
         projectName: 'test-project',
         options: { resume: true, dryRun: true },
       };
+      runtime.paths = {
+        runLockFile: makeRunLockPath('dry-run-resume'),
+      };
       runtime.checkpoint = {
         load: vi.fn().mockResolvedValue(state),
         getState: vi.fn().mockReturnValue(state),
@@ -269,6 +279,88 @@ describe('MigrationRuntime', () => {
       expect(runtime.checkpoint.load).toHaveBeenCalledWith('test-project', { fresh: false });
       expect(runtime.progress.initialize).not.toHaveBeenCalled();
       expect(runtime.progress.reconstructFromCheckpoint).toHaveBeenCalledWith(state);
+    });
+
+    it('rejects when another runtime already holds the run lock', async () => {
+      const lockRoot = await mkdtemp(join(tmpdir(), 'aamf-runtime-lock-'));
+      const lockPath = join(lockRoot, 'state', 'run.lock.json');
+      await mkdir(join(lockRoot, 'state'), { recursive: true });
+      await writeFile(
+        lockPath,
+        JSON.stringify({
+          version: 1,
+          projectName: 'test-project',
+          runId: 'other-run',
+          pid: process.pid,
+          hostname: hostname(),
+          acquiredAt: new Date().toISOString(),
+        }, null, 2) + '\n',
+        'utf-8',
+      );
+
+      const runtime = new MigrationRuntime() as any;
+      runtime.config = {
+        projectName: 'test-project',
+        options: { resume: false, dryRun: true },
+      };
+      runtime.runId = 'test-run-id';
+      runtime.paths = { runLockFile: lockPath };
+      runtime.checkpoint = {
+        load: vi.fn().mockResolvedValue(undefined),
+      };
+      runtime.progress = {
+        initialize: vi.fn().mockResolvedValue(undefined),
+        reconstructFromCheckpoint: vi.fn(),
+        appendEvent: vi.fn().mockResolvedValue(undefined),
+      };
+      runtime.logger = { info: vi.fn(), warn: vi.fn() };
+
+      await expect(runtime.run()).rejects.toThrow('already locked by another active runtime');
+
+      await rm(lockRoot, { recursive: true, force: true });
+    });
+
+    it('removes a stale run lock before continuing', async () => {
+      const lockRoot = await mkdtemp(join(tmpdir(), 'aamf-runtime-lock-'));
+      const lockPath = join(lockRoot, 'state', 'run.lock.json');
+      await mkdir(join(lockRoot, 'state'), { recursive: true });
+      await writeFile(
+        lockPath,
+        JSON.stringify({
+          version: 1,
+          projectName: 'test-project',
+          runId: 'stale-run',
+          pid: 999999,
+          hostname: hostname(),
+          acquiredAt: new Date().toISOString(),
+        }, null, 2) + '\n',
+        'utf-8',
+      );
+
+      const runtime = new MigrationRuntime() as any;
+      runtime.config = {
+        projectName: 'test-project',
+        options: { resume: false, dryRun: true },
+      };
+      runtime.runId = 'test-run-id';
+      runtime.paths = { runLockFile: lockPath };
+      runtime.checkpoint = {
+        load: vi.fn().mockResolvedValue(undefined),
+      };
+      runtime.progress = {
+        initialize: vi.fn().mockResolvedValue(undefined),
+        reconstructFromCheckpoint: vi.fn(),
+        appendEvent: vi.fn().mockResolvedValue(undefined),
+      };
+      runtime.logger = { info: vi.fn(), warn: vi.fn() };
+
+      const result = await runtime.run();
+
+      expect(result.success).toBe(true);
+      expect(runtime.logger.warn).toHaveBeenCalledWith(expect.stringContaining('Removing stale migration run lock'));
+      await expect(stat(lockPath)).rejects.toThrow();
+
+      await rm(lockRoot, { recursive: true, force: true });
     });
 
     it('runs flow runner on non-dry run, flushes logger, and returns result', async () => {
@@ -354,6 +446,7 @@ describe('MigrationRuntime', () => {
       runtime.paths = {
         root: '/tmp/.aamf/test-project',
         stateDir: '/tmp/.aamf/test-project/state',
+        runLockFile: makeRunLockPath('non-dry-run-success'),
         artifactsDir: '/tmp/.aamf/test-project/artifacts',
         artifactsPlanningDir: '/tmp/.aamf/test-project/artifacts/planning',
         artifactsContextsDir: '/tmp/.aamf/test-project/artifacts/contexts',
@@ -448,6 +541,7 @@ describe('MigrationRuntime', () => {
       runtime.runId = 'test-run-id';
       runtime.paths = {
         root: '/tmp/.aamf/test-project',
+        runLockFile: makeRunLockPath('migration-error'),
         kbDbFile: '/tmp/.aamf/test-project/kb.db',
         metricsDir: '/tmp/.aamf/test-project/metrics',
         reportsObservabilityDir: '/tmp/.aamf/test-project/reports/observability',
@@ -527,6 +621,7 @@ describe('MigrationRuntime', () => {
       runtime.runId = 'test-run-id';
       runtime.paths = {
         root: '/tmp/.aamf/test-project',
+        runLockFile: makeRunLockPath('stale-filter'),
         kbDbFile: '/tmp/.aamf/test-project/kb.db',
         metricsDir: '/tmp/.aamf/test-project/metrics',
         reportsObservabilityDir: '/tmp/.aamf/test-project/reports/observability',


### PR DESCRIPTION
## Summary
- add a migration state-directory run lock and stale-lock detection
- acquire and release the lock in the runtime lifecycle, including shutdown paths
- add runtime tests covering active-lock rejection and stale-lock cleanup

## Validation
- npm run build
- vitest tests/core/runtime.test.ts tests/agents/context-builder.test.ts

## Notes
- this PR contains only the run-lock change set
- existing unrelated local changes were left out intentionally