### PR TITLE
feat(parity): add suggestedFix to verifier issues and full history to resolver

### DIFF
--- a/agents/templates/parity-failure-resolver.md
+++ b/agents/templates/parity-failure-resolver.md
@@ -22,7 +22,9 @@ Resolve the failing task quickly and safely by:
 ## Required Process
 
 1. **Diagnose**
-        - Read the parity issues provided in `context.agentPayload.remediationContext.parityIssues` — a JSON array of `{ severity, description, details, sourceLocation, targetLocation? }` objects. Use your file-read tools to inspect the cited source and target locations.
+        - Read the parity issues provided in `context.agentPayload.remediationContext.parityIssues` — a JSON array of `{ severity, description, details, sourceLocation, targetLocation?, suggestedFix? }` objects. Use your file-read tools to inspect the cited source and target locations.
+        - When `suggestedFix` is present on an issue, treat it as an informed hint from the parity-verifier (which has already read both source and target). Prefer applying suggested fixes directly unless you identify a concrete reason they are wrong.
+        - **Check `context.agentPayload.remediationContext.priorAttempts`** — if present, this is an array of prior recovery rounds with `{ attempt, issueCount, unresolvedIssues, fullIssues? }`. Study the `fullIssues` from each prior attempt to understand which issues were already fixed and which are new. Avoid re-introducing issues that were resolved in earlier rounds — this is the most common cause of fix oscillation.
         - Read the referenced source/target files and relevant context artifacts.
         - Query the target KB (`aamf-kb-target`) with `lore_search` to check how dependency symbols were ported by prior tasks — mismatched imports, renamed types, or missing re-exports from earlier tasks are common root causes.
         - Identify the most likely root cause in one concise sentence.

--- a/agents/templates/parity-verifier.md
+++ b/agents/templates/parity-verifier.md
@@ -78,6 +78,7 @@ For each issue in the `issues` array:
 - `details`: 1-3 sentences explaining what the source does vs. what the target does (or fails to do). Be concise — do not exceed 3 sentences.
 - `sourceLocation` (required): the source file path and line range where the correct behavior is defined (e.g., `legacy/zstd_v04.c:342-358`). Use just the file path if the issue spans the entire file.
 - `targetLocation` (optional): the target file path and line range where the gap exists (e.g., `src/v04/decoder.rs:210-215`). Omit entirely if the target code/file was not produced at all.
+- `suggestedFix` (optional but strongly encouraged): a concise, actionable description of how to fix the gap. Since you've already read both source and target code side-by-side, capture that insight here. Examples: "Change `stat_t` alias from `std::fs::Metadata` to `libc::stat`", "Add `#[macro_export]` and `pub use` for `UTIL_STATIC`". Keep to 1-2 sentences.
 
 ## Context Window Management
 
@@ -95,7 +96,7 @@ For each issue in the `issues` array:
 ## Constraints
 
 - This is a **read-only** agent. Do not modify any code files.
-- Report facts, not opinions. If behavior differs, describe exactly how, don't suggest fixes.
+- Report facts, not opinions. If behavior differs, describe exactly how. When you can see how to fix the gap, include it in `suggestedFix` — but do not apply it.
 - Be thorough but proportional — a one-line utility function needs less analysis than a 200-line business logic method.
 - When in doubt about behavioral equivalence, flag it as ⚠️ rather than assuming ✅.
 

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -107,6 +107,7 @@ export const ParityVerifierSchema = AamfOutputBase.extend({
     details: z.string(),
     sourceLocation: z.string(),
     targetLocation: z.string().optional(),
+    suggestedFix: z.string().optional(),
   })).default([]),
 });
 export const TestWriterSchema = AamfOutputBase;
@@ -271,6 +272,7 @@ export const AGENT_REGISTRY: Record<AgentName, AgentRegistryEntry> = {
               details:        { type: 'string', minLength: 1 },
               sourceLocation: { type: 'string', minLength: 1 },
               targetLocation: { type: 'string', minLength: 1 },
+              suggestedFix:   { type: 'string', minLength: 1 },
             },
           },
         },

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -314,6 +314,7 @@ export interface AgentRemediationContext {
     details: string;
     sourceLocation: string;
     targetLocation?: string;
+    suggestedFix?: string;
   }>;
   /** Outcomes of prior recovery attempts, enabling the agent to avoid repeating failed strategies. */
   priorAttempts?: PriorRecoveryAttempt[];
@@ -350,6 +351,15 @@ export interface PriorRecoveryAttempt {
   issueCount: number;
   /** Descriptions of non-minor issues that remained unresolved. */
   unresolvedIssues: string[];
+  /** Full parity issues from this attempt, enabling the resolver to avoid regressions. */
+  fullIssues?: Array<{
+    severity: string;
+    description: string;
+    details: string;
+    sourceLocation: string;
+    targetLocation?: string;
+    suggestedFix?: string;
+  }>;
 }
 
 // ─── Terminal Exhaustion Contracts ────────────────────────────────────────────

--- a/src/flow/context.ts
+++ b/src/flow/context.ts
@@ -42,6 +42,7 @@ export interface ParityResultData {
     details: string;
     sourceLocation: string;
     targetLocation?: string;
+    suggestedFix?: string;
   }>;
 }
 

--- a/src/flow/steps/migration.ts
+++ b/src/flow/steps/migration.ts
@@ -16,6 +16,7 @@ import type { MigrationFlowContext, WaveValidationResult } from '../context.js';
 import type { PhaseResult, MigrationTask } from '../../agents/types.js';
 import type { TaskGraphOutput } from './task-graph.js';
 import { toAgentRemediationContext } from '../../agents/types.js';
+import type { PriorRecoveryAttempt } from '../../agents/types.js';
 import { parseMigrationPlan } from '../../agents/plan-parser.js';
 import { ParallelExecutor } from '../../execution/parallel-executor.js';
 import { TaskQueue } from '../../execution/task-queue.js';
@@ -268,7 +269,7 @@ async function runParityGateSubstep(
   let parityPassed = checkParityResult(ctx, task.id);
 
   if (!parityPassed && gateMode === 'enforce') {
-    const priorAttempts: Array<{ attempt: number; issueCount: number; unresolvedIssues: string[] }> = [];
+    const priorAttempts: PriorRecoveryAttempt[] = [];
     for (let attempt = 1; attempt <= maxParityRetries; attempt++) {
       const issueSummary = getParityIssueSummary(ctx, task.id);
       const enrichedSummary = issueSummary
@@ -314,7 +315,7 @@ async function runParityGateSubstep(
       if (parityPassed) { ctx.logger.info(`Parity recovered for ${task.id} on attempt ${attempt}`); break; }
       const storedResult = ctx.parityResults.get(task.id);
       const unresolvedIssues = (storedResult?.issues ?? []).filter(i => i.severity !== 'minor').map(i => i.description);
-      priorAttempts.push({ attempt, issueCount: storedResult?.issues?.length ?? 0, unresolvedIssues });
+      priorAttempts.push({ attempt, issueCount: storedResult?.issues?.length ?? 0, unresolvedIssues, fullIssues: storedResult?.issues });
     }
     if (!parityPassed) {
       if (hasNonMinorParityIssues(ctx, task.id)) {

--- a/tests/agents/agent-output-schemas.test.ts
+++ b/tests/agents/agent-output-schemas.test.ts
@@ -63,6 +63,38 @@ describe('Per-agent output schemas', () => {
         ParityVerifierSchema.parse({ status: VALID_STATUS, parity: 'pass' }),
       ).not.toThrow();
     });
+
+    it('accepts issues with suggestedFix', () => {
+      const result = ParityVerifierSchema.parse({
+        status: VALID_STATUS,
+        parity: 'partial',
+        issues: [{
+          severity: 'major',
+          description: 'stat_t uses wrong type',
+          details: 'Source uses libc::stat, target uses std::fs::Metadata',
+          sourceLocation: 'programs/util.h:111-190',
+          targetLocation: 'programs/util.rs:21-48',
+          suggestedFix: 'Change stat_t alias from std::fs::Metadata to libc::stat',
+        }],
+      });
+      expect(result.issues[0]!.suggestedFix).toBe(
+        'Change stat_t alias from std::fs::Metadata to libc::stat',
+      );
+    });
+
+    it('accepts issues without suggestedFix', () => {
+      const result = ParityVerifierSchema.parse({
+        status: VALID_STATUS,
+        parity: 'partial',
+        issues: [{
+          severity: 'minor',
+          description: 'sleep boundary difference',
+          details: 'Source has timespec overflow, target handles it correctly',
+          sourceLocation: 'programs/util.h:55-58',
+        }],
+      });
+      expect(result.issues[0]!.suggestedFix).toBeUndefined();
+    });
   });
 
   describe('TestWriterSchema', () => {


### PR DESCRIPTION
## Problem

When the parity-verifier identifies issues and the parity-failure-resolver attempts fixes, a **fix-oscillation pattern** emerges on complex tasks: each resolver fix addresses the flagged issues but introduces or unmasks new ones, because:

1. The verifier identifies problems but provides no actionable fix hints — the resolver must re-derive fixes from scratch each round
2. The resolver only receives the *current* round's issues, not the full history — so it has no visibility into which issues were previously fixed and risks regressing them

This was observed concretely in the zstd C-to-Rust migration on `task-29-0` (`programs/util.h` → `programs/util.rs`), where 3 resolver attempts each fixed the flagged issues but the verifier kept finding different problems, exhausting retries.

## Changes

### 1. `suggestedFix` field on parity-verifier issues

- **Schema**: Added optional `suggestedFix: string` to the Zod schema, JSON schema, `ParityResultData`, and `AgentRemediationContext.parityIssues`
- **Verifier prompt**: Updated to encourage emitting `suggestedFix` — the verifier already has both source and target code in context, so capturing the fix insight is nearly free
- **Resolver prompt**: Updated to prefer applying `suggestedFix` hints directly when present

### 2. Full issue history in `priorAttempts`

- **Type**: Added `fullIssues?` array to `PriorRecoveryAttempt` carrying complete issue objects (with `suggestedFix`) from each prior round
- **Flow**: Updated the parity gate loop to populate `fullIssues` when building `priorAttempts`
- **Resolver prompt**: Added instructions to study `fullIssues` from prior attempts to understand which issues were already fixed vs. newly introduced, preventing regression

### Files changed

| File | Change |
|------|--------|
| `src/agents/registry.ts` | Added `suggestedFix` to Zod + JSON schemas |
| `src/agents/types.ts` | Added `suggestedFix` to issue type, `fullIssues` to `PriorRecoveryAttempt` |
| `src/flow/context.ts` | Added `suggestedFix` to `ParityResultData` |
| `src/flow/steps/migration.ts` | Populate `fullIssues` in parity gate loop |
| `agents/templates/parity-verifier.md` | Document `suggestedFix`, update constraints |
| `agents/templates/parity-failure-resolver.md` | Document `suggestedFix` + `priorAttempts.fullIssues` usage |
| `tests/agents/agent-output-schemas.test.ts` | 2 new tests for `suggestedFix` (present + absent) |

## Testing

- `npm run lint` — passes (tsc --noEmit)
- `npx vitest run --exclude 'tests/e2e/**'` — 1445 tests pass, 0 failures