### PR TITLE
Plumb iteration limits through config

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ The `final-parity-checker` performs a codebase-wide parity sweep. If issues are 
 
 ### Phase 7: Idiomatic Refactor (Optional)
 
-When `options.idiomaticRefactor.enabled` is set, Phase 7 runs up to `maxIterations` (default: 2) review-and-refactor cycles:
+When `options.idiomaticRefactor.enabled` is set, Phase 7 runs up to `maxIterations` (default: 2, `0` = unlimited) review-and-refactor cycles:
 
 1. `idiomatic-reviewer` scans the migrated codebase for non-idiomatic patterns.
 2. For each flagged issue, `idiomatic-refactorer` applies targeted fixes with git commits.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,7 +139,7 @@ Create a `migration.config.json` file in your project root. Below is a full refe
 | `options.buildConcurrency` | `integer (0–10)` | `1` | Max concurrent build/test commands. 0 = uses `maxParallelAgents`. |
 | `options.executionMode` | `'per-task' \| 'wave-barrier'` | `'per-task'` | Phase 4 scheduler mode. |
 | `options.waveControl.waveSize` | `integer (≥1)` | `3` | Max migration tasks per wave in `wave-barrier` mode. |
-| `options.waveControl.maxConvergenceIterations` | `integer (≥1)` | `3` | Max validation/fix iterations per wave before blocking. |
+| `options.waveControl.maxConvergenceIterations` | `integer (≥0)` | `3` | Max validation/fix iterations per wave before blocking. `0` = unlimited. |
 | `options.continueOnBlocked` | `boolean` | `true` | Continue migration when tasks are blocked. |
 | `options.maxBlockedTasks` | `integer (≥0)` | `0` | Max blocked tasks before halting. 0 = unlimited. |
 | `options.qualityPolicy` | `'strict' \| 'balanced' \| 'deferred-strict'` | `'strict'` | Quality gating policy for wave-end validation. |
@@ -188,7 +188,7 @@ Create a `migration.config.json` file in your project root. Below is a full refe
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `options.idiomaticRefactor.enabled` | `boolean` | `false` | Enable the optional idiomatic refactor phase. |
-| `options.idiomaticRefactor.maxIterations` | `integer` | `2` | Max review-and-refactor cycles. |
+| `options.idiomaticRefactor.maxIterations` | `integer (≥0)` | `2` | Max review-and-refactor cycles. `0` = unlimited. |
 
 #### Agent Backend
 
@@ -286,7 +286,7 @@ In `wave-barrier` mode, each cycle is:
 
 1. **Migration wave** — run up to `waveControl.waveSize` ready, non-overlapping migration tasks in parallel.
 2. **Validation wave** — after migration settles, run build/test at the barrier (no migration/validation overlap).
-3. **Fix wave (if needed)** — rerun targeted migration tasks for failed validation and repeat validation until convergence or `waveControl.maxConvergenceIterations` is reached.
+3. **Fix wave (if needed)** — rerun targeted migration tasks for failed validation and repeat validation until convergence or `waveControl.maxConvergenceIterations` is reached (`0` = unlimited).
 
 Blocked-task policy (`continueOnBlocked`, `maxBlockedTasks`) is enforced after each wave.
 

--- a/src/agents/types.ts
+++ b/src/agents/types.ts
@@ -249,7 +249,7 @@ export interface ExecutionStrategy {
 
   /** Wave-barrier settings (only meaningful when `executionMode === 'wave-barrier'`). */
   waveControl: {
-    /** Maximum build/test convergence iterations per wave before giving up. */
+    /** Maximum build/test convergence iterations per wave before giving up. 0 = unlimited. */
     maxConvergenceIterations: number;
   };
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -105,7 +105,8 @@ export const MigrationConfigSchema = z.object({
      * These values are ignored in `per-task` mode.
      */
     waveControl: z.object({
-      maxConvergenceIterations: z.number().int().min(1).default(3),
+      /** Maximum validation/fix iterations per wave. 0 = unlimited. */
+      maxConvergenceIterations: z.number().int().min(0).default(3),
     }).default({
       maxConvergenceIterations: 3,
     }),
@@ -138,7 +139,8 @@ export const MigrationConfigSchema = z.object({
      */
     idiomaticRefactor: z.object({
       enabled: z.boolean().default(false),
-      maxIterations: z.number().int().min(1).default(2),
+      /** Maximum review-and-refactor cycles. 0 = unlimited. */
+      maxIterations: z.number().int().min(0).default(2),
     }).optional(),
     /**
      * Options for KB indexing (Phase 0).

--- a/src/flow/iteration-policy.ts
+++ b/src/flow/iteration-policy.ts
@@ -1,0 +1,11 @@
+/**
+ * Convert a configured iteration cap into the numeric bound expected by the
+ * flow runner. A config value of 0 means unlimited.
+ */
+export function resolveLoopMaxIterations(
+  configured: number | undefined,
+  fallback: number,
+): number {
+  const normalized = configured ?? fallback;
+  return normalized === 0 ? Number.POSITIVE_INFINITY : normalized;
+}

--- a/src/flow/migration-flow.ts
+++ b/src/flow/migration-flow.ts
@@ -44,6 +44,7 @@ import {
   noIdiomaticIssues,
 } from './steps/idiomatic-refactor.js';
 import { finalizeAndReport } from './steps/completion.js';
+import { resolveLoopMaxIterations } from './iteration-policy.js';
 
 /**
  * Budget gate evaluator — returns true when budget is OK.
@@ -61,6 +62,25 @@ function budgetOk(ctx: { context: MigrationFlowContext }): boolean {
  * the runner reads it (the thunk always runs first per the runner contract).
  */
 const _phase4RunnerOpts: FlowRunnerOptions<MigrationFlowContext> = {};
+
+/**
+ * Shared mutable ref for the Phase 7 loop node.
+ *
+ * As with Phase 4 runner options, the loop bound must be derived from runtime
+ * config even though the flow node is declared statically.
+ */
+const _idiomaticLoopNode = loop<MigrationFlowContext>({
+  id: 'idiomatic-loop',
+  dependsOn: ['idiomatic-loop-configure'],
+  maxIterations: 2,
+  do: [
+    step<MigrationFlowContext>({
+      id: 'idiomatic-iteration',
+      run: runIdiomaticReviewIteration,
+    }),
+  ],
+  until: noIdiomaticIssues,
+});
 
 /**
  * The AAMF migration pipeline expressed as a declarative flow.
@@ -182,17 +202,19 @@ export const migrationFlow: FlowDefinition<MigrationFlowContext> = defineFlow<Mi
       dependsOn: ['finalization'],
       when: (ctx) => ctx.context.config.options.idiomaticRefactor?.enabled === true,
       then: [
-        loop<MigrationFlowContext>({
-          id: 'idiomatic-loop',
-          maxIterations: 3,
-          do: [
-            step<MigrationFlowContext>({
-              id: 'idiomatic-iteration',
-              run: runIdiomaticReviewIteration,
-            }),
-          ],
-          until: noIdiomaticIssues,
+        step<MigrationFlowContext>({
+          id: 'idiomatic-loop-configure',
+          run: async (ctx) => {
+            _idiomaticLoopNode.maxIterations = resolveLoopMaxIterations(
+              ctx.context.config.options.idiomaticRefactor?.maxIterations,
+              2,
+            );
+            return {
+              maxIterations: ctx.context.config.options.idiomaticRefactor?.maxIterations ?? 2,
+            };
+          },
         }),
+        _idiomaticLoopNode,
       ],
     }),
 
@@ -226,6 +248,7 @@ export function nodeIdToPhase(nodeId: string): number {
     'e2e-suite-writers': 6,
     'documentation-writer': 6,
     'idiomatic-refactor-gate': 7,
+    'idiomatic-loop-configure': 7,
     'idiomatic-loop': 7,
     'idiomatic-iteration': 7,
     'completion': 8,

--- a/src/flow/steps/migration.ts
+++ b/src/flow/steps/migration.ts
@@ -18,6 +18,7 @@ import type { TaskGraphOutput } from './task-graph.js';
 import { toAgentRemediationContext } from '../../agents/types.js';
 import type { PriorRecoveryAttempt } from '../../agents/types.js';
 import { parseMigrationPlan } from '../../agents/plan-parser.js';
+import { resolveLoopMaxIterations } from '../iteration-policy.js';
 import { ParallelExecutor } from '../../execution/parallel-executor.js';
 import { TaskQueue } from '../../execution/task-queue.js';
 import { RetryExecutor } from '../../execution/retry.js';
@@ -568,7 +569,11 @@ function buildWaveBarrierFlow(
 ): FlowDefinition<MigrationFlowContext> {
   const waves = computeTopologicalWaves(tasks);
   const nodes: FlowNode<MigrationFlowContext>[] = [];
-  const maxConvergence = ctx.config.options.waveControl?.maxConvergenceIterations ?? 3;
+  const configuredMaxConvergence = ctx.config.options.waveControl?.maxConvergenceIterations;
+  const maxConvergence = resolveLoopMaxIterations(configuredMaxConvergence, 3);
+  const maxConvergenceLabel = (configuredMaxConvergence ?? 3) === 0
+    ? 'unlimited'
+    : String(configuredMaxConvergence ?? 3);
   const gateMode = getQualityGateMode(ctx);
 
   for (let w = 0; w < waves.length; w++) {
@@ -687,7 +692,7 @@ function buildWaveBarrierFlow(
         if (result && !result.success) {
           await raiseTerminalExhaustion(c.context, {
             reasonCode: 'wave-convergence-exhausted', wave: w, check: 'wave-validation',
-            summary: `Wave ${w} failed to converge after ${maxConvergence} iteration(s)`,
+            summary: `Wave ${w} failed to converge after ${maxConvergenceLabel} iteration(s)`,
           });
         }
       },

--- a/tests/agents/context-builder.test.ts
+++ b/tests/agents/context-builder.test.ts
@@ -190,6 +190,21 @@ describe('ContextBuilder', () => {
       expect(strategy.requiresNonOverlappingTargets).toBe(true);
     });
 
+    it('should preserve unlimited wave convergence in migration-planner executionStrategy', async () => {
+      const config = createMockConfig({
+        options: {
+          executionMode: 'wave-barrier' as const,
+          waveControl: { maxConvergenceIterations: 0 },
+        },
+      });
+      const b = new ContextBuilder(config, progressDir, paths);
+      const { contextPath } = await b.buildContext('migration-planner', 4);
+      const context = await readJson<AgentContext>(contextPath);
+      const strategy = context.payload?.executionStrategy as Record<string, unknown>;
+
+      expect(strategy.waveControl).toEqual({ maxConvergenceIterations: 0 });
+    });
+
     it('should route adjudicator to competing strategies file', async () => {
       const { contextPath } = await builder.buildContext('adjudicator', 3, undefined, {
         competingStrategiesFile: '/tmp/strategies.md',

--- a/tests/config/config-schema.test.ts
+++ b/tests/config/config-schema.test.ts
@@ -330,6 +330,14 @@ describe('MigrationConfigSchema', () => {
         expect(result.options.idiomaticRefactor?.enabled).toBe(true);
         expect(result.options.idiomaticRefactor?.maxIterations).toBe(3);
       });
+
+      it('should accept idiomaticRefactor.maxIterations of 0 (unlimited)', () => {
+        const result = MigrationConfigSchema.parse({
+          ...validConfig,
+          options: { idiomaticRefactor: { enabled: true, maxIterations: 0 } },
+        });
+        expect(result.options.idiomaticRefactor?.maxIterations).toBe(0);
+      });
     });
 
     it('should default agentBackend.runtime to copilot', () => {
@@ -408,10 +416,18 @@ describe('MigrationConfigSchema', () => {
       expect(result.success).toBe(false);
     });
 
-    it('should reject waveControl.maxConvergenceIterations less than 1', () => {
+    it('should accept waveControl.maxConvergenceIterations of 0 (unlimited)', () => {
       const result = MigrationConfigSchema.safeParse({
         ...validConfig,
         options: { waveControl: { maxConvergenceIterations: 0 } },
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject waveControl.maxConvergenceIterations less than 0', () => {
+      const result = MigrationConfigSchema.safeParse({
+        ...validConfig,
+        options: { waveControl: { maxConvergenceIterations: -1 } },
       });
       expect(result.success).toBe(false);
     });

--- a/tests/fixtures/tmux-c-project/migration.config.json
+++ b/tests/fixtures/tmux-c-project/migration.config.json
@@ -1,0 +1,86 @@
+{
+  "projectName": "tmux-to-rust",
+  "guidance": [
+    "Preserve tmux 3.6a compatibility across every platform supported by the C implementation, including terminal behavior, command/config semantics, key bindings, formats, control mode, copy-mode, mouse behavior, and client/server/session/window/pane behavior; any deviation must be explicit and documented.",
+    "Deliver a full pure native Rust port. Do NOT use FFI, bindgen, or link against the tmux C implementation. Do not use rust crates of a tmux port.",
+    "Preserve event-loop ordering, command queue semantics, protocol and error behavior, and OS-facing behavior for PTYs, signals, termios/ioctl, jobs, and socket IPC; do not introduce concurrent mutation of core tmux state.",
+    "Prefer idiomatic Rust ownership, enums, Result-based error handling, and modular crate boundaries over direct transliterations of tmux globals, macros, linked lists, and manual memory management.",
+    "Retain performance-critical terminal parsing, UTF-8 and cell-width behavior, screen diffing, and layout logic; use unsafe Rust only when clearly justified and encapsulated, and require differential parity tests against tmux 3.6a."
+  ],
+  "source": {
+    "path": "./tmux-src/tmux-3.6a",
+    "language": "c",
+    "entryPoints": [
+      "tmux.c",
+      "server-client.c",
+      "cmd-queue.c",
+      "tty.c",
+      "window.c"
+    ],
+    "excludePatterns": [
+      ".git",
+      ".github",
+      "*.o",
+      "*.lo",
+      "*.la",
+      "*.a",
+      "*.so",
+      "*.dylib",
+      "*.pc",
+      "Makefile*",
+      "config.*",
+      "configure*",
+      "aclocal.m4",
+      "autom4te.cache/**",
+      "compile",
+      "depcomp",
+      "install-sh",
+      "missing",
+      "ltmain.sh",
+      "*.md",
+      "*.1",
+      "example_tmux.conf"
+    ]
+  },
+  "target": {
+    "language": "rust",
+    "framework": "stable",
+    "outputPath": "./tmp/tmux-rust-output",
+    "buildCommand": "cargo build",
+    "testCommand": "cargo test"
+  },
+  "options": {
+    "qualityPolicy": "strict",
+    "maxParallelAgents": 12,
+    "maxRetriesPerTask": 5,
+    "maxLinesPerTask": 2000,
+    "executionMode": "wave-barrier",
+    "waveControl": {
+      "maxConvergenceIterations": 0
+    },
+    "tokenBudget": 50000000,
+    "dryRun": false,
+    "resume": true,
+    "idiomaticRefactor": {
+      "enabled": true,
+      "maxIterations": 0
+    },
+    "kbIndex": {
+      "enabled": true,
+      "embeddings": {
+        "enabled": false
+      }
+    }
+  },
+  "models": {
+    "default": "gpt-5.4",
+    "failureRecovery": "gpt-5.4"
+  },
+  "agentBackend": {
+    "runtime": "copilot",
+    "cliCommand": "copilot",
+    "effort": "xhigh",
+    "agentDir": "../../../.github/agents",
+    "timeout": 3600000
+  }
+}

--- a/tests/flow/iteration-policy.test.ts
+++ b/tests/flow/iteration-policy.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { resolveLoopMaxIterations } from '../../src/flow/iteration-policy.js';
+
+describe('resolveLoopMaxIterations', () => {
+  it('should use the fallback when config is undefined', () => {
+    expect(resolveLoopMaxIterations(undefined, 3)).toBe(3);
+  });
+
+  it('should preserve explicit finite limits', () => {
+    expect(resolveLoopMaxIterations(5, 3)).toBe(5);
+  });
+
+  it('should treat 0 as unlimited', () => {
+    expect(resolveLoopMaxIterations(0, 3)).toBe(Number.POSITIVE_INFINITY);
+  });
+});

--- a/tests/flow/migration-flow.test.ts
+++ b/tests/flow/migration-flow.test.ts
@@ -105,6 +105,7 @@ describe('nodeIdToPhase', () => {
 
   it('should return 7 for idiomatic-refactor nodes', () => {
     expect(nodeIdToPhase('idiomatic-refactor-gate')).toBe(7);
+    expect(nodeIdToPhase('idiomatic-loop-configure')).toBe(7);
     expect(nodeIdToPhase('idiomatic-loop')).toBe(7);
     expect(nodeIdToPhase('idiomatic-iteration')).toBe(7);
   });

--- a/tests/flow/steps/migration-waves.test.ts
+++ b/tests/flow/steps/migration-waves.test.ts
@@ -74,6 +74,41 @@ describe('buildPhase4Subflow — wave-barrier mode', () => {
     }
   });
 
+  it('should allow unlimited wave convergence iterations when configured as 0', async () => {
+    const launcherFn = createMockLauncher();
+    env = await setupFlowTestWithTasks(launcherFn, [SINGLE_AUTH_TASK], {
+      target: {
+        language: 'typescript',
+        outputPath: '/tmp/target',
+        buildCommand: 'npm run build',
+      },
+      options: {
+        executionMode: 'wave-barrier',
+        waveControl: { maxConvergenceIterations: 0 },
+        qualityPolicy: 'strict',
+        maxRetriesPerTask: 3,
+      },
+    });
+
+    let buildCallCount = 0;
+    const spawnMod = await import('../../../src/util/process.js');
+    const spawnSpy = vi.spyOn(spawnMod, 'spawnWithTimeout').mockImplementation(async () => {
+      buildCallCount++;
+      if (buildCallCount === 1) {
+        return { exitCode: 1, stdout: '', stderr: 'build failed', killed: false };
+      }
+      return { exitCode: 0, stdout: 'ok', stderr: '', killed: false };
+    });
+
+    try {
+      const result = await runPhase4(env);
+      expect(result.status).toBe('completed');
+      expect(buildCallCount).toBeGreaterThanOrEqual(2);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
   it('should emit wave lifecycle events', async () => {
     const launcherFn = createMockLauncher();
     env = await setupFlowTestWithTasks(launcherFn, [SINGLE_AUTH_TASK], {


### PR DESCRIPTION
## Summary
- plumb `options.idiomaticRefactor.maxIterations` into the Phase 7 loop instead of using a hardcoded limit
- support `0 = unlimited` for both idiomatic refactor iterations and wave convergence iterations
- update the tmux fixture to run with unlimited idiomatic refactor and wave convergence loops
- document the new semantics and add regression coverage for schema parsing, planner payloads, and flow behavior

## Validation
- `npm run lint`
- `npx vitest run tests/config/config-schema.test.ts tests/agents/context-builder.test.ts tests/flow/migration-flow.test.ts tests/flow/iteration-policy.test.ts tests/flow/steps/migration-waves.test.ts`