### PR TITLE
Runtime: enforce non-overlapping target-file scheduling in Phase 4

### DIFF
--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -241,7 +241,7 @@ export interface AgentContext {
  * calibrate task complexity against the available recovery budget.
  */
 export interface ExecutionStrategy {
-  /** Phase 4 execution mode: `'per-task'` (serial) or `'wave-barrier'` (concurrent waves). */
+  /** Phase 4 execution mode: `'per-task'` (task-local validation) or `'wave-barrier'` (concurrent waves). */
   executionMode: 'per-task' | 'wave-barrier';
 
   /** Maximum number of agent subprocesses running in parallel. */
@@ -269,7 +269,7 @@ export interface ExecutionStrategy {
   lintCommand?: string;
 
   /**
-   * Whether wave members must have non-overlapping target files/directories.
+   * Whether concurrently runnable tasks must have non-overlapping target files.
    * Always `true` — exposed so the planner can reason about the constraint.
    */
   requiresNonOverlappingTargets: true;

--- a/src/execution/task-queue.ts
+++ b/src/execution/task-queue.ts
@@ -15,11 +15,12 @@ export interface PipelinedTaskResult<T> {
 }
 
 /**
- * Dependency-aware task queue for Phase 4 execution.
+ * Phase 4 graph-ordering and overlap-batching helpers.
  *
- * Tracks task completion and blocked status, and determines which tasks
- * are ready based on dependency satisfaction. Supports checkpoint resume
- * and topological sorting with cycle detection.
+ * The live Phase 4 runner is built declaratively in flow/steps/migration.ts
+ * using Cadre flow nodes. This module provides the reusable task-graph
+ * primitives that runner needs: dependency ordering, ready-queue state for
+ * imperative helpers/tests, and target-file overlap batching utilities.
  */
 export class TaskQueue {
   private tasks: Map<string, MigrationTask> = new Map();

--- a/src/flow/context.ts
+++ b/src/flow/context.ts
@@ -32,7 +32,6 @@ import type {
 import type { EmbeddingProvider } from '@jafreck/lore';
 import type { KbServerProcess } from '../core/kb-server-process.js';
 import type { TargetIndexer } from '../core/target-indexer.js';
-import type { TaskQueue } from '../execution/task-queue.js';
 
 /** Parity result data extracted from parity-verifier aamf-json output. */
 export interface ParityResultData {

--- a/src/flow/steps/migration.ts
+++ b/src/flow/steps/migration.ts
@@ -39,6 +39,84 @@ import {
   assertPhaseSuccess,
 } from './shared.js';
 
+function buildWaveTaskBranch(
+  task: MigrationTask,
+  retryExec: RetryExecutor,
+  gateMode: ReturnType<typeof getQualityGateMode>,
+): FlowNode<MigrationFlowContext>[] {
+  const branchSteps: FlowNode<MigrationFlowContext>[] = [
+    step<MigrationFlowContext>({
+      id: `${task.id}/migrate`,
+      run: (c) => runMigrateSubstep(c.context, task, retryExec),
+    }),
+    step<MigrationFlowContext>({
+      id: `${task.id}/commit`,
+      run: (c) => runCommitSubstep(c.context, task),
+    }),
+    step<MigrationFlowContext>({
+      id: `${task.id}/target-index`,
+      run: (c) => runTargetIndexSubstep(c.context, task),
+    }),
+    step<MigrationFlowContext>({
+      id: `${task.id}/parity`,
+      run: (c) => runParitySubstep(c.context, task),
+    }),
+  ];
+  if (gateMode !== 'skip') {
+    branchSteps.push(
+      step<MigrationFlowContext>({
+        id: `${task.id}/parity-gate`,
+        run: (c) => runParityGateSubstep(c.context, task),
+      }),
+      step<MigrationFlowContext>({
+        id: `${task.id}/minor-repass`,
+        run: (c) => runMinorRepassSubstep(c.context, task),
+      }),
+    );
+  }
+  return branchSteps;
+}
+
+function computeTargetOverlapPredecessors(tasks: MigrationTask[]): Map<string, string[]> {
+  const predecessors = new Map<string, Set<string>>();
+  const lastWriterByTarget = new Map<string, string>();
+
+  for (const task of tasks) {
+    for (const targetFile of new Set(task.targetFiles)) {
+      const previousTaskId = lastWriterByTarget.get(targetFile);
+      if (previousTaskId && previousTaskId !== task.id) {
+        const deps = predecessors.get(task.id) ?? new Set<string>();
+        deps.add(previousTaskId);
+        predecessors.set(task.id, deps);
+      }
+      lastWriterByTarget.set(targetFile, task.id);
+    }
+  }
+
+  return new Map(
+    [...predecessors.entries()].map(([taskId, deps]) => [taskId, [...deps]]),
+  );
+}
+
+function splitWaveIntoNonOverlappingBatches(tasks: MigrationTask[]): MigrationTask[][] {
+  const pending = [...tasks];
+  const batches: MigrationTask[][] = [];
+
+  while (pending.length > 0) {
+    const batch = TaskQueue.selectNonOverlappingBatch(pending, pending.length);
+    if (batch.length === 0) {
+      throw new Error('Failed to build a non-overlapping task batch for wave execution');
+    }
+    batches.push(batch);
+    const batchIds = new Set(batch.map(task => task.id));
+    for (let i = pending.length - 1; i >= 0; i--) {
+      if (batchIds.has(pending[i]!.id)) pending.splice(i, 1);
+    }
+  }
+
+  return batches;
+}
+
 // ─── Substep Functions ───────────────────────────────────────────────
 // Each function executes one logical substep within a per-task migration.
 // The framework's checkpoint skip replaces the manual hasPhase4Substep guards.
@@ -340,18 +418,28 @@ function buildPerTaskFlow(
 ): FlowDefinition<MigrationFlowContext> {
   const taskSet = new Set(tasks.map(t => t.id));
   const gateMode = getQualityGateMode(ctx);
+  const overlapPredecessors = computeTargetOverlapPredecessors(tasks);
+  const overlapDependencyCount = [...overlapPredecessors.values()].reduce((sum, deps) => sum + deps.length, 0);
 
   const nodes: FlowNode<MigrationFlowContext>[] = [];
 
+  if (overlapDependencyCount > 0) {
+    ctx.logger.info(
+      `Per-task mode: added ${overlapDependencyCount} target-overlap ordering edge(s) across ` +
+      `${overlapPredecessors.size} task(s)`,
+    );
+  }
+
   for (const task of tasks) {
-    const deps = task.dependencies.filter(d => taskSet.has(d));
+    const deps = new Set(task.dependencies.filter(d => taskSet.has(d)));
+    for (const overlapDep of overlapPredecessors.get(task.id) ?? []) deps.add(overlapDep);
     const substepIds: string[] = [];
 
     // Migrate
     const migrateId = `${task.id}/migrate`;
     nodes.push(step<MigrationFlowContext>({
       id: migrateId,
-      dependsOn: deps.length > 0 ? deps.map(d => `${d}/complete`) : undefined,
+      dependsOn: deps.size > 0 ? [...deps].map(d => `${d}/complete`) : undefined,
       run: (c) => runMigrateSubstep(c.context, task, retryExec),
     }));
     substepIds.push(migrateId);
@@ -471,12 +559,18 @@ function buildWaveBarrierFlow(
     // Wave start marker — emit lifecycle event
     const waveTasksCopy = waveTasks;
     const waveTaskIds = waveTasksCopy.map(t => t.id);
+    const waveBatches = splitWaveIntoNonOverlappingBatches(waveTasksCopy);
     nodes.push(step<MigrationFlowContext>({
       id: `wave-${w}-start`,
       dependsOn: prevDep,
       run: async (c) => {
         if (c.context.phase4Snapshot) c.context.phase4Snapshot.waveCount++;
         c.context.logger.info(`Wave ${w}: migrating ${waveTasksCopy.length} task(s)`);
+        if (waveBatches.length > 1) {
+          c.context.logger.info(
+            `Wave ${w}: split into ${waveBatches.length} non-overlapping batch(es) to avoid shared target-file edits`,
+          );
+        }
         c.context.logger.event({ type: 'wave-started', wave: w, taskIds: waveTaskIds });
         await c.context.progress.appendWaveLifecycle({ wave: w, milestone: 'started' });
       },
@@ -485,43 +579,36 @@ function buildWaveBarrierFlow(
     // Wave task execution (parallel branches)
     // Each branch runs: migrate → commit → target-index → parity → parity-gate → minor-repass
     // Build/test gates run at the wave barrier, but parity is per-task.
-    nodes.push(parallel<MigrationFlowContext>({
-      id: `wave-${w}-tasks`,
-      dependsOn: [`wave-${w}-start`],
-      branches: Object.fromEntries(waveTasksCopy.map(task => {
-        const branchSteps: FlowNode<MigrationFlowContext>[] = [
-          step<MigrationFlowContext>({
-            id: `${task.id}/migrate`,
-            run: (c) => runMigrateSubstep(c.context, task, retryExec),
-          }),
-          step<MigrationFlowContext>({
-            id: `${task.id}/commit`,
-            run: (c) => runCommitSubstep(c.context, task),
-          }),
-          step<MigrationFlowContext>({
-            id: `${task.id}/target-index`,
-            run: (c) => runTargetIndexSubstep(c.context, task),
-          }),
-          step<MigrationFlowContext>({
-            id: `${task.id}/parity`,
-            run: (c) => runParitySubstep(c.context, task),
-          }),
-        ];
-        if (gateMode !== 'skip') {
-          branchSteps.push(
-            step<MigrationFlowContext>({
-              id: `${task.id}/parity-gate`,
-              run: (c) => runParityGateSubstep(c.context, task),
-            }),
-            step<MigrationFlowContext>({
-              id: `${task.id}/minor-repass`,
-              run: (c) => runMinorRepassSubstep(c.context, task),
-            }),
-          );
-        }
-        return [task.id, branchSteps];
-      })),
-    }));
+    if (waveBatches.length === 1) {
+      nodes.push(parallel<MigrationFlowContext>({
+        id: `wave-${w}-tasks`,
+        dependsOn: [`wave-${w}-start`],
+        branches: Object.fromEntries(waveTasksCopy.map(task => [
+          task.id,
+          buildWaveTaskBranch(task, retryExec, gateMode),
+        ])),
+      }));
+    } else {
+      let batchDependency = `wave-${w}-start`;
+      for (let batchIndex = 0; batchIndex < waveBatches.length; batchIndex++) {
+        const batch = waveBatches[batchIndex]!;
+        const batchId = `wave-${w}-tasks-batch-${batchIndex}`;
+        nodes.push(parallel<MigrationFlowContext>({
+          id: batchId,
+          dependsOn: [batchDependency],
+          branches: Object.fromEntries(batch.map(task => [
+            task.id,
+            buildWaveTaskBranch(task, retryExec, gateMode),
+          ])),
+        }));
+        batchDependency = batchId;
+      }
+      nodes.push(step<MigrationFlowContext>({
+        id: `wave-${w}-tasks`,
+        dependsOn: [batchDependency],
+        run: async () => undefined,
+      }));
+    }
 
     // Barrier entry marker
     nodes.push(step<MigrationFlowContext>({
@@ -873,7 +960,7 @@ async function recoverWaveValidationFailure(
   if (failure.success) return true;
   const waveTask = buildWaveRecoveryTask(wave, waveCandidates);
   const artifactPaths = Array.from(new Set(waveCandidates.flatMap(t => [...t.sourceFiles, ...t.targetFiles])));
-  return runCommandWithRecovery(ctx, failedLabel, failedCommand, waveTask, undefined, {
+  return runCommandWithRecovery(ctx, failedLabel, failedCommand, waveTask, {
     initialFailure: failure, wave, retryScope: 'wave', artifactPaths,
     suppressTerminalOnExhaustion: true,
     failureSummary: failure.error ?? `Wave ${wave} ${failedLabel} failed`,

--- a/src/flow/steps/shared.ts
+++ b/src/flow/steps/shared.ts
@@ -36,7 +36,6 @@ import type {
   TerminalExhaustionDetails,
 } from '../context.js';
 import { formatDuration } from '../../util/format.js';
-import { TaskQueue } from '../../execution/task-queue.js';
 
 // ─── Constants ─────────────────────────────────────────────────────────
 
@@ -612,7 +611,6 @@ export async function runCommandWithRecovery(
   label: string,
   command: string,
   task: MigrationTask,
-  queue?: TaskQueue,
   options?: {
     initialFailure?: CommandExecutionResult;
     wave?: number;

--- a/tests/flow/steps/migration-waves.test.ts
+++ b/tests/flow/steps/migration-waves.test.ts
@@ -139,6 +139,49 @@ describe('buildPhase4Subflow — wave-barrier mode', () => {
     }
   });
 
+  it('should split overlapping wave tasks into sequential non-overlapping batches', async () => {
+    const tasks = [
+      { ...SINGLE_AUTH_TASK, id: 'task-001', targetFiles: ['src/shared.ts'] },
+      { ...makeTask('task-002'), targetFiles: ['src/shared.ts'] },
+    ];
+    const baseLauncher = createMockLauncher();
+    let current = 0;
+    let maxConcurrent = 0;
+    const launcherFn = async (inv: AgentInvocation): Promise<AgentResult> => {
+      const result = await baseLauncher(inv);
+      if (inv.agent === 'code-migrator') {
+        current++;
+        maxConcurrent = Math.max(maxConcurrent, current);
+        await new Promise(resolve => setTimeout(resolve, 20));
+        current--;
+      }
+      return result;
+    };
+
+    env = await setupFlowTestWithTasks(launcherFn, tasks, {
+      options: {
+        executionMode: 'wave-barrier',
+        waveControl: { maxConvergenceIterations: 1 },
+        maxParallelAgents: 2,
+        qualityPolicy: 'balanced',
+      },
+    });
+
+    const spawnMod = await import('../../../src/util/process.js');
+    const spawnSpy = vi.spyOn(spawnMod, 'spawnWithTimeout').mockResolvedValue({
+      exitCode: 0, stdout: 'ok', stderr: '', killed: false,
+    });
+
+    try {
+      const result = await runPhase4(env);
+
+      expect(result.status).toBe('completed');
+      expect(maxConcurrent).toBe(1);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
   // ─── Wave Convergence Retry ─────────────────────────────────────────
 
   it('should retry wave validation when build fails then succeeds', async () => {

--- a/tests/flow/steps/migration.test.ts
+++ b/tests/flow/steps/migration.test.ts
@@ -18,6 +18,7 @@ import {
   createFailingLauncher,
   DEFAULT_PLANNING_TASKS,
   SINGLE_AUTH_TASK,
+  makeTask,
   withParityOutput,
 } from '../../helpers/flow-mocks.js';
 import type { FlowTestEnv } from '../../helpers/flow-mocks.js';
@@ -78,6 +79,38 @@ describe('buildPhase4Subflow (Phase 4)', () => {
         (c) => typeof c[0] === 'string' && c[0].includes('Phase 4:'),
       );
       expect(projectionLog).toBeDefined();
+    });
+
+    it('should add a complete-step dependency between overlapping per-task tasks', async () => {
+      const tasks: MigrationTask[] = [
+        { ...SINGLE_AUTH_TASK, id: 'task-001', targetFiles: ['src/shared.ts'] },
+        { ...makeTask('task-002'), targetFiles: ['src/shared.ts'] },
+      ];
+      env = await setupFlowTestWithTasks(createMockLauncher(), tasks, {
+        options: { maxParallelAgents: 2, qualityPolicy: 'balanced' },
+      });
+
+      const flow = await buildPhase4Subflow(env.flowCtx);
+      const task002Migrate = flow.nodes.find(node => node.id === 'task-002/migrate');
+
+      expect(task002Migrate).toBeDefined();
+      expect((task002Migrate as { dependsOn?: string[] }).dependsOn).toContain('task-001/complete');
+    });
+
+    it('should not add overlap dependencies for distinct per-task targets', async () => {
+      const tasks: MigrationTask[] = [
+        { ...SINGLE_AUTH_TASK, id: 'task-001', targetFiles: ['src/one.ts'] },
+        { ...makeTask('task-002'), targetFiles: ['src/two.ts'] },
+      ];
+      env = await setupFlowTestWithTasks(createMockLauncher(), tasks, {
+        options: { maxParallelAgents: 2, qualityPolicy: 'balanced' },
+      });
+
+      const flow = await buildPhase4Subflow(env.flowCtx);
+      const task002Migrate = flow.nodes.find(node => node.id === 'task-002/migrate');
+
+      expect(task002Migrate).toBeDefined();
+      expect((task002Migrate as { dependsOn?: string[] }).dependsOn ?? []).not.toContain('task-001/complete');
     });
   });
 

--- a/tests/flow/steps/shared-extended.test.ts
+++ b/tests/flow/steps/shared-extended.test.ts
@@ -45,7 +45,6 @@ import {
   makeTask,
 } from '../../helpers/flow-mocks.js';
 import type { FlowTestEnv } from '../../helpers/flow-mocks.js';
-import { TaskQueue } from '../../../src/execution/task-queue.js';
 
 let env: FlowTestEnv;
 
@@ -196,10 +195,9 @@ describe('runCommandWithRecovery', () => {
     });
 
     const task = makeTask('task-001');
-    const queue = new TaskQueue([task]);
 
     try {
-      const result = await runCommandWithRecovery(env.ctx, 'build', 'npm run build', task, queue);
+      const result = await runCommandWithRecovery(env.ctx, 'build', 'npm run build', task);
       expect(result).toBe(true);
     } finally {
       spawnSpy.mockRestore();
@@ -223,10 +221,9 @@ describe('runCommandWithRecovery', () => {
     });
 
     const task = makeTask('task-001');
-    const queue = new TaskQueue([task]);
 
     try {
-      const result = await runCommandWithRecovery(env.ctx, 'build', 'npm run build', task, queue);
+      const result = await runCommandWithRecovery(env.ctx, 'build', 'npm run build', task);
       expect(result).toBe(true);
       expect(callCount).toBeGreaterThan(1);
     } finally {
@@ -251,10 +248,9 @@ describe('runCommandWithRecovery', () => {
     });
 
     const task = makeTask('task-001');
-    const queue = new TaskQueue([task]);
 
     try {
-      const result = await runCommandWithRecovery(env.ctx, 'build', 'npm run build', task, queue);
+      const result = await runCommandWithRecovery(env.ctx, 'build', 'npm run build', task);
       // Should eventually succeed or throw on exhaustion
       const resolverInvs = env.mockLauncher.invocations.filter(
         i => i.agent === 'parity-failure-resolver',
@@ -277,11 +273,10 @@ describe('runCommandWithRecovery', () => {
     });
 
     const task = makeTask('task-001');
-    const queue = new TaskQueue([task]);
 
     try {
       await expect(
-        runCommandWithRecovery(env.ctx, 'build', 'npm run build', task, queue),
+        runCommandWithRecovery(env.ctx, 'build', 'npm run build', task),
       ).rejects.toThrow(TerminalExhaustionError);
     } finally {
       spawnSpy.mockRestore();
@@ -300,10 +295,9 @@ describe('runCommandWithRecovery', () => {
     });
 
     const task = makeTask('task-001');
-    const queue = new TaskQueue([task]);
 
     try {
-      const result = await runCommandWithRecovery(env.ctx, 'build', 'npm run build', task, queue, {
+      const result = await runCommandWithRecovery(env.ctx, 'build', 'npm run build', task, {
         suppressTerminalOnExhaustion: true,
       });
       expect(result).toBe(false);


### PR DESCRIPTION
## Summary
- add target-overlap ordering edges in per-task mode so tasks that write the same target file cannot migrate concurrently
- split wave-barrier waves into sequential non-overlapping batches using the existing TaskQueue batching helper
- remove stale queue plumbing from shared recovery helpers and update comments/tests to match the live Cadre scheduler design

## Testing
- npm run lint
- npm test

Closes #196.
Part of #64.