### PR TITLE
fix(runtime): token tracking and centralize model config

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,15 +230,15 @@ In both modes, the runtime:
 
 #### Model Routing
 
-When `options.modelRouting.enabled` is set, Phase 4 automatically escalates tasks to heavier models based on complexity score and retry behavior:
+When `models.routing.enabled` is set, Phase 4 automatically escalates tasks to heavier models based on complexity score and retry behavior:
 
 | Tier | Trigger | Model Config Key |
 |------|---------|------------------|
-| `normal` | Default | `copilot.model` (or `claudeCode.model`) |
-| `heavy` | Complexity score ≥ `heavyThreshold` | `modelRouting.heavyModel` |
-| `critical` | Complexity ≥ `criticalThreshold`, or agent in `criticalAgents`, or retry attempt ≥ `escalateOnRetryAttempt` | `modelRouting.criticalModel` |
+| `normal` | Default | `models.default` |
+| `heavy` | Complexity score ≥ `heavyThreshold` | `models.routing.heavy` |
+| `critical` | Complexity ≥ `criticalThreshold`, or agent in `criticalAgents`, or retry attempt ≥ `escalateOnRetryAttempt` | `models.routing.critical` |
 
-Escalation cost is tracked and capped by `modelRouting.maxEscalationCostUsd`.
+Escalation cost is tracked and capped by `models.routing.maxEscalationCostUsd`.
 
 ### Phase 5 — Final Parity Verification
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,6 @@ Create a `migration.config.json` file in your project root. Below is a full refe
 ```json
 {
   "projectName": "my-migration",
-  "agentRuntime": "copilot",
   "source": {
     "path": "../legacy-app",
     "language": "python",
@@ -64,14 +63,6 @@ Create a `migration.config.json` file in your project root. Below is a full refe
         "pythonBin": "python3"
       }
     },
-    "modelRouting": {
-      "enabled": true,
-      "heavyModel": "claude-opus-4.6",
-      "criticalModel": "claude-opus-4.6",
-      "heavyThreshold": 40,
-      "criticalThreshold": 70,
-      "escalateOnRetryAttempt": 2
-    },
     "git": {
       "enabled": true,
       "autoInit": true,
@@ -82,10 +73,21 @@ Create a `migration.config.json` file in your project root. Below is a full refe
       "maxIterations": 2
     }
   },
-  "copilot": {
+  "models": {
+    "default": "claude-sonnet-4.6",
+    "failureRecovery": "claude-opus-4.6",
+    "routing": {
+      "enabled": true,
+      "heavy": "claude-opus-4.6",
+      "critical": "claude-opus-4.6",
+      "heavyThreshold": 40,
+      "criticalThreshold": 70,
+      "escalateOnRetryAttempt": 2
+    }
+  },
+  "agentBackend": {
+    "runtime": "copilot",
     "cliCommand": "copilot",
-    "model": "claude-sonnet-4.6",
-    "failureRecoveryModel": "claude-opus-4.6",
     "agentDir": ".github/agents",
     "timeout": 300000
   }
@@ -99,7 +101,8 @@ Create a `migration.config.json` file in your project root. Below is a full refe
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `projectName` | `string` | *required* | Unique identifier for this migration (kebab-case). Used for checkpoint and log directories. |
-| `agentRuntime` | `'copilot' \| 'claude-code'` | `'copilot'` | Which agent CLI to use for invocations. |
+| `models.default` | `string` | — | Baseline model used for all invocations unless a routing or failure-recovery override applies. |
+| `models.failureRecovery` | `string` | — | Model used for transient-retry recovery and `parity-failure-resolver`. |
 
 #### Source
 
@@ -153,21 +156,20 @@ Create a `migration.config.json` file in your project root. Below is a full refe
 | `options.kbIndex.embeddings.model` | `string` | `'Qwen/Qwen3-Embedding-0.6B'` | Sentence-transformers model for embeddings. |
 | `options.kbIndex.embeddings.pythonBin` | `string` | `'python3'` | Path to Python binary. |
 
-#### Model Routing
+#### Model Policy
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `options.modelRouting.enabled` | `boolean` | `false` | Enable automatic model tier escalation. |
-| `options.modelRouting.defaultModel` | `string` | — | Override default model for routing (falls back to `copilot.model`). |
-| `options.modelRouting.heavyModel` | `string` | — | Model for heavy-tier tasks. |
-| `options.modelRouting.criticalModel` | `string` | — | Model for critical-tier tasks. |
-| `options.modelRouting.heavyThreshold` | `integer (0–100)` | `40` | Complexity score threshold for heavy tier. |
-| `options.modelRouting.criticalThreshold` | `integer (0–100)` | `70` | Complexity score threshold for critical tier. |
-| `options.modelRouting.criticalAgents` | `string[]` | — | Agent names that always use the critical model. |
-| `options.modelRouting.criticalTaskPatterns` | `string[]` | — | Task ID patterns that always use the critical model. |
-| `options.modelRouting.maxCriticalTasks` | `integer (≥0)` | `0` | Max tasks routed to critical tier. 0 = unlimited. |
-| `options.modelRouting.maxEscalationCostUsd` | `number (≥0)` | `0` | Cost cap for escalated invocations. 0 = unlimited. |
-| `options.modelRouting.escalateOnRetryAttempt` | `integer (≥1)` | `2` | Retry attempt number that triggers escalation. |
+| `models.routing.enabled` | `boolean` | `false` | Enable automatic model tier escalation. |
+| `models.routing.heavy` | `string` | — | Model for heavy-tier tasks. |
+| `models.routing.critical` | `string` | — | Model for critical-tier tasks. |
+| `models.routing.heavyThreshold` | `integer (0–100)` | `40` | Complexity score threshold for heavy tier. |
+| `models.routing.criticalThreshold` | `integer (0–100)` | `70` | Complexity score threshold for critical tier. |
+| `models.routing.criticalAgents` | `string[]` | — | Agent names that always use the critical model. |
+| `models.routing.criticalTaskPatterns` | `string[]` | — | Task ID patterns that always use the critical model. |
+| `models.routing.maxEscalatedTasks` | `integer (≥0)` | `0` | Max tasks routed above the baseline model. 0 = unlimited. |
+| `models.routing.maxEscalationCostUsd` | `number (≥0)` | `0` | Cost cap for escalated invocations. 0 = unlimited. |
+| `models.routing.escalateOnRetryAttempt` | `integer (≥1)` | `2` | Retry attempt number that triggers escalation. |
 
 #### Git Automation
 
@@ -188,30 +190,16 @@ Create a `migration.config.json` file in your project root. Below is a full refe
 | `options.idiomaticRefactor.enabled` | `boolean` | `false` | Enable the optional idiomatic refactor phase. |
 | `options.idiomaticRefactor.maxIterations` | `integer` | `2` | Max review-and-refactor cycles. |
 
-#### Copilot
+#### Agent Backend
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `copilot.cliCommand` | `string` | `'copilot'` | Path or name of the Copilot CLI binary. |
-| `copilot.model` | `string` | — | Model to use via `--model` flag (e.g. `claude-sonnet-4.6`). |
-| `copilot.failureRecoveryModel` | `string` | — | Model to use for `failure-adjudicator` invocations. |
-| `copilot.agentDir` | `string` | `'.github/agents'` | Directory containing `.agent.md` prompt files. |
-| `copilot.timeout` | `integer` | `300000` | Per-agent invocation timeout in ms (5 minutes). |
-| `copilot.costOverrides` | `Record<string, { input, output }>` | — | Per-model pricing overrides (USD per 1M tokens). |
-| `copilot.phaseTimeouts` | `Record<number, integer>` | — | Per-phase timeout overrides in ms, keyed by phase number. |
-
-#### Claude Code
-
-| Field | Type | Default | Description |
-|-------|------|---------|-------------|
-| `claudeCode.cliCommand` | `string` | `'claude'` | Path or name of the Claude Code binary. |
-| `claudeCode.model` | `string` | — | Model to use. |
-| `claudeCode.failureRecoveryModel` | `string` | — | Model for failure adjudication. |
-| `claudeCode.agentDir` | `string` | `'.claude/agents'` | Directory containing `.agent.md` prompt files. |
-| `claudeCode.timeout` | `integer` | `300000` | Per-agent invocation timeout in ms. |
-| `claudeCode.contextWindowTokens` | `integer` | — | Context window token limit. |
-| `claudeCode.costOverrides` | `Record<string, { input, output }>` | — | Per-model pricing overrides (USD per 1M tokens). |
-| `claudeCode.phaseTimeouts` | `Record<number, integer>` | — | Per-phase timeout overrides in ms. |
+| `agentBackend.runtime` | `'copilot' \| 'claude-code'` | `'copilot'` | Which agent CLI to use for invocations. |
+| `agentBackend.cliCommand` | `string` | `'copilot'` or `'claude'` | Path or name of the selected CLI binary. |
+| `agentBackend.agentDir` | `string` | `'.github/agents'` or `'.claude/agents'` | Directory containing agent prompt files for the selected runtime. |
+| `agentBackend.timeout` | `integer` | `300000` | Per-agent invocation timeout in ms (5 minutes). |
+| `agentBackend.phaseTimeouts` | `Record<number, integer>` | — | Per-phase timeout overrides in ms, keyed by phase number. |
+| `agentBackend.effort` | `'low' \| 'medium' \| 'high' \| 'xhigh'` | — | Copilot reasoning effort level. |
 
 #### Environment
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -32,6 +32,45 @@ export const MigrationConfigSchema = z.object({
     formatCommand: z.string().optional(),
     lintCommand: z.string().optional(),
   }),
+  /**
+   * Model-selection policy shared across all runtimes.
+   *
+   * This is the single authoritative location for baseline model choice,
+   * difficulty-based escalation, and failure-recovery model overrides.
+   */
+  models: z.object({
+    /** Baseline model used for all invocations unless a policy override applies. */
+    default: z.string().optional(),
+    /** Model used for failure-recovery retries and parity-failure-resolver. */
+    failureRecovery: z.string().optional(),
+    /**
+     * Difficulty-based per-invocation routing policy.
+     * When enabled, the orchestrator may override `models.default` for
+     * heavy or critical tasks and agents.
+     */
+    routing: z.object({
+      /** Enable automatic model tier escalation. */
+      enabled: z.boolean().default(false),
+      /** Model used for heavy-tier tasks (score >= heavyThreshold). */
+      heavy: z.string().optional(),
+      /** Model used for critical-tier tasks (score >= criticalThreshold). */
+      critical: z.string().optional(),
+      /** Score threshold (0–100) at which a task is promoted to heavy tier. */
+      heavyThreshold: z.number().int().min(0).max(100).default(40),
+      /** Score threshold (0–100) at which a task is promoted to critical tier. */
+      criticalThreshold: z.number().int().min(0).max(100).default(70),
+      /** Agent names that always route to the critical model. */
+      criticalAgents: z.array(z.string()).optional(),
+      /** Task ID glob patterns (`*` and `?`) that always route to the critical model. */
+      criticalTaskPatterns: z.array(z.string()).optional(),
+      /** Max tasks escalated beyond the default model per run. 0 = unlimited. */
+      maxEscalatedTasks: z.number().int().min(0).default(0),
+      /** Max incremental cost (USD) for escalated invocations. 0 = unlimited. */
+      maxEscalationCostUsd: z.number().min(0).default(0),
+      /** Retry attempt number at which to escalate model tier. */
+      escalateOnRetryAttempt: z.number().int().min(1).default(2),
+    }).optional(),
+  }).default({}),
   options: z.object({
     maxParallelAgents: z.number().int().min(1).default(3),
     maxRetriesPerTask: z.number().int().min(1).max(5).default(3),
@@ -167,9 +206,8 @@ export const MigrationConfigSchema = z.object({
      */
     keepArtifacts: z.boolean().default(false),
     /**
-     * Model routing configuration for intelligent model selection.
-     * When enabled, the orchestrator selects models based on task complexity,
-     * file count, dependencies, and retry history.
+     * Deprecated compatibility alias for `models.routing`.
+     * Prefer the root-level `models` block for all model-selection policy.
      */
     modelRouting: z.object({
       /** Enable model routing. When false, all tasks use the default model. */
@@ -257,9 +295,9 @@ export const MigrationConfigSchema = z.object({
     runtime: z.enum(['copilot', 'claude-code']).default('copilot'),
     /** CLI command to invoke. Defaults to `'copilot'` or `'claude'` based on `runtime`. */
     cliCommand: z.string().optional(),
-    /** Model identifier to pass to the CLI. */
+    /** Deprecated compatibility alias for `models.default`. */
     model: z.string().optional(),
-    /** Model to use for failure-recovery retries. */
+    /** Deprecated compatibility alias for `models.failureRecovery`. */
     failureRecoveryModel: z.string().optional(),
     /**
      * Reasoning effort level for the Copilot CLI (`--effort` flag).

--- a/src/core/agent-launcher.ts
+++ b/src/core/agent-launcher.ts
@@ -13,6 +13,7 @@ import { AgentInvocation, AgentName, AgentResult } from '../agents/types.js';
 import { MigrationConfig } from '../config/schema.js';
 import { ensureDir, atomicWrite, fileExists } from '../util/fs.js';
 import { parseAamfOutput, MISSING_BLOCK_ERROR } from '../agents/agent-output-schemas.js';
+import { parseTokenUsage } from '../agents/token-usage-parser.js';
 import { getOutputSchema } from '../agents/registry.js';
 import { Logger } from '../logging/logger.js';
 import { TokenTracker } from '../budget/token-tracker.js';
@@ -32,10 +33,77 @@ interface CopilotEvent {
 /** Summary extracted from the copilot `result` event. */
 interface CopilotResultSummary {
   exitCode: number;
+  tokenUsage?: { input: number; output: number; cachedInput?: number };
   premiumRequests?: number;
   totalApiDurationMs?: number;
   sessionDurationMs?: number;
   codeChanges?: { linesAdded: number; linesRemoved: number; filesModified: string[] };
+}
+
+function readNumericField(record: Record<string, unknown>, keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'number') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function extractCopilotTokenUsage(usage: Record<string, unknown> | undefined): CopilotResultSummary['tokenUsage'] {
+  if (!usage) return undefined;
+
+  const input = readNumericField(usage, ['input', 'inputTokens', 'input_tokens', 'promptTokens', 'prompt_tokens', 'tokensIn', 'tokens_in']);
+  const output = readNumericField(usage, ['output', 'outputTokens', 'output_tokens', 'completionTokens', 'completion_tokens', 'tokensOut', 'tokens_out']);
+  const cachedInput = readNumericField(usage, ['cachedInput', 'cachedInputTokens', 'cached_input_tokens', 'cache_read_input_tokens', 'tokensCached', 'tokens_cached']);
+
+  if (input == null || output == null) {
+    return undefined;
+  }
+
+  return {
+    input,
+    output,
+    ...(cachedInput != null ? { cachedInput } : {}),
+  };
+}
+
+function hasMeaningfulTokenUsage(tokenUsage: AgentResult['tokenUsage']): boolean {
+  if (!tokenUsage) return false;
+  return tokenUsage.input > 0 || tokenUsage.output > 0 || (tokenUsage.cachedInput ?? 0) > 0;
+}
+
+function normalizeStructuredTokenUsage(raw: unknown): AgentResult['tokenUsage'] {
+  if (!raw || typeof raw !== 'object') return null;
+
+  const tokenUsage = raw as Record<string, unknown>;
+  const input = typeof tokenUsage.input === 'number'
+    ? tokenUsage.input
+    : typeof tokenUsage.prompt === 'number'
+      ? tokenUsage.prompt
+      : undefined;
+  const output = typeof tokenUsage.output === 'number'
+    ? tokenUsage.output
+    : typeof tokenUsage.completion === 'number'
+      ? tokenUsage.completion
+      : undefined;
+  const cachedInput = typeof tokenUsage.cachedInput === 'number' ? tokenUsage.cachedInput : undefined;
+
+  if (input == null || output == null) {
+    return null;
+  }
+
+  return {
+    input,
+    output,
+    ...(cachedInput != null ? { cachedInput } : {}),
+  };
+}
+
+function getTokenUsageRuntime(runtime: MigrationConfig['agentBackend']['runtime']): 'claude-code' | 'copilot-cli' | undefined {
+  if (runtime === 'claude-code') return 'claude-code';
+  if (runtime === 'copilot') return 'copilot-cli';
+  return undefined;
 }
 
 /**
@@ -83,15 +151,34 @@ function parseCopilotJsonl(stdout: string): {
           break;
         }
         case 'result': {
-          const data = event as { exitCode?: number; usage?: Record<string, unknown> };
-          const usage = data.usage as {
+          const eventData = (event.data && typeof event.data === 'object')
+            ? event.data as Record<string, unknown>
+            : undefined;
+          const usage = (eventData?.usage && typeof eventData.usage === 'object'
+            ? eventData.usage
+            : ('usage' in event && typeof event.usage === 'object' ? event.usage : undefined)) as {
+            input?: number;
+            inputTokens?: number;
+            input_tokens?: number;
+            output?: number;
+            outputTokens?: number;
+            output_tokens?: number;
+            cachedInput?: number;
+            cachedInputTokens?: number;
+            cached_input_tokens?: number;
+            cache_read_input_tokens?: number;
+            tokensCached?: number;
+            tokens_cached?: number;
             premiumRequests?: number;
             totalApiDurationMs?: number;
             sessionDurationMs?: number;
             codeChanges?: { linesAdded: number; linesRemoved: number; filesModified: string[] };
           } | undefined;
           resultSummary = {
-            exitCode: data.exitCode ?? -1,
+            exitCode: typeof eventData?.exitCode === 'number'
+              ? eventData.exitCode
+              : (typeof event.exitCode === 'number' ? event.exitCode : -1),
+            tokenUsage: extractCopilotTokenUsage(usage),
             premiumRequests: usage?.premiumRequests,
             totalApiDurationMs: usage?.totalApiDurationMs,
             sessionDurationMs: usage?.sessionDurationMs,
@@ -163,7 +250,7 @@ export function buildBackendRuntimeConfig(config: MigrationConfig): BackendRunti
   return {
     agent: {
       backend: backendName,
-      model: config.agentBackend.model,
+      model: config.models?.default ?? config.agentBackend.model,
       timeout: config.agentBackend.timeout,
       copilot: {
         cliCommand: backendName === 'copilot' ? config.agentBackend.cliCommand : undefined,
@@ -228,7 +315,11 @@ function toAamfResult(
     if (typeof fwResult.tokenUsage === 'number') {
       tokenUsage = { input: fwResult.tokenUsage, output: 0 };
     } else {
-      tokenUsage = { input: fwResult.tokenUsage.input, output: fwResult.tokenUsage.output };
+      tokenUsage = {
+        input: fwResult.tokenUsage.input,
+        output: fwResult.tokenUsage.output,
+        ...(fwResult.tokenUsage.cachedInput != null ? { cachedInput: fwResult.tokenUsage.cachedInput } : {}),
+      };
     }
   }
 
@@ -256,18 +347,19 @@ function toAamfResult(
 function finaliseResult(
   agentResult: AgentResult,
   stdout: string,
+  stderr: string,
+  runtime: MigrationConfig['agentBackend']['runtime'],
   logger: Logger,
 ): AgentResult {
   const schema = getOutputSchema(agentResult.agent);
   const parseResult = parseAamfOutput(stdout, schema);
   if (parseResult.parsed) {
-    const parsedData = parseResult.data as Record<string, unknown> & {
-      tokenUsage?: { input: number; output: number; cachedInput?: number };
-    };
+    const parsedData = parseResult.data as Record<string, unknown>;
     agentResult.extensions.structuredOutput = parsedData;
     agentResult.extensions.outputParsed = true;
-    if (parsedData.tokenUsage) {
-      agentResult.tokenUsage = parsedData.tokenUsage;
+    const normalizedTokenUsage = normalizeStructuredTokenUsage(parsedData.tokenUsage);
+    if (normalizedTokenUsage) {
+      agentResult.tokenUsage = normalizedTokenUsage;
     }
   } else if (parseResult.error === MISSING_BLOCK_ERROR) {
     logger.warn(`Agent ${agentResult.agent} did not emit an aamf-json block`);
@@ -279,7 +371,20 @@ function finaliseResult(
     agentResult.error = `aamf-json parse failed: ${parseResult.error}`;
   }
 
-  if (!agentResult.tokenUsage) {
+  if (!hasMeaningfulTokenUsage(agentResult.tokenUsage)) {
+    const parsedTokenUsage = parseTokenUsage(`${stdout}\n${stderr}`, getTokenUsageRuntime(runtime));
+    if (parsedTokenUsage) {
+      agentResult.tokenUsage = {
+        input: parsedTokenUsage.input,
+        output: parsedTokenUsage.output,
+        ...(parsedTokenUsage.cachedInput != null ? { cachedInput: parsedTokenUsage.cachedInput } : {}),
+      };
+      if (parsedTokenUsage.premiumRequests != null) {
+        agentResult.extensions.premiumRequests = parsedTokenUsage.premiumRequests;
+      }
+      return agentResult;
+    }
+
     const estimatedTotal = TokenTracker.estimateTokens(stdout);
     logger.warn(
       `Token usage unavailable for ${agentResult.agent}; falling back to prompt-length estimate`,
@@ -394,6 +499,9 @@ export class AgentLauncher {
         resultSummary: parsed.resultSummary,
         errorCount: parsed.errorEvents.length,
       };
+      if (!hasMeaningfulTokenUsage(agentResult.tokenUsage) && parsed.resultSummary?.tokenUsage) {
+        agentResult.tokenUsage = parsed.resultSummary.tokenUsage;
+      }
       // Extract premiumRequests from copilot result summary
       if (parsed.resultSummary?.premiumRequests != null) {
         agentResult.extensions.premiumRequests = parsed.resultSummary.premiumRequests;
@@ -401,6 +509,6 @@ export class AgentLauncher {
     }
 
     // Parse aamf-json structured output and fill in token usage fallback
-    return finaliseResult(agentResult, stdoutForParsing, invLogger);
+    return finaliseResult(agentResult, stdoutForParsing, fwResult.stderr, this.config.agentBackend.runtime, invLogger);
   }
 }

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -104,7 +104,7 @@ export class MigrationRuntime {
     if (this.config.agentBackend.runtime === 'claude-code') {
       return {
         agentDir: this.config.agentBackend.agentDir,
-        model: this.config.agentBackend.model,
+        model: this.config.models?.default ?? this.config.agentBackend.model,
         agentFileSuffix: '.md',
         validateSchemaContract: false,
       };
@@ -112,7 +112,7 @@ export class MigrationRuntime {
 
     return {
       agentDir: this.config.agentBackend.agentDir,
-      model: this.config.agentBackend.model,
+      model: this.config.models?.default ?? this.config.agentBackend.model,
       agentFileSuffix: '.agent.md',
       validateSchemaContract: true,
     };

--- a/src/flow/steps/migration.ts
+++ b/src/flow/steps/migration.ts
@@ -40,6 +40,21 @@ import {
   assertPhaseSuccess,
 } from './shared.js';
 
+type RoutingConfig = NonNullable<MigrationFlowContext['config']['models']['routing']>
+  | NonNullable<MigrationFlowContext['config']['options']['modelRouting']>;
+
+function isLegacyRoutingConfig(routing: RoutingConfig): routing is NonNullable<MigrationFlowContext['config']['options']['modelRouting']> {
+  return 'heavyModel' in routing || 'criticalModel' in routing || 'maxCriticalTasks' in routing;
+}
+
+function getRoutingHeavyModel(routing: RoutingConfig): string | undefined {
+  return isLegacyRoutingConfig(routing) ? routing.heavyModel : routing.heavy;
+}
+
+function getRoutingCriticalModel(routing: RoutingConfig): string | undefined {
+  return isLegacyRoutingConfig(routing) ? routing.criticalModel : routing.critical;
+}
+
 function buildWaveTaskBranch(
   task: MigrationTask,
   retryExec: RetryExecutor,
@@ -133,7 +148,8 @@ async function runMigrateSubstep(
   });
   const migratorInv = buildInvocation(ctx, 'code-migrator', migratorCtx, 5, task.id, task);
   const fallbackModel = getFailureRecoveryModel(ctx);
-  const initialRoutingDecision = ctx.config.options.modelRouting?.enabled
+  const routing = ctx.config.models?.routing ?? ctx.config.options.modelRouting;
+  const initialRoutingDecision = routing?.enabled
     ? selectModelForInvocation(ctx, task, 'code-migrator') : undefined;
 
   const migratorResult = await retryExec.executeWithRetry(migratorInv, {
@@ -149,13 +165,15 @@ async function runMigrateSubstep(
         migratorInv.modelOverride = fallbackModel;
         ctx.logger.warn(`Switching ${task.id} code-migrator to fallback model: ${fallbackModel}`);
       } else if (initialRoutingDecision) {
-        const routing = ctx.config.options.modelRouting!;
+        const routing = ctx.config.models?.routing ?? ctx.config.options.modelRouting;
+        if (!routing) return;
         const escalateAt = routing.escalateOnRetryAttempt ?? 2;
         if (attempt >= escalateAt) {
           const targetTier = initialRoutingDecision.tier === 'normal'
             ? 'heavy' as const : initialRoutingDecision.tier === 'heavy' ? 'critical' as const : 'critical' as const;
           const escalatedModel = targetTier === 'critical'
-            ? (routing.criticalModel ?? routing.heavyModel) : routing.heavyModel;
+            ? (getRoutingCriticalModel(routing) ?? getRoutingHeavyModel(routing))
+            : getRoutingHeavyModel(routing);
           if (escalatedModel) {
             const retryDecision = applyRoutingCaps(ctx, {
               ...initialRoutingDecision, tier: targetTier, selectedModel: escalatedModel,

--- a/src/flow/steps/shared.ts
+++ b/src/flow/steps/shared.ts
@@ -110,7 +110,7 @@ export function assertPhaseSuccess(result: import('../../agents/types.js').Phase
 // ─── Helper Functions ──────────────────────────────────────────────────
 
 export function getConfiguredRuntimeModel(ctx: MigrationFlowContext): string {
-  return ctx.config.agentBackend.model ?? 'claude-sonnet-4';
+  return ctx.config.models?.default ?? ctx.config.agentBackend.model ?? 'claude-sonnet-4';
 }
 
 export function getRuntimeTimeout(ctx: MigrationFlowContext): number {
@@ -134,12 +134,40 @@ export function isGitAutomationEnabled(ctx: MigrationFlowContext): boolean {
 }
 
 export function getFailureRecoveryModel(ctx: MigrationFlowContext): string | undefined {
-  return ctx.config.agentBackend.failureRecoveryModel;
+  return ctx.config.models?.failureRecovery ?? ctx.config.agentBackend.failureRecoveryModel;
 }
 
 export function getDefaultRoutingModel(ctx: MigrationFlowContext): string {
-  const routing = ctx.config.options.modelRouting;
-  return routing?.defaultModel ?? (ctx.config.agentBackend.model ?? 'unknown');
+  return ctx.config.models?.default
+    ?? ctx.config.options.modelRouting?.defaultModel
+    ?? ctx.config.agentBackend.model
+    ?? 'unknown';
+}
+
+function getRoutingConfig(ctx: MigrationFlowContext) {
+  return ctx.config.models?.routing ?? ctx.config.options.modelRouting;
+}
+
+type RoutingConfig = NonNullable<ReturnType<typeof getRoutingConfig>>;
+type LegacyRoutingConfig = NonNullable<MigrationFlowContext['config']['options']['modelRouting']>;
+
+function isLegacyRoutingConfig(routing: RoutingConfig): routing is LegacyRoutingConfig {
+  return 'heavyModel' in routing || 'criticalModel' in routing || 'maxCriticalTasks' in routing;
+}
+
+function getRoutingHeavyModel(routing: ReturnType<typeof getRoutingConfig>): string | undefined {
+  if (!routing) return undefined;
+  return isLegacyRoutingConfig(routing) ? routing.heavyModel : routing.heavy;
+}
+
+function getRoutingCriticalModel(routing: ReturnType<typeof getRoutingConfig>): string | undefined {
+  if (!routing) return undefined;
+  return isLegacyRoutingConfig(routing) ? routing.criticalModel : routing.critical;
+}
+
+function getRoutingMaxEscalatedTasks(routing: ReturnType<typeof getRoutingConfig>): number {
+  if (!routing) return 0;
+  return isLegacyRoutingConfig(routing) ? routing.maxCriticalTasks : routing.maxEscalatedTasks;
 }
 
 export function isTransientModelFailure(errorText: string): boolean {
@@ -185,7 +213,8 @@ export function buildInvocation(
   let routingTier: ModelTier | undefined;
   let routingReason: string | undefined;
 
-  if (!failureRecoveryOverride && ctx.config.options.modelRouting?.enabled) {
+  const routing = getRoutingConfig(ctx);
+  if (!failureRecoveryOverride && routing?.enabled) {
     const decision = applyRoutingCaps(
       ctx, selectModelForInvocation(ctx, task, agent), taskId,
     );
@@ -245,8 +274,8 @@ export function selectModelForInvocation(
   task: MigrationTask | undefined,
   agent: AgentName,
 ): RoutingDecision {
-  const routing = ctx.config.options.modelRouting;
-  const defaultModel = routing?.defaultModel ?? (ctx.config.agentBackend.model ?? 'unknown');
+  const routing = getRoutingConfig(ctx);
+  const defaultModel = getDefaultRoutingModel(ctx);
 
   if (!routing?.enabled) {
     return { tier: 'normal', selectedModel: defaultModel, reason: 'routing-disabled', score: 0, escalated: false };
@@ -269,18 +298,18 @@ export function selectModelForInvocation(
   if (task && routing.criticalTaskPatterns?.length) {
     for (const pattern of routing.criticalTaskPatterns) {
       if (globToRegex(pattern).test(task.id)) {
-        return { tier: 'critical', selectedModel: routing.criticalModel ?? defaultModel, reason: 'critical-task-pattern', score, escalated: false };
+        return { tier: 'critical', selectedModel: getRoutingCriticalModel(routing) ?? defaultModel, reason: 'critical-task-pattern', score, escalated: false };
       }
     }
   }
   if (routing.criticalAgents?.length && routing.criticalAgents.includes(agent)) {
-    return { tier: 'critical', selectedModel: routing.criticalModel ?? defaultModel, reason: 'critical-agent', score, escalated: false };
+    return { tier: 'critical', selectedModel: getRoutingCriticalModel(routing) ?? defaultModel, reason: 'critical-agent', score, escalated: false };
   }
   if (score >= routing.criticalThreshold) {
-    return { tier: 'critical', selectedModel: routing.criticalModel ?? defaultModel, reason: 'score-critical', score, escalated: false };
+    return { tier: 'critical', selectedModel: getRoutingCriticalModel(routing) ?? defaultModel, reason: 'score-critical', score, escalated: false };
   }
   if (score >= routing.heavyThreshold) {
-    return { tier: 'heavy', selectedModel: routing.heavyModel ?? defaultModel, reason: 'score-heavy', score, escalated: false };
+    return { tier: 'heavy', selectedModel: getRoutingHeavyModel(routing) ?? defaultModel, reason: 'score-heavy', score, escalated: false };
   }
   return { tier: 'normal', selectedModel: defaultModel, reason: 'score-normal', score, escalated: false };
 }
@@ -291,13 +320,14 @@ export function applyRoutingCaps(
   taskId?: string,
 ): RoutingDecision {
   if (decision.tier === 'normal') return decision;
-  const routing = ctx.config.options.modelRouting;
+  const routing = getRoutingConfig(ctx);
   if (!routing?.enabled) return decision;
   const defaultModel = getDefaultRoutingModel(ctx);
 
   const isNewRoutedTask = Boolean(taskId && !ctx.routedTaskIds.has(taskId));
   const routedTaskCountAfterDecision = ctx.routedTaskIds.size + (isNewRoutedTask ? 1 : 0);
-  if (routing.maxCriticalTasks > 0 && routedTaskCountAfterDecision > routing.maxCriticalTasks) {
+  const maxEscalatedTasks = getRoutingMaxEscalatedTasks(routing);
+  if (maxEscalatedTasks > 0 && routedTaskCountAfterDecision > maxEscalatedTasks) {
     return { ...decision, tier: 'normal', selectedModel: defaultModel, reason: `${decision.reason}:capped-max-tasks` };
   }
   if (routing.maxEscalationCostUsd > 0) {
@@ -344,7 +374,7 @@ export async function launchAgentWithEvents(
   }
 
   const endTime = new Date().toISOString();
-  const configModel = ctx.config.agentBackend.model ?? 'unknown';
+  const configModel = getConfiguredRuntimeModel(ctx);
   const model = invocation.modelOverride ?? configModel;
   const tokensInput = result.tokenUsage?.input ?? 0;
   const tokensOutput = result.tokenUsage?.output ?? 0;
@@ -355,9 +385,10 @@ export async function launchAgentWithEvents(
 
   const routingTier = invocation.extensions?.routingTier;
   const routingReason = invocation.extensions?.routingReason;
-  const routingDecision = ctx.config.options.modelRouting?.enabled && routingTier
+  const routing = getRoutingConfig(ctx);
+  const routingDecision = routing?.enabled && routingTier
     ? (() => {
-        const defaultModel = ctx.config.options.modelRouting!.defaultModel ?? configModel;
+        const defaultModel = getDefaultRoutingModel(ctx);
         const projectedCost = ctx.costEstimator.projectCost(model, AVG_TOKENS_PER_TASK).total;
         const baseCost = ctx.costEstimator.projectCost(defaultModel, AVG_TOKENS_PER_TASK).total;
         return { incrementalCost: Math.max(0, projectedCost - baseCost) };

--- a/tests/config/config-schema.test.ts
+++ b/tests/config/config-schema.test.ts
@@ -30,6 +30,8 @@ describe('MigrationConfigSchema', () => {
     expect(result.options.git?.commitByAgent).toBe(true);
     expect(result.options.git?.commitPerTask).toBe(true);
     expect(result.options.git?.allowEmptyTaskCommits).toBe(true);
+    expect(result.models.default).toBeUndefined();
+    expect(result.models.failureRecovery).toBeUndefined();
     expect(result.agentBackend.cliCommand).toBe('copilot');
     expect(result.agentBackend.timeout).toBe(300000);
     expect(result.agentBackend.failureRecoveryModel).toBeUndefined();
@@ -111,7 +113,8 @@ describe('MigrationConfigSchema', () => {
       source: { ...validConfig.source, entryPoints: ['main.py'], excludePatterns: ['venv'] },
       target: { ...validConfig.target, framework: 'express' },
       options: { maxParallelAgents: 5, tokenBudget: 1000000 },
-      agentBackend: { runtime: 'copilot', cliCommand: 'copilot', model: 'gpt-4o', agentDir: '.github/agents', timeout: 300000 },
+      models: { default: 'gpt-4o' },
+      agentBackend: { runtime: 'copilot', cliCommand: 'copilot', agentDir: '.github/agents', timeout: 300000 },
     };
     const result = MigrationConfigSchema.safeParse(full);
     expect(result.success).toBe(true);
@@ -137,15 +140,15 @@ describe('MigrationConfigSchema', () => {
   });
 
   describe('Additional Validation', () => {
-    it('should accept agentBackend.failureRecoveryModel override', () => {
+    it('should accept models.failureRecovery override', () => {
       const result = MigrationConfigSchema.parse({
         ...validConfig,
-        agentBackend: { failureRecoveryModel: 'gpt-4.1' },
+        models: { failureRecovery: 'gpt-4.1' },
       });
-      expect(result.agentBackend.failureRecoveryModel).toBe('gpt-4.1');
+      expect(result.models.failureRecovery).toBe('gpt-4.1');
     });
 
-    it('should accept agentBackend.failureRecoveryModel override for claude-code', () => {
+    it('should continue accepting agentBackend.failureRecoveryModel as a compatibility alias', () => {
       const result = MigrationConfigSchema.parse({
         ...validConfig,
         agentBackend: { runtime: 'claude-code', failureRecoveryModel: 'claude-sonnet-4.5' },
@@ -356,6 +359,7 @@ describe('MigrationConfigSchema', () => {
       expect(result.agentBackend.cliCommand).toBe('copilot');
       expect(result.agentBackend.agentDir).toBe('.github/agents');
       expect(result.agentBackend.timeout).toBe(300000);
+      expect(result.models.default).toBeUndefined();
       expect(result.agentBackend.model).toBeUndefined();
       expect(result.agentBackend.phaseTimeouts).toBeUndefined();
     });
@@ -374,16 +378,16 @@ describe('MigrationConfigSchema', () => {
     it('should accept explicit agentBackend config', () => {
       const result = MigrationConfigSchema.parse({
         ...validConfig,
+        models: { default: 'claude-sonnet-4-5' },
         agentBackend: {
           runtime: 'claude-code',
           cliCommand: 'claude',
-          model: 'claude-sonnet-4-5',
           agentDir: '.claude/agents',
           timeout: 600000,
           phaseTimeouts: { 4: 120000 },
         },
       });
-      expect(result.agentBackend.model).toBe('claude-sonnet-4-5');
+      expect(result.models.default).toBe('claude-sonnet-4-5');
       expect(result.agentBackend.timeout).toBe(600000);
     });
 
@@ -412,56 +416,65 @@ describe('MigrationConfigSchema', () => {
       expect(result.success).toBe(false);
     });
 
-    describe('modelRouting option', () => {
-      it('should leave modelRouting undefined when omitted', () => {
+    describe('models routing', () => {
+      it('should leave models.routing undefined when omitted', () => {
         const result = MigrationConfigSchema.parse(validConfig);
-        expect(result.options.modelRouting).toBeUndefined();
+        expect(result.models.routing).toBeUndefined();
       });
 
-      it('should default enabled to false when modelRouting is {}', () => {
+      it('should default enabled to false when models.routing is {}', () => {
         const result = MigrationConfigSchema.parse({
           ...validConfig,
-          options: { modelRouting: {} },
+          models: { routing: {} },
         });
-        expect(result.options.modelRouting?.enabled).toBe(false);
+        expect(result.models.routing?.enabled).toBe(false);
       });
 
       it('should default thresholds and caps correctly', () => {
         const result = MigrationConfigSchema.parse({
           ...validConfig,
-          options: { modelRouting: {} },
+          models: { routing: {} },
         });
-        const mr = result.options.modelRouting;
+        const mr = result.models.routing;
         expect(mr?.heavyThreshold).toBe(40);
         expect(mr?.criticalThreshold).toBe(70);
-        expect(mr?.maxCriticalTasks).toBe(0);
+        expect(mr?.maxEscalatedTasks).toBe(0);
         expect(mr?.maxEscalationCostUsd).toBe(0);
         expect(mr?.escalateOnRetryAttempt).toBe(2);
       });
 
-      it('should accept modelRouting with enabled: true and heavyModel', () => {
+      it('should accept models.routing with enabled: true and heavy', () => {
+        const result = MigrationConfigSchema.parse({
+          ...validConfig,
+          models: { routing: { enabled: true, heavy: 'claude-opus-4.5' } },
+        });
+        expect(result.models.routing?.enabled).toBe(true);
+        expect(result.models.routing?.heavy).toBe('claude-opus-4.5');
+      });
+
+      it('should accept criticalAgents as an array of strings', () => {
+        const result = MigrationConfigSchema.parse({
+          ...validConfig,
+          models: { routing: { criticalAgents: ['code-migrator', 'parity-verifier'] } },
+        });
+        expect(result.models.routing?.criticalAgents).toEqual(['code-migrator', 'parity-verifier']);
+      });
+
+      it('should accept criticalTaskPatterns as an array of strings', () => {
+        const result = MigrationConfigSchema.parse({
+          ...validConfig,
+          models: { routing: { criticalTaskPatterns: ['task-00*'] } },
+        });
+        expect(result.models.routing?.criticalTaskPatterns).toEqual(['task-00*']);
+      });
+
+      it('should continue accepting options.modelRouting as a compatibility alias', () => {
         const result = MigrationConfigSchema.parse({
           ...validConfig,
           options: { modelRouting: { enabled: true, heavyModel: 'claude-opus-4.5' } },
         });
         expect(result.options.modelRouting?.enabled).toBe(true);
         expect(result.options.modelRouting?.heavyModel).toBe('claude-opus-4.5');
-      });
-
-      it('should accept criticalAgents as an array of strings', () => {
-        const result = MigrationConfigSchema.parse({
-          ...validConfig,
-          options: { modelRouting: { criticalAgents: ['code-migrator', 'parity-verifier'] } },
-        });
-        expect(result.options.modelRouting?.criticalAgents).toEqual(['code-migrator', 'parity-verifier']);
-      });
-
-      it('should accept criticalTaskPatterns as an array of strings', () => {
-        const result = MigrationConfigSchema.parse({
-          ...validConfig,
-          options: { modelRouting: { criticalTaskPatterns: ['task-00*'] } },
-        });
-        expect(result.options.modelRouting?.criticalTaskPatterns).toEqual(['task-00*']);
       });
 
     });

--- a/tests/core/agent-launcher.test.ts
+++ b/tests/core/agent-launcher.test.ts
@@ -8,9 +8,12 @@
  *   - Post-processing (aamf-json parsing, copilot events, output detection)
  *   - Invocation delay logic
  */
-import { describe, it, expect } from 'vitest';
-import { buildBackendRuntimeConfig, toFrameworkInvocation } from '../../src/core/agent-launcher.js';
-import { createMockConfig } from '../helpers/mocks.js';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, vi } from 'vitest';
+import { AgentLauncher, buildBackendRuntimeConfig, toFrameworkInvocation } from '../../src/core/agent-launcher.js';
+import { createMockConfig, createSilentLogger } from '../helpers/mocks.js';
 import type { AgentInvocation } from '../../src/agents/types.js';
 
 describe('buildBackendRuntimeConfig', () => {
@@ -29,7 +32,7 @@ describe('buildBackendRuntimeConfig', () => {
   });
 
   it('should pass through model', () => {
-    const config = createMockConfig({ agentBackend: { runtime: 'copilot', model: 'gpt-4.1', timeout: 300_000 } });
+    const config = createMockConfig({ models: { default: 'gpt-4.1' }, agentBackend: { runtime: 'copilot', timeout: 300_000 } });
     const rtConfig = buildBackendRuntimeConfig(config);
     expect(rtConfig.agent.model).toBe('gpt-4.1');
   });
@@ -123,5 +126,101 @@ describe('toFrameworkInvocation', () => {
     const inv = baseInvocation({ workItemId: undefined });
     const fw = toFrameworkInvocation(inv);
     expect(fw.workItemId).toBe('');
+  });
+});
+
+describe('AgentLauncher token usage post-processing', () => {
+  async function createHarness(configOverrides?: Parameters<typeof createMockConfig>[0]) {
+    const tempDir = await mkdtemp(join(tmpdir(), 'aamf-agent-launcher-'));
+    const contextPath = join(tempDir, 'context.json');
+    await writeFile(contextPath, JSON.stringify({ outputPath: join(tempDir, 'out') }), 'utf-8');
+
+    const config = createMockConfig({
+      projectName: 'launcher-test',
+      source: { path: tempDir },
+      target: { outputPath: join(tempDir, 'target') },
+      ...configOverrides,
+    });
+    const logger = createSilentLogger(tempDir);
+    const launcher = new AgentLauncher(config, tempDir, logger);
+
+    return {
+      contextPath,
+      launcher,
+      tempDir,
+    };
+  }
+
+  it('should estimate token usage when the framework reports zero tokens', async () => {
+    const { launcher, contextPath } = await createHarness();
+    const launchAgent = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      success: true,
+      timedOut: false,
+      duration: 100,
+      stdout: 'Agent output with useful content\n```aamf-json\n{"status":"completed"}\n```',
+      stderr: '',
+      tokenUsage: 0,
+      outputPath: '',
+      outputExists: true,
+    });
+    (launcher as any).frameworkLauncher = { init: vi.fn(), launchAgent };
+
+    const result = await launcher.launchAgent({
+      agent: 'knowledge-builder',
+      contextPath,
+      outputPath: '',
+      phase: 2,
+      workItemId: '',
+    });
+
+    expect(result.tokenUsage).not.toBeNull();
+    expect(result.tokenUsage?.input).toBeGreaterThan(0);
+    expect(result.tokenUsage?.output).toBe(0);
+  });
+
+  it('should extract token usage from Copilot JSONL result events', async () => {
+    const { launcher, contextPath } = await createHarness();
+    const stdout = [
+      JSON.stringify({
+        type: 'assistant.message',
+        data: { content: '```aamf-json\n{"status":"completed"}\n```' },
+      }),
+      JSON.stringify({
+        type: 'result',
+        data: {
+          exitCode: 0,
+          usage: {
+            inputTokens: 1200,
+            outputTokens: 300,
+            cachedInputTokens: 100,
+            premiumRequests: 2,
+          },
+        },
+      }),
+    ].join('\n');
+    const launchAgent = vi.fn().mockResolvedValue({
+      exitCode: 0,
+      success: true,
+      timedOut: false,
+      duration: 100,
+      stdout,
+      stderr: '',
+      tokenUsage: 0,
+      outputPath: '',
+      outputExists: true,
+    });
+    (launcher as any).frameworkLauncher = { init: vi.fn(), launchAgent };
+
+    const result = await launcher.launchAgent({
+      agent: 'migration-planner',
+      contextPath,
+      outputPath: '',
+      phase: 3,
+      workItemId: '',
+    });
+
+    expect(result.tokenUsage).toEqual({ input: 1200, output: 300, cachedInput: 100 });
+    expect(result.extensions.premiumRequests).toBe(2);
   });
 });

--- a/tests/core/runtime.test.ts
+++ b/tests/core/runtime.test.ts
@@ -134,7 +134,8 @@ describe('MigrationRuntime', () => {
       // Inject a minimal config so formatDuration and CostEstimator work
       (runtime as any).config = {
         projectName: 'test-project',
-        agentBackend: { runtime: 'copilot', model: 'claude-sonnet-4' },
+        models: { default: 'claude-sonnet-4' },
+        agentBackend: { runtime: 'copilot' },
       };
       consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     });
@@ -507,12 +508,13 @@ describe('MigrationRuntime', () => {
 
       runtime.config = {
         projectName: 'test-project',
+        models: { default: 'claude-sonnet-4' },
         options: {
           resume: false, dryRun: false,
           maxParallelAgents: 1, buildConcurrency: 1,
           git: { enabled: false },
         },
-        agentBackend: { runtime: 'copilot', model: 'claude-sonnet-4', timeout: 300_000 },
+        agentBackend: { runtime: 'copilot', timeout: 300_000 },
         source: { path: '/tmp/source', language: 'python' },
         target: { language: 'typescript', outputPath: '/tmp/target' },
         environment: {},
@@ -587,12 +589,13 @@ describe('MigrationRuntime', () => {
 
       runtime.config = {
         projectName: 'test-project',
+        models: { default: 'claude-sonnet-4' },
         options: {
           resume: false, dryRun: false,
           maxParallelAgents: 1, buildConcurrency: 1,
           git: { enabled: false },
         },
-        agentBackend: { runtime: 'copilot', model: 'claude-sonnet-4', timeout: 300_000 },
+        agentBackend: { runtime: 'copilot', timeout: 300_000 },
         source: { path: '/tmp/source', language: 'python' },
         target: { language: 'typescript', outputPath: '/tmp/target' },
         environment: {},

--- a/tests/e2e/e2e-sqlite-csharp.test.ts
+++ b/tests/e2e/e2e-sqlite-csharp.test.ts
@@ -77,6 +77,13 @@ async function ensureSqliteSource(): Promise<void> {
 async function writeMigrationConfig(): Promise<void> {
   const config = {
     projectName: 'sqlite-to-csharp-net9',
+    guidance: [
+      'Preserve externally observable behavior, but do not do a line-by-line transliteration of C into C#.',
+      'Prefer idiomatic .NET 9 and C# patterns over manual C-style memory and control-flow patterns when behavior can remain equivalent.',
+      'Use .NET standard library abstractions such as Stream, Span<T>, Memory<T>, string, collections, IDisposable, and SafeHandle where appropriate.',
+      'Avoid exposing pointer-oriented or macro-shaped designs in the target unless they are required for parity at the public boundary.',
+      'Choose C# naming, file layout, and project structure that are idiomatic for a .NET codebase rather than preserving C source layout mechanically.',
+    ],
     source: {
       path: sourceDir,
       language: 'c',
@@ -89,21 +96,42 @@ async function writeMigrationConfig(): Promise<void> {
       outputPath: outputDir,
       buildCommand: 'dotnet build',
       testCommand: 'dotnet test',
+      formatCommand: 'dotnet format',
+      lintCommand: 'dotnet format --verify-no-changes',
     },
     options: {
+      qualityPolicy: 'strict',
       maxParallelAgents: 3,
       maxRetriesPerTask: 2,
       maxLinesPerTask: 500,
+      executionMode: 'wave-barrier',
+      waveControl: {
+        maxConvergenceIterations: 3,
+      },
       tokenBudget: 500000,
       dryRun: false,
       resume: false,
+      idiomaticRefactor: {
+        enabled: true,
+        maxIterations: 3,
+      },
+    },
+    models: {
+      default: 'claude-sonnet-4.6',
+      routing: {
+        enabled: true,
+        heavy: 'claude-opus-4.6',
+        critical: 'claude-opus-4.6',
+        heavyThreshold: 30,
+        criticalThreshold: 55,
+      },
     },
     agentBackend: {
       runtime: 'copilot',
       cliCommand: 'copilot',
-      model: 'claude-sonnet-4.6',
-      agentDir: '../../../../.github/agents',
-      timeout: 300_000,
+      effort: 'high',
+      agentDir: '../../../.github/agents',
+      timeout: 1_800_000,
     },
   };
 

--- a/tests/fixtures/jq-c-project/migration.config.json
+++ b/tests/fixtures/jq-c-project/migration.config.json
@@ -28,10 +28,12 @@
       }
     }
   },
+  "models": {
+    "default": "claude-sonnet-4.6"
+  },
   "agentBackend": {
     "runtime": "copilot",
     "cliCommand": "copilot",
-    "model": "claude-sonnet-4.6",
     "agentDir": "../../../../.github/agents",
     "timeout": 300000
   }

--- a/tests/fixtures/lz4-c-project/migration.config.json
+++ b/tests/fixtures/lz4-c-project/migration.config.json
@@ -60,10 +60,12 @@
       }
     }
   },
+  "models": {
+    "default": "claude-sonnet-4.6"
+  },
   "agentBackend": {
     "runtime": "copilot",
     "cliCommand": "copilot",
-    "model": "claude-sonnet-4.6",
     "agentDir": "../../../../.github/agents",
     "timeout": 1800000
   }

--- a/tests/fixtures/protobuf-upb-project/migration.config.json
+++ b/tests/fixtures/protobuf-upb-project/migration.config.json
@@ -41,10 +41,12 @@
       }
     }
   },
+  "models": {
+    "default": "claude-sonnet-4.6"
+  },
   "agentBackend": {
     "runtime": "copilot",
     "cliCommand": "copilot",
-    "model": "claude-sonnet-4.6",
     "agentDir": "../../../../.github/agents",
     "timeout": 1800000
   }

--- a/tests/fixtures/sqlite-c-project/migration.config.json
+++ b/tests/fixtures/sqlite-c-project/migration.config.json
@@ -1,5 +1,12 @@
 {
   "projectName": "sqlite-to-csharp-net9",
+  "guidance": [
+    "Preserve externally observable behavior, but do not do a line-by-line transliteration of C into C#.",
+    "Prefer idiomatic .NET 9 and C# patterns over manual C-style memory and control-flow patterns when behavior can remain equivalent.",
+    "Use .NET standard library abstractions such as Stream, Span<T>, Memory<T>, string, collections, IDisposable, and SafeHandle where appropriate.",
+    "Avoid exposing pointer-oriented or macro-shaped designs in the target unless they are required for parity at the public boundary.",
+    "Choose C# naming, file layout, and project structure that are idiomatic for a .NET codebase rather than preserving C source layout mechanically."
+  ],
   "source": {
     "path": "./sqlite-src/sqlite-autoconf-3510200",
     "language": "c",
@@ -11,16 +18,26 @@
     "framework": "net9.0",
     "outputPath": "./tmp/sqlite-csharp-output",
     "buildCommand": "dotnet build",
-    "testCommand": "dotnet test"
+    "testCommand": "dotnet test",
+    "formatCommand": "dotnet format",
+    "lintCommand": "dotnet format --verify-no-changes"
   },
   "options": {
     "qualityPolicy": "strict",
     "maxParallelAgents": 3,
     "maxRetriesPerTask": 2,
     "maxLinesPerTask": 500,
+    "executionMode": "wave-barrier",
+    "waveControl": {
+      "maxConvergenceIterations": 3
+    },
     "tokenBudget": 500000,
     "dryRun": false,
     "resume": false,
+    "idiomaticRefactor": {
+      "enabled": true,
+      "maxIterations": 3
+    },
     "kbIndex": {
       "enabled": true,
       "embeddings": {
@@ -28,11 +45,21 @@
       }
     }
   },
+  "models": {
+    "default": "claude-sonnet-4.6",
+    "routing": {
+      "enabled": true,
+      "heavy": "claude-opus-4.6",
+      "critical": "claude-opus-4.6",
+      "heavyThreshold": 30,
+      "criticalThreshold": 55
+    }
+  },
   "agentBackend": {
     "runtime": "copilot",
     "cliCommand": "copilot",
-    "model": "claude-sonnet-4.6",
-    "agentDir": "../../../../.github/agents",
-    "timeout": 300000
+    "effort": "high",
+    "agentDir": "../../../.github/agents",
+    "timeout": 1800000
   }
 }

--- a/tests/fixtures/tiny-python-project/migration.config.json
+++ b/tests/fixtures/tiny-python-project/migration.config.json
@@ -26,10 +26,12 @@
       }
     }
   },
+  "models": {
+    "default": "claude-sonnet-4.6"
+  },
   "agentBackend": {
     "runtime": "copilot",
     "cliCommand": "copilot",
-    "model": "claude-sonnet-4.6",
     "agentDir": "../../../../.github/agents",
     "timeout": 300000
   }

--- a/tests/fixtures/zstd-c-project/migration.config.json
+++ b/tests/fixtures/zstd-c-project/migration.config.json
@@ -79,11 +79,13 @@
       }
     }
   },
+  "models": {
+    "default": "gpt-5.4",
+    "failureRecovery": "gpt-5.4"
+  },
   "agentBackend": {
     "runtime": "copilot",
     "cliCommand": "copilot",
-    "model": "gpt-5.4",
-    "failureRecoveryModel": "gpt-5.4",
     "effort": "xhigh",
     "agentDir": "../../../../.github/agents",
     "timeout": 3600000,

--- a/tests/flow/steps/migration.test.ts
+++ b/tests/flow/steps/migration.test.ts
@@ -306,7 +306,8 @@ describe('buildPhase4Subflow (Phase 4)', () => {
         return {};
       });
       env = await setupFlowTestWithTasks(launcherFn, [SINGLE_AUTH_TASK], {
-        agentBackend: { runtime: 'copilot', failureRecoveryModel: 'gpt-4.1-mini' },
+        models: { failureRecovery: 'gpt-4.1-mini' },
+        agentBackend: { runtime: 'copilot' },
       });
 
       await runPhase4(env);
@@ -325,12 +326,12 @@ describe('buildPhase4Subflow (Phase 4)', () => {
     it('should route a task matching criticalTaskPatterns to criticalModel', async () => {
       const launcherFn = createMockLauncher();
       env = await setupFlowTestWithTasks(launcherFn, DEFAULT_PLANNING_TASKS, {
-        options: {
-          modelRouting: {
+        models: {
+          default: 'gpt-5-mini',
+          routing: {
             enabled: true,
-            defaultModel: 'gpt-5-mini',
-            heavyModel: 'gpt-4.1',
-            criticalModel: 'claude-opus-4.6',
+            heavy: 'gpt-4.1',
+            critical: 'claude-opus-4.6',
             heavyThreshold: 40,
             criticalThreshold: 70,
             criticalTaskPatterns: ['task-001'],
@@ -350,16 +351,16 @@ describe('buildPhase4Subflow (Phase 4)', () => {
     it('should downgrade to normal when maxCriticalTasks is reached', async () => {
       const launcherFn = createMockLauncher();
       env = await setupFlowTestWithTasks(launcherFn, DEFAULT_PLANNING_TASKS, {
-        options: {
-          modelRouting: {
+        models: {
+          default: 'gpt-5-mini',
+          routing: {
             enabled: true,
-            defaultModel: 'gpt-5-mini',
-            heavyModel: 'gpt-4.1',
-            criticalModel: 'claude-opus-4.6',
+            heavy: 'gpt-4.1',
+            critical: 'claude-opus-4.6',
             heavyThreshold: 40,
             criticalThreshold: 70,
             criticalTaskPatterns: ['task-*'],
-            maxCriticalTasks: 1,
+            maxEscalatedTasks: 1,
           },
         },
       });
@@ -378,10 +379,10 @@ describe('buildPhase4Subflow (Phase 4)', () => {
     it('should not set modelOverride when routing is disabled', async () => {
       const launcherFn = createMockLauncher();
       env = await setupFlowTestWithTasks(launcherFn, DEFAULT_PLANNING_TASKS, {
-        options: {
-          modelRouting: {
+        models: {
+          default: 'gpt-5-mini',
+          routing: {
             enabled: false,
-            defaultModel: 'gpt-5-mini',
             criticalTaskPatterns: ['task-*'],
           },
         },

--- a/tests/flow/steps/shared.test.ts
+++ b/tests/flow/steps/shared.test.ts
@@ -38,10 +38,10 @@ function mockContext(overrides: Record<string, unknown> = {}): MigrationFlowCont
       projectName: 'test-project',
       source: { path: '/src', language: 'python' },
       target: { language: 'typescript', outputPath: '/out', framework: 'node' },
-      agentBackend: { runtime: 'copilot', model: 'claude-sonnet-4', timeout: 300_000 },
+      models: { default: 'claude-sonnet-4', routing: { enabled: false } },
+      agentBackend: { runtime: 'copilot', timeout: 300_000 },
       options: {
         git: { enabled: false },
-        modelRouting: { enabled: false },
         qualityPolicy: 'strict',
         ...(overrides.options ?? {}),
       },
@@ -90,6 +90,14 @@ function mockContext(overrides: Record<string, unknown> = {}): MigrationFlowCont
       ...(overrides.agentBackend as Record<string, unknown>),
     };
     delete overrides.agentBackend;
+  }
+
+  if (overrides.models) {
+    (defaults.config as Record<string, unknown>).models = {
+      ...((defaults.config as Record<string, unknown>).models as Record<string, unknown>),
+      ...(overrides.models as Record<string, unknown>),
+    };
+    delete overrides.models;
   }
 
   return { ...defaults, ...overrides } as unknown as MigrationFlowContext;
@@ -222,7 +230,7 @@ describe('getConfiguredRuntimeModel', () => {
   });
 
   it('should fallback to claude-sonnet-4 when no model configured', () => {
-    const ctx = mockContext({ agentBackend: { runtime: 'copilot', model: undefined, timeout: 300_000 } });
+    const ctx = mockContext({ models: { default: undefined }, agentBackend: { runtime: 'copilot', timeout: 300_000 } });
     expect(getConfiguredRuntimeModel(ctx)).toBe('claude-sonnet-4');
   });
 });
@@ -241,7 +249,7 @@ describe('getPhaseTimeout', () => {
   });
 
   it('should return phase-specific timeout when configured', () => {
-    const ctx = mockContext({ agentBackend: { runtime: 'copilot', model: 'claude-sonnet-4', timeout: 300_000, phaseTimeouts: { 5: 600_000 } } });
+    const ctx = mockContext({ agentBackend: { runtime: 'copilot', timeout: 300_000, phaseTimeouts: { 5: 600_000 } } });
     expect(getPhaseTimeout(ctx, 5)).toBe(600_000);
     expect(getPhaseTimeout(ctx, 3)).toBe(300_000);
   });
@@ -288,18 +296,18 @@ describe('getFailureRecoveryModel', () => {
   });
 
   it('should return the configured model', () => {
-    const ctx = mockContext({ agentBackend: { runtime: 'copilot', model: 'claude-sonnet-4', timeout: 300_000, failureRecoveryModel: 'claude-opus-4' } });
+    const ctx = mockContext({ models: { default: 'claude-sonnet-4', failureRecovery: 'claude-opus-4' } });
     expect(getFailureRecoveryModel(ctx)).toBe('claude-opus-4');
   });
 });
 
 describe('getDefaultRoutingModel', () => {
-  it('should use routing defaultModel when routing is configured', () => {
-    const ctx = mockContext({ options: { modelRouting: { enabled: true, defaultModel: 'gpt-4o' } } });
+  it('should use models.default when routing is configured', () => {
+    const ctx = mockContext({ models: { default: 'gpt-4o', routing: { enabled: true } } });
     expect(getDefaultRoutingModel(ctx)).toBe('gpt-4o');
   });
 
-  it('should fall back to agentBackend model', () => {
+  it('should fall back to models.default', () => {
     const ctx = mockContext();
     expect(getDefaultRoutingModel(ctx)).toBe('claude-sonnet-4');
   });
@@ -317,12 +325,12 @@ describe('selectModelForInvocation', () => {
 
   it('should score based on task complexity', () => {
     const routing = {
-      enabled: true, defaultModel: 'base', criticalModel: 'critical',
-      heavyModel: 'heavy', criticalThreshold: 60, heavyThreshold: 30,
+      enabled: true, critical: 'critical',
+      heavy: 'heavy', criticalThreshold: 60, heavyThreshold: 30,
       criticalTaskPatterns: [], criticalAgents: [],
-      maxCriticalTasks: 10, maxEscalationCostUsd: 100,
+      maxEscalatedTasks: 10, maxEscalationCostUsd: 100,
     };
-    const ctx = mockContext({ options: { modelRouting: routing } });
+    const ctx = mockContext({ models: { default: 'base', routing } });
     const simple = mockTask({ complexity: 'simple', sourceFiles: ['a.py'], targetFiles: ['a.ts'], dependencies: [] });
     const complex = mockTask({ complexity: 'complex', sourceFiles: Array(10).fill('a.py'), targetFiles: Array(10).fill('a.ts'), dependencies: Array(10).fill('dep') });
 
@@ -334,12 +342,12 @@ describe('selectModelForInvocation', () => {
 
   it('should route to critical for task matching criticalTaskPatterns', () => {
     const routing = {
-      enabled: true, defaultModel: 'base', criticalModel: 'opus',
-      heavyModel: 'heavy', criticalThreshold: 60, heavyThreshold: 30,
+      enabled: true, critical: 'opus',
+      heavy: 'heavy', criticalThreshold: 60, heavyThreshold: 30,
       criticalTaskPatterns: ['task-auth-*'], criticalAgents: [],
-      maxCriticalTasks: 10, maxEscalationCostUsd: 100,
+      maxEscalatedTasks: 10, maxEscalationCostUsd: 100,
     };
-    const ctx = mockContext({ options: { modelRouting: routing } });
+    const ctx = mockContext({ models: { default: 'base', routing } });
     const task = mockTask({ id: 'task-auth-001' });
     const result = selectModelForInvocation(ctx, task, 'code-migrator');
     expect(result.tier).toBe('critical');
@@ -348,12 +356,12 @@ describe('selectModelForInvocation', () => {
 
   it('should route to critical for agents in criticalAgents list', () => {
     const routing = {
-      enabled: true, defaultModel: 'base', criticalModel: 'opus',
-      heavyModel: 'heavy', criticalThreshold: 60, heavyThreshold: 30,
+      enabled: true, critical: 'opus',
+      heavy: 'heavy', criticalThreshold: 60, heavyThreshold: 30,
       criticalTaskPatterns: [], criticalAgents: ['adjudicator'],
-      maxCriticalTasks: 10, maxEscalationCostUsd: 100,
+      maxEscalatedTasks: 10, maxEscalationCostUsd: 100,
     };
-    const ctx = mockContext({ options: { modelRouting: routing } });
+    const ctx = mockContext({ models: { default: 'base', routing } });
     const result = selectModelForInvocation(ctx, undefined, 'adjudicator');
     expect(result.tier).toBe('critical');
     expect(result.reason).toBe('critical-agent');
@@ -367,14 +375,14 @@ describe('applyRoutingCaps', () => {
     expect(applyRoutingCaps(ctx, decision)).toBe(decision);
   });
 
-  it('should cap when maxCriticalTasks is exceeded', () => {
+  it('should cap when maxEscalatedTasks is exceeded', () => {
     const routing = {
-      enabled: true, defaultModel: 'base', criticalModel: 'opus',
-      heavyModel: 'heavy', criticalThreshold: 60, heavyThreshold: 30,
+      enabled: true, critical: 'opus',
+      heavy: 'heavy', criticalThreshold: 60, heavyThreshold: 30,
       criticalTaskPatterns: [], criticalAgents: [],
-      maxCriticalTasks: 1, maxEscalationCostUsd: 100,
+      maxEscalatedTasks: 1, maxEscalationCostUsd: 100,
     };
-    const ctx = mockContext({ options: { modelRouting: routing } });
+    const ctx = mockContext({ models: { default: 'base', routing } });
     // Already have one routed task
     ctx.routedTaskIds.add('task-existing');
     const decision = { tier: 'critical' as const, selectedModel: 'opus', reason: 'score-critical', score: 70, escalated: false };
@@ -592,13 +600,13 @@ describe('buildInvocation', () => {
   });
 
   it('should use phase-specific timeout', () => {
-    const ctx = mockContext({ agentBackend: { runtime: 'copilot', model: 'claude-sonnet-4', timeout: 300_000, phaseTimeouts: { 5: 600_000 } } });
+    const ctx = mockContext({ agentBackend: { runtime: 'copilot', timeout: 300_000, phaseTimeouts: { 5: 600_000 } } });
     const inv = buildInvocation(ctx, 'code-migrator', { contextPath: '/tmp/ctx.json', outputPath: '/tmp/out' }, 5);
     expect(inv.timeout).toBe(600_000);
   });
 
   it('should apply failureRecoveryModel for parity-failure-resolver', () => {
-    const ctx = mockContext({ agentBackend: { runtime: 'copilot', model: 'claude-sonnet-4', timeout: 300_000, failureRecoveryModel: 'gpt-4o-fallback' } });
+    const ctx = mockContext({ models: { default: 'claude-sonnet-4', failureRecovery: 'gpt-4o-fallback' } });
     const inv = buildInvocation(ctx, 'parity-failure-resolver', { contextPath: '/tmp/ctx.json', outputPath: '/tmp/out' }, 5);
     expect(inv.modelOverride).toBe('gpt-4o-fallback');
   });

--- a/tests/helpers/mocks.ts
+++ b/tests/helpers/mocks.ts
@@ -96,6 +96,9 @@ export function createMockConfig(overrides?: any): MigrationConfig {
       outputPath: '/tmp/target',
       ...(overrides?.target ?? {}),
     },
+    models: {
+      ...(overrides?.models ?? {}),
+    },
     options: {
       maxParallelAgents: 3,
       maxRetriesPerTask: 3,


### PR DESCRIPTION
## Summary

This PR intentionally combines two in-progress changes that were already local in this branch:

- fix Copilot token tracking so AAMF does not persist zero-token usage when the framework cannot parse usage directly
- move model selection to the root \`models\` config block and keep legacy agent-backend / routing fields as compatibility aliases during migration

## What Changed

- treat framework-reported zero token usage as missing and fall back to AAMF runtime-specific parsing or prompt-length estimation
- parse Copilot JSONL \`result.data.usage\` payloads and normalize structured \`aamf-json\` token usage into the runtime's \`input/output\` shape
- switch runtime model lookup, failure-recovery model lookup, and routing model selection to prefer \`models.default\`, \`models.failureRecovery\`, and \`models.routing\`
- update config schema, docs, fixtures, and tests to use the new model configuration layout while preserving compatibility aliases

## Testing

- \`npm run lint\`
- \`npm test -- tests/config/config-schema.test.ts tests/flow/steps/shared.test.ts tests/flow/steps/migration.test.ts tests/core/agent-launcher.test.ts tests/core/runtime.test.ts\`

## Notes

- this branch includes both the token tracking fix and the migration-config model specification changes by design
